### PR TITLE
refactor: soft-refresh via SecurityContextRepository decorator instead of filter

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -96,6 +96,8 @@ public interface CacheProvider {
 
   <V> Cache<V> createApiKeyCache();
 
+  <V> Cache<V> createUserDetailsAuthzCache();
+
   <V> Cache<V> createTeAttributesCache();
 
   <V> Cache<V> createProgramTeAttributesCache();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/authz/AuthzConstants.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/authz/AuthzConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,47 +27,19 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.common.cache;
+package org.hisp.dhis.user.authz;
 
 /**
- * Enum is used to make sure we do not use same region twice. Each method should have its own
- * constant.
+ * Session attribute names used by UserDetails soft-refresh.
+ *
+ * @author Morten Svanæs
  */
-@SuppressWarnings("squid:S115") // allow non enum-ish names
-public enum Region {
-  analyticsResponse,
-  defaultObjectCache,
-  allConstantsCache,
-  inUserOrgUnitHierarchy,
-  periodIdCache,
-  userAccountRecoverAttempt,
-  userFailedLoginAttempt,
-  twoFaDisableFailedAttempt,
-  programOwner,
-  programTempOwner,
-  currentUserGroupInfoCache,
-  attrOptionComboIdCache,
-  googleAccessToken,
-  dataItemsPagination,
-  metadataAttributes,
-  canDataWriteCocCache,
-  analyticsSql,
-  propertyTransformerCache,
-  programHasRulesCache,
-  userGroupNameCache,
-  userDisplayNameCache,
-  pgmOrgUnitAssocCache,
-  catOptOrgUnitAssocCache,
-  dataSetOrgUnitAssocCache,
-  apiTokensCache,
-  teAttributesCache,
-  programTeAttributesCache,
-  userGroupUIDCache,
-  securityCache,
-  dataIntegritySummaryCache,
-  dataIntegrityDetailsCache,
-  queryAliasCache,
-  corsWhitelistCache,
-  notificationTemplateCache,
-  userDetailsAuthzCache
+public final class AuthzConstants {
+  /** HttpSession attribute: effective authz generation stamped at last soft-refresh check. */
+  public static final String SESSION_AUTHZ_GEN_ATTR = "DHIS2_AUTHZ_GEN";
+
+  /** HttpSession attribute: global authz epoch at last soft-refresh check. */
+  public static final String SESSION_AUTHZ_EPOCH_ATTR = "DHIS2_AUTHZ_EPOCH";
+
+  private AuthzConstants() {}
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/authz/AuthzService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/authz/AuthzService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,47 +27,34 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.common.cache;
+package org.hisp.dhis.user.authz;
+
+import java.util.Collection;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.hisp.dhis.user.UserDetails;
 
 /**
- * Enum is used to make sure we do not use same region twice. Each method should have its own
- * constant.
+ * Soft-refresh facade over authz generation stamps and cached UserDetails snapshots.
+ *
+ * @author Morten Svanæs
  */
-@SuppressWarnings("squid:S115") // allow non enum-ish names
-public enum Region {
-  analyticsResponse,
-  defaultObjectCache,
-  allConstantsCache,
-  inUserOrgUnitHierarchy,
-  periodIdCache,
-  userAccountRecoverAttempt,
-  userFailedLoginAttempt,
-  twoFaDisableFailedAttempt,
-  programOwner,
-  programTempOwner,
-  currentUserGroupInfoCache,
-  attrOptionComboIdCache,
-  googleAccessToken,
-  dataItemsPagination,
-  metadataAttributes,
-  canDataWriteCocCache,
-  analyticsSql,
-  propertyTransformerCache,
-  programHasRulesCache,
-  userGroupNameCache,
-  userDisplayNameCache,
-  pgmOrgUnitAssocCache,
-  catOptOrgUnitAssocCache,
-  dataSetOrgUnitAssocCache,
-  apiTokensCache,
-  teAttributesCache,
-  programTeAttributesCache,
-  userGroupUIDCache,
-  securityCache,
-  dataIntegritySummaryCache,
-  dataIntegrityDetailsCache,
-  queryAliasCache,
-  corsWhitelistCache,
-  notificationTemplateCache,
-  userDetailsAuthzCache
+public interface AuthzService {
+  long currentEpoch();
+
+  /** One batched read: max of the principal's user-uid gen and role gens. */
+  long effectiveGen(@Nonnull UserDetails principal);
+
+  /**
+   * Epoch-validated, cached, immutable snapshot for username. Returns a snapshot that reflects
+   * every authz change committed up to the epoch value read at call entry. Null if user unknown.
+   */
+  @CheckForNull
+  UserDetails getFreshUserDetails(@Nonnull String username);
+
+  void bumpUserAuthz(@Nonnull String userUid);
+
+  void bumpRoleAuthz(@Nonnull String roleUid);
+
+  void bumpUsers(@Nonnull Collection<String> userUids);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/authz/AuthzVersion.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/authz/AuthzVersion.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user.authz;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import java.io.Serializable;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Generation-stamp row for UserDetails soft-refresh.
+ *
+ * <p>Exists solely so Hibernate schema tooling knows the table (H2 test contexts generate schema
+ * from mappings; production schema is Flyway-managed and validated at startup). All runtime access
+ * goes through JdbcAuthzVersionStore, never ORM.
+ *
+ * @author Morten Svanæs
+ */
+@Entity
+@Table(name = "authz_version")
+@IdClass(AuthzVersion.AuthzVersionId.class)
+public class AuthzVersion {
+
+  @Id
+  @Column(name = "scope", length = 16, nullable = false)
+  private String scope;
+
+  @Id
+  @Column(name = "key_name", length = 255, nullable = false)
+  private String keyName;
+
+  @Column(name = "gen", nullable = false)
+  private long gen;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "updated_at", nullable = false)
+  private Date updatedAt;
+
+  protected AuthzVersion() {}
+
+  public String getScope() {
+    return scope;
+  }
+
+  public void setScope(String scope) {
+    this.scope = scope;
+  }
+
+  public String getKeyName() {
+    return keyName;
+  }
+
+  public void setKeyName(String keyName) {
+    this.keyName = keyName;
+  }
+
+  public long getGen() {
+    return gen;
+  }
+
+  public void setGen(long gen) {
+    this.gen = gen;
+  }
+
+  public Date getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(Date updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class AuthzVersionId implements Serializable {
+    private String scope;
+    private String keyName;
+  }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/authz/AuthzVersionStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/authz/AuthzVersionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,47 +27,31 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.common.cache;
+package org.hisp.dhis.user.authz;
+
+import java.util.Collection;
+import javax.annotation.Nonnull;
 
 /**
- * Enum is used to make sure we do not use same region twice. Each method should have its own
- * constant.
+ * Generation stamps that drive UserDetails soft-refresh.
+ *
+ * <p>Every bump advances the global epoch. Bumps participate in the caller's ambient transaction
+ * (JdbcTemplate joins it), so a reader can never observe a gen/epoch value without also seeing the
+ * committed data that caused it.
+ *
+ * @author Morten Svanæs
  */
-@SuppressWarnings("squid:S115") // allow non enum-ish names
-public enum Region {
-  analyticsResponse,
-  defaultObjectCache,
-  allConstantsCache,
-  inUserOrgUnitHierarchy,
-  periodIdCache,
-  userAccountRecoverAttempt,
-  userFailedLoginAttempt,
-  twoFaDisableFailedAttempt,
-  programOwner,
-  programTempOwner,
-  currentUserGroupInfoCache,
-  attrOptionComboIdCache,
-  googleAccessToken,
-  dataItemsPagination,
-  metadataAttributes,
-  canDataWriteCocCache,
-  analyticsSql,
-  propertyTransformerCache,
-  programHasRulesCache,
-  userGroupNameCache,
-  userDisplayNameCache,
-  pgmOrgUnitAssocCache,
-  catOptOrgUnitAssocCache,
-  dataSetOrgUnitAssocCache,
-  apiTokensCache,
-  teAttributesCache,
-  programTeAttributesCache,
-  userGroupUIDCache,
-  securityCache,
-  dataIntegritySummaryCache,
-  dataIntegrityDetailsCache,
-  queryAliasCache,
-  corsWhitelistCache,
-  notificationTemplateCache,
-  userDetailsAuthzCache
+public interface AuthzVersionStore {
+  /** Global epoch; advanced by every bump. Missing row = 0. */
+  long getEpoch();
+
+  /** max(user gen for userUid, role gens for roleUids); missing keys count as 0. */
+  long getMaxGen(@Nonnull String userUid, @Nonnull Collection<String> roleUids);
+
+  void bumpUserGen(@Nonnull String userUid);
+
+  void bumpRoleGen(@Nonnull String roleUid);
+
+  /** Bumps each distinct uid once and the epoch once. */
+  void bumpUserGens(@Nonnull Collection<String> userUids);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.security.oidc.DhisOidcClientRegistration;
 import org.hisp.dhis.security.oidc.DhisOidcProviderRepository;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.authz.AuthzService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -109,6 +110,7 @@ public class Dhis2JwtAuthenticationManagerResolver
   @Autowired private DhisOidcProviderRepository clientRegistrationRepository;
   @Autowired private Dhis2OAuth2ClientService oAuth2ClientService;
   @Autowired private UserService userService;
+  @Autowired private AuthzService authzService;
 
   private final Map<String, AuthenticationManager> authenticationManagers =
       new ConcurrentHashMap<>();
@@ -218,7 +220,7 @@ public class Dhis2JwtAuthenticationManagerResolver
       String mappingValue = jwt.getClaim(mappingClaimKey);
       UserDetails currentUserDetails =
           switch (mappingClaimKey) {
-            case "username" -> userService.createUserDetailsByUsername(mappingValue);
+            case "username" -> authzService.getFreshUserDetails(mappingValue);
             case "email" -> userService.createUserDetailsByOpenId(mappingValue);
             default -> throw new InvalidBearerTokenException("Invalid mapping claim");
           };

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.cache.HibernateCacheManager;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.authz.AuthzService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,19 +54,23 @@ public class DefaultUserGroupService implements UserGroupService {
   private final AclService aclService;
   private final HibernateCacheManager cacheManager;
   private final Cache<String> userGroupNameCache;
+  private final AuthzService authzService;
 
   public DefaultUserGroupService(
       UserGroupStore userGroupStore,
       AclService aclService,
       HibernateCacheManager cacheManager,
-      CacheProvider cacheProvider) {
+      CacheProvider cacheProvider,
+      AuthzService authzService) {
     checkNotNull(userGroupStore);
     checkNotNull(aclService);
     checkNotNull(cacheManager);
+    checkNotNull(authzService);
 
     this.userGroupStore = userGroupStore;
     this.aclService = aclService;
     this.cacheManager = cacheManager;
+    this.authzService = authzService;
 
     userGroupNameCache = cacheProvider.createUserGroupNameCache();
   }
@@ -148,13 +153,18 @@ public class DefaultUserGroupService implements UserGroupService {
   @Override
   @Transactional
   public void addUserToGroups(User user, Collection<String> uids, UserDetails currentUser) {
+    boolean modified = false;
     for (String uid : uids) {
       UserGroup userGroup = getUserGroup(uid);
       if (canAddOrRemoveMember(userGroup, currentUser)
           && userGroupStore.addMember(
               userGroup.getUID(), user.getUID(), UID.of(currentUser.getUid()))) {
         user.getGroups().add(userGroup);
+        modified = true;
       }
+    }
+    if (modified) {
+      authzService.bumpUserAuthz(user.getUid());
     }
     aclService.invalidateCurrentUserGroupInfoCache();
   }
@@ -165,6 +175,7 @@ public class DefaultUserGroupService implements UserGroupService {
     Collection<UserGroup> updates = getUserGroupsByUid(uids);
     UID currentUserUid = UID.of(currentUser.getUid());
     UID userUid = user.getUID();
+    boolean modified = false;
 
     // Remove user from groups they're no longer in (SQL bypass avoids loading UserGroup.members)
     for (UserGroup userGroup : new HashSet<>(user.getGroups())) {
@@ -172,6 +183,7 @@ public class DefaultUserGroupService implements UserGroupService {
           && canAddOrRemoveMember(userGroup, currentUser)
           && userGroupStore.removeMember(userGroup.getUID(), userUid, currentUserUid)) {
         user.getGroups().remove(userGroup);
+        modified = true;
       }
     }
 
@@ -180,9 +192,13 @@ public class DefaultUserGroupService implements UserGroupService {
       if (canAddOrRemoveMember(userGroup, currentUser)
           && userGroupStore.addMember(userGroup.getUID(), userUid, currentUserUid)) {
         user.getGroups().add(userGroup);
+        modified = true;
       }
     }
 
+    if (modified) {
+      authzService.bumpUserAuthz(user.getUid());
+    }
     aclService.invalidateCurrentUserGroupInfoCache();
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/authz/DefaultAuthzService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/authz/DefaultAuthzService.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user.authz;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserService;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+/**
+ * Epoch-validated, cached UserDetails soft-refresh service.
+ *
+ * <p>The cached {@code checkedEpoch} is always read before {@code createUserDetailsByUsername}
+ * starts. Hence {@code entry.checkedEpoch >= currentEpoch} proves the snapshot includes every bump
+ * committed up to {@code currentEpoch}. Never reorder these reads.
+ *
+ * @author Morten Svanæs
+ */
+@Slf4j
+@Service("org.hisp.dhis.user.authz.AuthzService")
+public class DefaultAuthzService implements AuthzService {
+
+  private static final int LOCK_STRIPES = 64;
+
+  /** Snapshot plus the epoch value read BEFORE the snapshot was built. */
+  record CachedUserDetails(UserDetails details, long checkedEpoch) {}
+
+  private final AuthzVersionStore versionStore;
+  private final UserService userService;
+  private final Cache<CachedUserDetails> cache;
+  private final Object[] locks = new Object[LOCK_STRIPES];
+
+  public DefaultAuthzService(
+      AuthzVersionStore versionStore, @Lazy UserService userService, CacheProvider cacheProvider) {
+    this.versionStore = versionStore;
+    this.userService = userService;
+    this.cache = cacheProvider.createUserDetailsAuthzCache();
+    for (int i = 0; i < LOCK_STRIPES; i++) {
+      locks[i] = new Object();
+    }
+  }
+
+  @Override
+  public long currentEpoch() {
+    return versionStore.getEpoch();
+  }
+
+  @Override
+  public long effectiveGen(@Nonnull UserDetails principal) {
+    String uid = principal.getUid();
+    if (uid == null) {
+      return 0L;
+    }
+    Set<String> roleIds = principal.getUserRoleIds();
+    return versionStore.getMaxGen(uid, roleIds == null ? Set.of() : roleIds);
+  }
+
+  @Override
+  @CheckForNull
+  public UserDetails getFreshUserDetails(@Nonnull String username) {
+    long epoch = versionStore.getEpoch(); // MUST be read before any snapshot build
+    CachedUserDetails entry = cache.getIfPresent(username).orElse(null);
+    if (entry != null && entry.checkedEpoch() >= epoch) {
+      return entry.details();
+    }
+    Object lock = locks[Math.floorMod(username.hashCode(), LOCK_STRIPES)];
+    synchronized (lock) {
+      entry = cache.getIfPresent(username).orElse(null); // double-check under lock
+      if (entry != null && entry.checkedEpoch() >= epoch) {
+        return entry.details();
+      }
+      UserDetails fresh = userService.createUserDetailsByUsername(username);
+      if (fresh == null) {
+        cache.invalidate(username);
+        return null;
+      }
+      cache.put(username, new CachedUserDetails(fresh, epoch));
+      log.debug("Rebuilt UserDetails snapshot for {} at epoch {}", username, epoch);
+      return fresh;
+    }
+  }
+
+  @Override
+  public void bumpUserAuthz(@Nonnull String userUid) {
+    versionStore.bumpUserGen(userUid);
+    // No cache invalidation on bumps: the epoch check self-corrects, and in-tx bumps are not
+    // visible to other readers until commit.
+    log.debug("Bumped user authz for {}", userUid);
+  }
+
+  @Override
+  public void bumpRoleAuthz(@Nonnull String roleUid) {
+    versionStore.bumpRoleGen(roleUid);
+    // No cache invalidation on bumps: the epoch check self-corrects, and in-tx bumps are not
+    // visible to other readers until commit.
+    log.debug("Bumped role authz for {}", roleUid);
+  }
+
+  @Override
+  public void bumpUsers(@Nonnull Collection<String> userUids) {
+    List<String> filtered = new ArrayList<>();
+    for (String uid : userUids) {
+      if (uid == null) {
+        continue;
+      }
+      String trimmed = uid.trim();
+      if (!trimmed.isEmpty()) {
+        filtered.add(trimmed);
+      }
+    }
+    if (filtered.isEmpty()) {
+      return;
+    }
+    versionStore.bumpUserGens(filtered);
+    // No cache invalidation on bumps: the epoch check self-corrects, and in-tx bumps are not
+    // visible to other readers until commit.
+    log.debug("Bumped authz for {} users", filtered.size());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/authz/JdbcAuthzVersionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/authz/JdbcAuthzVersionStore.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user.authz;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import javax.annotation.Nonnull;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
+import org.springframework.stereotype.Repository;
+
+/**
+ * JDBC generation-stamp store for UserDetails soft-refresh.
+ *
+ * <p>Every bump advances the global epoch row in the same ambient transaction as the entity change
+ * that triggered it (JdbcTemplate joins the caller's {@code @Transactional} boundary). Therefore a
+ * reader can never observe a gen/epoch value without also seeing the committed data that caused it.
+ * This atomic visibility guarantee is the linchpin of soft-refresh correctness.
+ *
+ * @author Morten Svanæs
+ */
+@Repository("org.hisp.dhis.user.authz.AuthzVersionStore")
+public class JdbcAuthzVersionStore implements AuthzVersionStore {
+
+  private static final String SCOPE_USER = "user";
+  private static final String SCOPE_ROLE = "role";
+  private static final String SCOPE_EPOCH = "epoch";
+  private static final String KEY_EPOCH = "epoch";
+
+  // Update-first bump: the hot path (row exists) is one portable UPDATE. Only the first-ever bump
+  // of a key takes the insert path, which is dialect-branched because H2 (used by the H2 test
+  // contexts, even in PostgreSQL mode) does not support ON CONFLICT at all, while on Postgres
+  // ON CONFLICT DO NOTHING is the only race-safe insert that cannot abort the enclosing
+  // transaction (a plain INSERT losing a concurrent race would poison the import transaction).
+  private static final String INCREMENT_SQL =
+      """
+      update authz_version set gen = gen + 1, updated_at = now()
+      where scope = :scope and key_name = :key
+      """;
+
+  private static final String INSERT_SQL =
+      "insert into authz_version (scope, key_name, gen, updated_at) values (:scope, :key, 1, now())";
+
+  private static final String INSERT_IGNORE_PG_SQL =
+      INSERT_SQL + " on conflict (scope, key_name) do nothing";
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  /** Lazily resolved: true on PostgreSQL, false on H2 test databases. */
+  private volatile Boolean onConflictSupported;
+
+  public JdbcAuthzVersionStore(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public long getEpoch() {
+    try {
+      Long value =
+          jdbcTemplate.queryForObject(
+              "select gen from authz_version where scope = 'epoch' and key_name = 'epoch'",
+              new MapSqlParameterSource(),
+              Long.class);
+      return value == null ? 0L : value;
+    } catch (EmptyResultDataAccessException ex) {
+      return 0L;
+    }
+  }
+
+  @Override
+  public long getMaxGen(@Nonnull String userUid, @Nonnull Collection<String> roleUids) {
+    Long value;
+    if (roleUids.isEmpty()) {
+      value =
+          jdbcTemplate.queryForObject(
+              """
+              select coalesce(max(gen), 0) from authz_version
+              where scope = 'user' and key_name = :user
+              """,
+              new MapSqlParameterSource("user", userUid),
+              Long.class);
+    } else {
+      value =
+          jdbcTemplate.queryForObject(
+              """
+              select coalesce(max(gen), 0) from authz_version
+              where (scope = 'user' and key_name = :user)
+                 or (scope = 'role' and key_name in (:roles))
+              """,
+              new MapSqlParameterSource().addValue("user", userUid).addValue("roles", roleUids),
+              Long.class);
+    }
+    return value == null ? 0L : value;
+  }
+
+  @Override
+  public void bumpUserGen(@Nonnull String userUid) {
+    bump(SCOPE_USER, userUid);
+    // Epoch last: deadlock-avoidance order (entity key before global epoch).
+    bump(SCOPE_EPOCH, KEY_EPOCH);
+  }
+
+  @Override
+  public void bumpRoleGen(@Nonnull String roleUid) {
+    bump(SCOPE_ROLE, roleUid);
+    // Epoch last: deadlock-avoidance order (entity key before global epoch).
+    bump(SCOPE_EPOCH, KEY_EPOCH);
+  }
+
+  @Override
+  public void bumpUserGens(@Nonnull Collection<String> userUids) {
+    // Distinct, non-blank, sorted for stable lock order.
+    TreeSet<String> distinct = new TreeSet<>();
+    for (String uid : userUids) {
+      if (uid == null) {
+        continue;
+      }
+      String trimmed = uid.trim();
+      if (!trimmed.isEmpty()) {
+        distinct.add(trimmed);
+      }
+    }
+    if (distinct.isEmpty()) {
+      return;
+    }
+
+    List<Map<String, Object>> batchMaps = new ArrayList<>(distinct.size());
+    for (String uid : distinct) {
+      batchMaps.add(Map.of("scope", SCOPE_USER, "key", uid));
+    }
+    int[] updated =
+        jdbcTemplate.batchUpdate(INCREMENT_SQL, SqlParameterSourceUtils.createBatch(batchMaps));
+    List<String> missing = new ArrayList<>();
+    int i = 0;
+    for (String uid : distinct) {
+      if (updated[i++] == 0) {
+        missing.add(uid);
+      }
+    }
+    for (String uid : missing) {
+      insertFresh(SCOPE_USER, uid);
+    }
+
+    // One epoch bump for the whole batch. Epoch last for deadlock avoidance.
+    bump(SCOPE_EPOCH, KEY_EPOCH);
+  }
+
+  private void bump(String scope, String key) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue("scope", scope).addValue("key", key);
+    if (jdbcTemplate.update(INCREMENT_SQL, params) > 0) {
+      return;
+    }
+    insertFresh(scope, key);
+  }
+
+  /** Cold path: first-ever bump of this key. */
+  private void insertFresh(String scope, String key) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue("scope", scope).addValue("key", key);
+    if (isOnConflictSupported()) {
+      if (jdbcTemplate.update(INSERT_IGNORE_PG_SQL, params) == 0) {
+        // Lost the first-insert race; the winner has committed, increment its row.
+        jdbcTemplate.update(INCREMENT_SQL, params);
+      }
+    } else {
+      // H2 test contexts: no ON CONFLICT support, but no concurrent bumps either.
+      jdbcTemplate.update(INSERT_SQL, params);
+    }
+  }
+
+  private boolean isOnConflictSupported() {
+    Boolean cached = onConflictSupported;
+    if (cached == null) {
+      cached =
+          Boolean.TRUE.equals(
+              jdbcTemplate
+                  .getJdbcTemplate()
+                  .execute(
+                      (java.sql.Connection con) ->
+                          "PostgreSQL"
+                              .equalsIgnoreCase(con.getMetaData().getDatabaseProductName())));
+      onConflictSupported = cached;
+    }
+    return cached;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/authz/DefaultAuthzServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/authz/DefaultAuthzServiceTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user.authz;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.cache.SimpleCacheBuilder;
+import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+
+/**
+ * @author Morten Svanæs
+ */
+class DefaultAuthzServiceTest {
+
+  private InMemoryAuthzVersionStore versionStore;
+  private UserService userService;
+  private DefaultAuthzService authzService;
+
+  @BeforeEach
+  void setUp() {
+    versionStore = new InMemoryAuthzVersionStore();
+    userService = mock(UserService.class);
+    CacheProvider cacheProvider = mock(CacheProvider.class);
+    when(cacheProvider.createUserDetailsAuthzCache())
+        .thenAnswer(
+            (Answer<Cache<?>>)
+                invocation ->
+                    new SimpleCacheBuilder<>()
+                        .forRegion("userDetailsAuthzCache-test")
+                        .expireAfterWrite(5, TimeUnit.MINUTES)
+                        .withInitialCapacity(16)
+                        .withMaximumSize(100)
+                        .build());
+    authzService = new DefaultAuthzService(versionStore, userService, cacheProvider);
+  }
+
+  @Test
+  void sameEpochReturnsSameInstanceAndLoadsOnce() {
+    UserDetails first = details("alice", "u1");
+    when(userService.createUserDetailsByUsername("alice")).thenReturn(first);
+
+    UserDetails a = authzService.getFreshUserDetails("alice");
+    UserDetails b = authzService.getFreshUserDetails("alice");
+
+    assertSame(first, a);
+    assertSame(a, b);
+    verify(userService, times(1)).createUserDetailsByUsername("alice");
+  }
+
+  @Test
+  void bumpRoleAuthzForcesRebuild() {
+    UserDetails first = details("alice", "u1");
+    UserDetails second = details("alice", "u1");
+    when(userService.createUserDetailsByUsername("alice")).thenReturn(first, second);
+
+    UserDetails a = authzService.getFreshUserDetails("alice");
+    authzService.bumpRoleAuthz("r1");
+    UserDetails b = authzService.getFreshUserDetails("alice");
+
+    assertSame(first, a);
+    assertSame(second, b);
+    assertNotSame(a, b);
+    verify(userService, times(2)).createUserDetailsByUsername("alice");
+  }
+
+  @Test
+  void bumpUserAuthzForcesRebuild() {
+    UserDetails first = details("alice", "u1");
+    UserDetails second = details("alice", "u1");
+    when(userService.createUserDetailsByUsername("alice")).thenReturn(first, second);
+
+    UserDetails a = authzService.getFreshUserDetails("alice");
+    authzService.bumpUserAuthz("u1");
+    UserDetails b = authzService.getFreshUserDetails("alice");
+
+    assertSame(first, a);
+    assertSame(second, b);
+    assertNotSame(a, b);
+    verify(userService, times(2)).createUserDetailsByUsername("alice");
+  }
+
+  @Test
+  void stampBeforeBuildInvariant_entryUsesPreReadEpoch() {
+    AtomicInteger calls = new AtomicInteger();
+    when(userService.createUserDetailsByUsername("alice"))
+        .thenAnswer(
+            invocation -> {
+              int n = calls.incrementAndGet();
+              // Simulate a concurrent authz change observed during snapshot build.
+              versionStore.bumpUserGen("u1");
+              return details("alice-" + n, "u1");
+            });
+
+    UserDetails first = authzService.getFreshUserDetails("alice");
+    assertNotNull(first);
+    // Entry was stamped with the pre-build epoch, so the bump during build must force a rebuild.
+    UserDetails second = authzService.getFreshUserDetails("alice");
+    assertNotNull(second);
+    assertNotSame(first, second);
+    verify(userService, times(2)).createUserDetailsByUsername("alice");
+  }
+
+  @Test
+  void effectiveGenIsMaxOfUserAndRoleGens() {
+    versionStore.bumpUserGen("u1"); // 1
+    versionStore.bumpRoleGen("r1"); // 1
+    versionStore.bumpRoleGen("r2"); // 1
+    versionStore.bumpRoleGen("r2"); // 2
+
+    UserDetails principal =
+        UserDetails.empty().username("alice").uid("u1").userRoleIds(Set.of("r1", "r2")).build();
+
+    assertEquals(2L, authzService.effectiveGen(principal));
+  }
+
+  @Test
+  void unknownUserReturnsNullAndDoesNotCacheNull() {
+    when(userService.createUserDetailsByUsername("ghost")).thenReturn(null);
+
+    assertNull(authzService.getFreshUserDetails("ghost"));
+    assertNull(authzService.getFreshUserDetails("ghost"));
+    verify(userService, times(2)).createUserDetailsByUsername("ghost");
+  }
+
+  @Test
+  void currentEpochDelegates() {
+    assertEquals(0L, authzService.currentEpoch());
+    authzService.bumpUserAuthz("u1");
+    assertEquals(1L, authzService.currentEpoch());
+  }
+
+  private static UserDetails details(String username, String uid) {
+    return UserDetails.empty().username(username).uid(uid).userRoleIds(Set.of()).build();
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/authz/InMemoryAuthzVersionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/authz/InMemoryAuthzVersionStore.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user.authz;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nonnull;
+
+/**
+ * Test-scope in-memory {@link AuthzVersionStore}. Mirrors the JDBC contract: missing keys are 0,
+ * and each bump (or batch) advances the epoch once.
+ *
+ * @author Morten Svanæs
+ */
+public class InMemoryAuthzVersionStore implements AuthzVersionStore {
+
+  private final ConcurrentHashMap<String, AtomicLong> userGens = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, AtomicLong> roleGens = new ConcurrentHashMap<>();
+  private final AtomicLong epoch = new AtomicLong(0);
+
+  @Override
+  public long getEpoch() {
+    return epoch.get();
+  }
+
+  @Override
+  public long getMaxGen(@Nonnull String userUid, @Nonnull Collection<String> roleUids) {
+    long max = genOf(userGens, userUid);
+    for (String roleUid : roleUids) {
+      max = Math.max(max, genOf(roleGens, roleUid));
+    }
+    return max;
+  }
+
+  @Override
+  public void bumpUserGen(@Nonnull String userUid) {
+    bump(userGens, userUid);
+    epoch.incrementAndGet();
+  }
+
+  @Override
+  public void bumpRoleGen(@Nonnull String roleUid) {
+    bump(roleGens, roleUid);
+    epoch.incrementAndGet();
+  }
+
+  @Override
+  public void bumpUserGens(@Nonnull Collection<String> userUids) {
+    TreeSet<String> distinct = new TreeSet<>();
+    for (String uid : userUids) {
+      if (uid == null) {
+        continue;
+      }
+      String trimmed = uid.trim();
+      if (!trimmed.isEmpty()) {
+        distinct.add(trimmed);
+      }
+    }
+    if (distinct.isEmpty()) {
+      return;
+    }
+    for (String uid : distinct) {
+      bump(userGens, uid);
+    }
+    epoch.incrementAndGet();
+  }
+
+  private static long genOf(ConcurrentHashMap<String, AtomicLong> map, String key) {
+    AtomicLong value = map.get(key);
+    return value == null ? 0L : value.get();
+  }
+
+  private static void bump(ConcurrentHashMap<String, AtomicLong> map, String key) {
+    Objects.requireNonNull(key);
+    map.computeIfAbsent(key, k -> new AtomicLong(0)).incrementAndGet();
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/authz/InMemoryAuthzVersionStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/authz/InMemoryAuthzVersionStoreTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user.authz;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Morten Svanæs
+ */
+class InMemoryAuthzVersionStoreTest {
+
+  private InMemoryAuthzVersionStore store;
+
+  @BeforeEach
+  void setUp() {
+    store = new InMemoryAuthzVersionStore();
+  }
+
+  @Test
+  void missingKeysAreZero() {
+    assertEquals(0L, store.getEpoch());
+    assertEquals(0L, store.getMaxGen("u1", Set.of()));
+    assertEquals(0L, store.getMaxGen("u1", Set.of("r1", "r2")));
+  }
+
+  @Test
+  void userAndRoleBumpsAreIndependent() {
+    store.bumpUserGen("u1");
+    store.bumpRoleGen("r1");
+
+    assertEquals(1L, store.getMaxGen("u1", Set.of()));
+    assertEquals(1L, store.getMaxGen("other", Set.of("r1")));
+    assertEquals(1L, store.getMaxGen("u1", Set.of("r1")));
+    assertEquals(0L, store.getMaxGen("u2", Set.of("r2")));
+  }
+
+  @Test
+  void everyBumpMovesEpoch() {
+    assertEquals(0L, store.getEpoch());
+    store.bumpUserGen("u1");
+    assertEquals(1L, store.getEpoch());
+    store.bumpRoleGen("r1");
+    assertEquals(2L, store.getEpoch());
+    store.bumpUserGen("u1");
+    assertEquals(3L, store.getEpoch());
+  }
+
+  @Test
+  void batchBumpIsDistinctAndAdvancesEpochOnce() {
+    store.bumpUserGens(java.util.Arrays.asList("u2", "u1", "u1", "", "  ", null, "u2"));
+
+    assertEquals(1L, store.getEpoch());
+    assertEquals(1L, store.getMaxGen("u1", Set.of()));
+    assertEquals(1L, store.getMaxGen("u2", Set.of()));
+    assertEquals(0L, store.getMaxGen("u3", Set.of()));
+  }
+
+  @Test
+  void getMaxGenPicksMaxAcrossUserAndRoles() {
+    store.bumpUserGen("u1"); // user=1 epoch=1
+    store.bumpRoleGen("r1"); // role=1 epoch=2
+    store.bumpRoleGen("r2"); // role=1 epoch=3
+    store.bumpRoleGen("r2"); // role=2 epoch=4
+
+    assertEquals(2L, store.getMaxGen("u1", Set.of("r1", "r2")));
+    assertEquals(1L, store.getMaxGen("u1", Set.of("r1")));
+    assertEquals(2L, store.getMaxGen("unknown", Set.of("r2")));
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserGroupObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserGroupObjectBundleHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,15 +29,70 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.user.UserGroup;
+import org.hisp.dhis.user.authz.AuthzService;
 import org.springframework.stereotype.Component;
 
+/**
+ * Metadata import hook for {@link UserGroup}. Group membership affects the sharing/ACL snapshot
+ * inside {@code UserDetails} ({@code getUserGroupIds}), so membership changes soft-bump affected
+ * users. Group metadata-only changes (name, etc.) do not touch members.
+ *
+ * <p>{@code UserGroup.members} is the owning side of the membership relation; this is the import
+ * path that can mutate group membership.
+ *
+ * @author Morten Svanæs
+ */
 @Component
+@AllArgsConstructor
 public class UserGroupObjectBundleHook extends AbstractObjectBundleHook<UserGroup> {
+
+  public static final String MEMBER_DELTA_KEY = "userGroupMemberDelta";
+
+  private final AuthzService authzService;
+
   @Override
   public void preUpdate(UserGroup object, UserGroup persistedObject, ObjectBundle bundle) {
     handleCreatedUserProperty(object, persistedObject, bundle);
+
+    Set<String> before = uids(persistedObject.getMembers());
+    Set<String> after = uids(object.getMembers());
+    Set<String> delta = symmetricDifference(before, after);
+    bundle.putExtras(object, MEMBER_DELTA_KEY, delta);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void postUpdate(UserGroup persistedObject, ObjectBundle bundle) {
+    Set<String> delta = (Set<String>) bundle.getExtras(persistedObject, MEMBER_DELTA_KEY);
+    if (delta != null && !delta.isEmpty()) {
+      authzService.bumpUsers(delta);
+    }
+    bundle.removeExtras(persistedObject, MEMBER_DELTA_KEY);
+  }
+
+  @Override
+  public void postCreate(UserGroup persistedObject, ObjectBundle bundle) {
+    Set<String> memberUids = uids(persistedObject.getMembers());
+    if (!memberUids.isEmpty()) {
+      authzService.bumpUsers(memberUids);
+    }
+  }
+
+  @Override
+  public void preDelete(UserGroup persistedObject, ObjectBundle bundle) {
+    Set<String> memberUids = uids(persistedObject.getMembers());
+    if (!memberUids.isEmpty()) {
+      authzService.bumpUsers(memberUids);
+    }
   }
 
   /**
@@ -49,5 +104,26 @@ public class UserGroupObjectBundleHook extends AbstractObjectBundleHook<UserGrou
       UserGroup userGroup, UserGroup persistedUserGroup, ObjectBundle bundle) {
     userGroup.setCreatedBy(persistedUserGroup.getCreatedBy());
     bundle.getPreheat().put(bundle.getPreheatIdentifier(), persistedUserGroup.getCreatedBy());
+  }
+
+  private static Set<String> uids(Collection<? extends IdentifiableObject> objects) {
+    if (objects == null) {
+      return Set.of();
+    }
+    return objects.stream()
+        .filter(Objects::nonNull)
+        .map(IdentifiableObject::getUid)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+  }
+
+  private static Set<String> symmetricDifference(Set<String> before, Set<String> after) {
+    Set<String> added = new HashSet<>(after);
+    added.removeAll(before);
+    Set<String> removed = new HashSet<>(before);
+    removed.removeAll(after);
+    Set<String> delta = new HashSet<>(added);
+    delta.addAll(removed);
+    return delta;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -59,6 +60,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.user.UserSettingsService;
+import org.hisp.dhis.user.authz.AuthzService;
 import org.springframework.stereotype.Component;
 
 /**
@@ -68,7 +70,7 @@ import org.springframework.stereotype.Component;
 @AllArgsConstructor
 public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
   public static final String USERNAME = "username";
-  public static final String INVALIDATE_SESSIONS_KEY = "shouldInvalidateUserSessions";
+  public static final String AUTHZ_SNAPSHOT_CHANGED_KEY = "authzSnapshotChanged";
   public static final String PRE_UPDATE_USER_KEY = "preUpdateUser";
 
   private final UserService userService;
@@ -80,6 +82,8 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
   private final UserSettingsService userSettingsService;
 
   private final DhisConfigurationProvider dhisConfig;
+
+  private final AuthzService authzService;
 
   @Override
   public void validate(User user, ObjectBundle bundle, Consumer<ErrorReport> addReports) {
@@ -180,7 +184,7 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
     if (user == null) return;
 
     bundle.putExtras(user, PRE_UPDATE_USER_KEY, user);
-    bundle.putExtras(persisted, INVALIDATE_SESSIONS_KEY, userRolesUpdated(user, persisted));
+    bundle.putExtras(persisted, AUTHZ_SNAPSHOT_CHANGED_KEY, authzSnapshotChanged(user, persisted));
 
     if (persisted.getAvatar() != null
         && (user.getAvatar() == null
@@ -197,20 +201,30 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
     }
   }
 
-  private Boolean userRolesUpdated(User preUpdateUser, User persistedUser) {
-    Set<String> before =
-        preUpdateUser.getUserRoles().stream().map(UserRole::getUid).collect(Collectors.toSet());
-    Set<String> after =
-        persistedUser.getUserRoles().stream().map(UserRole::getUid).collect(Collectors.toSet());
+  private Boolean authzSnapshotChanged(User preUpdateUser, User persistedUser) {
+    return !Objects.equals(uids(preUpdateUser.getUserRoles()), uids(persistedUser.getUserRoles()))
+        || !Objects.equals(
+            uids(preUpdateUser.getOrganisationUnits()), uids(persistedUser.getOrganisationUnits()))
+        || !Objects.equals(
+            uids(preUpdateUser.getDataViewOrganisationUnits()),
+            uids(persistedUser.getDataViewOrganisationUnits()))
+        || !Objects.equals(
+            uids(preUpdateUser.getTeiSearchOrganisationUnits()),
+            uids(persistedUser.getTeiSearchOrganisationUnits()));
+  }
 
-    return !Objects.equals(before, after);
+  private static Set<String> uids(Collection<? extends IdentifiableObject> objects) {
+    if (objects == null) {
+      return Set.of();
+    }
+    return objects.stream().map(IdentifiableObject::getUid).collect(Collectors.toSet());
   }
 
   @Override
   public void postUpdate(User persistedUser, ObjectBundle bundle) {
     final User preUpdateUser = (User) bundle.getExtras(persistedUser, PRE_UPDATE_USER_KEY);
-    final Boolean invalidateSessions =
-        (Boolean) bundle.getExtras(persistedUser, INVALIDATE_SESSIONS_KEY);
+    final Boolean authzChanged =
+        (Boolean) bundle.getExtras(persistedUser, AUTHZ_SNAPSHOT_CHANGED_KEY);
 
     if (!StringUtils.isEmpty(preUpdateUser.getPassword())) {
       userService.encodeAndSetPassword(persistedUser, preUpdateUser.getPassword());
@@ -219,12 +233,12 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
 
     updateUserSettings(persistedUser);
 
-    if (Boolean.TRUE.equals(invalidateSessions)) {
-      userService.invalidateUserSessions(persistedUser.getUsername());
+    if (Boolean.TRUE.equals(authzChanged)) {
+      authzService.bumpUserAuthz(persistedUser.getUid());
     }
 
     bundle.removeExtras(persistedUser, PRE_UPDATE_USER_KEY);
-    bundle.removeExtras(persistedUser, INVALIDATE_SESSIONS_KEY);
+    bundle.removeExtras(persistedUser, AUTHZ_SNAPSHOT_CHANGED_KEY);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,50 +30,62 @@
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
 import java.util.Objects;
-import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
-import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserRole;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.authz.AuthzService;
 import org.springframework.stereotype.Component;
 
 /**
- * @author Morten Svanæs <msvanaes@dhi2.org>
+ * Soft-refreshes principals affected by user-role authority or restriction changes by bumping the
+ * role authz generation (and global epoch) instead of invalidating sessions.
+ *
+ * <p>Role-side membership is intentionally not handled here: {@code UserRole.members} is mapped
+ * with {@code inverse="true"} and the exposed {@code users} property has no setter, so the metadata
+ * importer cannot mutate membership from the role side. Membership deltas flow through the owning
+ * side ({@code User.userRoles}) and are handled by {@link UserObjectBundleHook}.
+ *
+ * @author Morten Svanæs
  */
 @Component
 @AllArgsConstructor
 @Slf4j
 public class UserRoleBundleHook extends AbstractObjectBundleHook<UserRole> {
 
-  public static final String INVALIDATE_SESSION_KEY = "shouldInvalidateUserSessions";
+  public static final String BUMP_ROLE_AUTHZ_KEY = "shouldBumpRoleAuthz";
 
-  private final UserService userService;
+  private final AuthzService authzService;
 
   @Override
   public void preUpdate(UserRole update, UserRole existing, ObjectBundle bundle) {
     if (update == null) return;
-    bundle.putExtras(update, INVALIDATE_SESSION_KEY, userRolesUpdated(update, existing));
+    bundle.putExtras(update, BUMP_ROLE_AUTHZ_KEY, roleAuthzChanged(update, existing));
   }
 
-  private Boolean userRolesUpdated(UserRole update, UserRole existing) {
-    Set<String> newAuthorities = update.getAuthorities();
-    Set<String> existingAuthorities = existing.getAuthorities();
-    return !Objects.equals(newAuthorities, existingAuthorities);
+  private Boolean roleAuthzChanged(UserRole update, UserRole existing) {
+    return !Objects.equals(update.getAuthorities(), existing.getAuthorities())
+        || !Objects.equals(update.getRestrictions(), existing.getRestrictions());
   }
 
   @Override
   public void postUpdate(UserRole updatedUserRole, ObjectBundle bundle) {
-    final Boolean invalidateSessions =
-        (Boolean) bundle.getExtras(updatedUserRole, INVALIDATE_SESSION_KEY);
+    final Boolean shouldBump = (Boolean) bundle.getExtras(updatedUserRole, BUMP_ROLE_AUTHZ_KEY);
 
-    if (Boolean.TRUE.equals(invalidateSessions)) {
-      for (User user : updatedUserRole.getUsers()) {
-        userService.invalidateUserSessions(user.getUsername());
-      }
+    if (Boolean.TRUE.equals(shouldBump) && updatedUserRole.getUid() != null) {
+      authzService.bumpRoleAuthz(updatedUserRole.getUid());
     }
 
-    bundle.removeExtras(updatedUserRole, INVALIDATE_SESSION_KEY);
+    bundle.removeExtras(updatedUserRole, BUMP_ROLE_AUTHZ_KEY);
+  }
+
+  @Override
+  public void preDelete(UserRole persistedObject, ObjectBundle bundle) {
+    // Bumping the soon-orphaned role key moves the epoch and the gens still referenced by live
+    // principals' snapshots, forcing their next-request refresh which then drops the deleted role.
+    // O(1); the orphan authz_version row is harmless.
+    if (persistedObject.getUid() != null) {
+      authzService.bumpRoleAuthz(persistedObject.getUid());
+    }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleHooksTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleHooksTest.java
@@ -63,7 +63,7 @@ class ObjectBundleHooksTest {
       new ObjectBundleHooks(
           asList(
               new OrganisationUnitObjectBundleHook(null, null, null),
-              new UserObjectBundleHook(null, null, null, null, null),
+              new UserObjectBundleHook(null, null, null, null, null, null),
               new IdentifiableObjectBundleHook(null),
               new VersionedObjectObjectBundleHook(),
               new AnalyticalObjectObjectBundleHook(null)));

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_17__authz_version.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_17__authz_version.sql
@@ -1,0 +1,9 @@
+-- Generation stamps for UserDetails soft-refresh: per-user ('user', <uid>), per-role
+-- ('role', <uid>), and the global change epoch ('epoch', 'epoch').
+CREATE TABLE IF NOT EXISTS authz_version (
+  scope VARCHAR(16) NOT NULL,
+  key_name VARCHAR(255) NOT NULL,
+  gen BIGINT NOT NULL DEFAULT 0,
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  PRIMARY KEY (scope, key_name)
+);

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -372,6 +372,17 @@ public class DefaultCacheProvider implements CacheProvider {
   }
 
   @Override
+  public <V> Cache<V> createUserDetailsAuthzCache() {
+    return registerCache(
+        this.<V>newBuilder()
+            .forRegion(Region.userDetailsAuthzCache.name())
+            .expireAfterWrite(5, TimeUnit.MINUTES)
+            .withInitialCapacity((int) getActualSize(SIZE_1K))
+            .forceInMemory()
+            .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_10K))));
+  }
+
+  @Override
   public <V> Cache<V> createTeAttributesCache() {
     return registerCache(
         this.<V>newBuilder()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/authz/JdbcAuthzVersionStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/authz/JdbcAuthzVersionStoreTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user.authz;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Validates {@link JdbcAuthzVersionStore} ON CONFLICT SQL against real Postgres.
+ *
+ * @author Morten Svanæs
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+@Transactional
+class JdbcAuthzVersionStoreTest extends PostgresIntegrationTestBase {
+
+  @Autowired private AuthzVersionStore store;
+
+  @Test
+  void epochStartsAtZero() {
+    assertEquals(0L, store.getEpoch());
+  }
+
+  @Test
+  void bumpUserGenAdvancesUserGenAndEpoch() {
+    long epochBefore = store.getEpoch();
+    store.bumpUserGen("userA");
+
+    assertEquals(epochBefore + 1, store.getEpoch());
+    assertEquals(1L, store.getMaxGen("userA", Set.of()));
+  }
+
+  @Test
+  void bumpRoleGenIsIndependent() {
+    store.bumpUserGen("userA");
+    store.bumpRoleGen("roleA");
+
+    assertEquals(1L, store.getMaxGen("userA", Set.of()));
+    assertEquals(1L, store.getMaxGen("other", Set.of("roleA")));
+    assertEquals(1L, store.getMaxGen("userA", Set.of("roleA")));
+  }
+
+  @Test
+  void repeatedBumpsIncrementViaUpsertConflictPath() {
+    store.bumpUserGen("userB");
+    store.bumpUserGen("userB");
+    store.bumpUserGen("userB");
+
+    assertEquals(3L, store.getMaxGen("userB", Set.of()));
+    assertEquals(3L, store.getEpoch());
+  }
+
+  @Test
+  void bumpUserGensDeduplicatesAndAdvancesEpochOnce() {
+    long epochBefore = store.getEpoch();
+    store.bumpUserGens(List.of("u2", "u1", "u1", "", "  ", "u2"));
+
+    assertEquals(epochBefore + 1, store.getEpoch());
+    assertEquals(1L, store.getMaxGen("u1", Set.of()));
+    assertEquals(1L, store.getMaxGen("u2", Set.of()));
+  }
+
+  @Test
+  void getMaxGenAcrossUserAndRoles() {
+    store.bumpUserGen("userC"); // user=1
+    store.bumpRoleGen("role1"); // role=1
+    store.bumpRoleGen("role2"); // role=1
+    store.bumpRoleGen("role2"); // role=2
+
+    assertEquals(2L, store.getMaxGen("userC", Set.of("role1", "role2")));
+  }
+
+  @Test
+  void getMaxGenUnknownKeysIsZero() {
+    assertEquals(0L, store.getMaxGen("missing-user", Set.of("missing-role")));
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -77,6 +77,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserRole;
+import org.hisp.dhis.user.authz.AuthzVersionStore;
 import org.hisp.dhis.user.sharing.Sharing;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.jboss.aerogear.security.otp.api.Base32;
@@ -107,6 +108,8 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
 
   @Autowired private DhisConfigurationProvider config;
 
+  @Autowired private AuthzVersionStore authzVersionStore;
+
   private User peter;
 
   @BeforeEach
@@ -136,7 +139,7 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
-  void updateRolesShouldInvalidateUserSessions() {
+  void updateUserRolesShouldBumpAuthzGenWithoutKillingSessions() {
     UserDetails sessionPrincipal = userService.createUserDetails(getAdminUser());
     sessionRegistry.registerNewSession("session1", sessionPrincipal);
     assertFalse(sessionRegistry.getAllSessions(sessionPrincipal, false).isEmpty());
@@ -145,17 +148,21 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
     userService.addUserRole(roleB);
 
     String roleBID = userService.getUserRoleByName("ROLE_B").getUid();
+    long epochBefore = authzVersionStore.getEpoch();
 
     PATCH(
             "/users/" + getAdminUid(),
             "[{'op':'add','path':'/userRoles','value':[{'id':'" + roleBID + "'}]}]")
         .content(HttpStatus.OK);
 
-    assertTrue(sessionRegistry.getAllSessions(sessionPrincipal, false).isEmpty());
+    // Soft-refresh: the session survives, the user's authz generation moves instead.
+    assertFalse(sessionRegistry.getAllSessions(sessionPrincipal, false).isEmpty());
+    assertTrue(authzVersionStore.getEpoch() > epochBefore);
+    assertTrue(authzVersionStore.getMaxGen(getAdminUid(), Set.of()) > 0);
   }
 
   @Test
-  void updateRolesAuthoritiesShouldInvalidateUserSessions() {
+  void updateRoleAuthoritiesShouldBumpRoleAuthzGenWithoutKillingSessions() {
     UserDetails sessionPrincipal = userService.createUserDetails(getAdminUser());
 
     UserRole roleB = createUserRole("ROLE_B", "ALL");
@@ -171,6 +178,9 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
     sessionRegistry.registerNewSession("session1", sessionPrincipal);
     assertFalse(sessionRegistry.getAllSessions(sessionPrincipal, false).isEmpty());
 
+    long epochBefore = authzVersionStore.getEpoch();
+    long roleGenBefore = authzVersionStore.getMaxGen("nonexistentUid", Set.of(roleBID));
+
     PATCH(
             "/userRoles/" + roleBID,
             "["
@@ -182,7 +192,10 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
                 + "]")
         .content(HttpStatus.OK);
 
-    assertTrue(sessionRegistry.getAllSessions(sessionPrincipal, false).isEmpty());
+    // Soft-refresh: the session survives, the role's authz generation moves instead.
+    assertFalse(sessionRegistry.getAllSessions(sessionPrincipal, false).isEmpty());
+    assertTrue(authzVersionStore.getEpoch() > epochBefore);
+    assertTrue(authzVersionStore.getMaxGen("nonexistentUid", Set.of(roleBID)) > roleGenBefore);
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/authz/AuthzSoftRefreshH2CompatTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/authz/AuthzSoftRefreshH2CompatTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.authz;
+
+import static org.hisp.dhis.http.HttpAssertions.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.user.authz.AuthzVersionStore;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Proves the authz_version SQL and the bundle-hook bump paths work against the Hibernate-generated
+ * H2 schema, and that the bumps actually fire (generation and epoch assertions, not just HTTP
+ * status).
+ *
+ * @author Morten Svanæs
+ */
+@Transactional
+class AuthzSoftRefreshH2CompatTest extends H2ControllerIntegrationTestBase {
+
+  @Autowired private AuthzVersionStore authzVersionStore;
+
+  @Test
+  void groupMembershipBumpRunsOnH2() {
+    String adminUid = getAdminUid();
+    long epochBefore = authzVersionStore.getEpoch();
+
+    String groupId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST("/userGroups", "{'name':'GroupA','users':[{'id':'" + adminUid + "'}]}"));
+
+    assertTrue(
+        GET("/userGroups/" + groupId + "?fields=users")
+            .content(HttpStatus.OK)
+            .toString()
+            .contains(adminUid),
+        "group import must persist the posted member");
+    long genAfterCreate = authzVersionStore.getMaxGen(adminUid, Set.of());
+    assertTrue(authzVersionStore.getEpoch() > epochBefore, "group create must advance the epoch");
+    assertTrue(genAfterCreate > 0, "group create with member must bump the member's user gen");
+
+    assertStatus(HttpStatus.OK, PUT("/userGroups/" + groupId, "{'name':'GroupA','users':[]}"));
+
+    assertTrue(
+        authzVersionStore.getMaxGen(adminUid, Set.of()) > genAfterCreate,
+        "membership removal must bump the removed member's user gen");
+  }
+
+  @Test
+  void roleAuthorityChangeBumpRunsOnH2() {
+    String roleId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST("/userRoles", "{'name':'RoleA','authorities':['F_DATAVALUE_ADD']}"));
+
+    long roleGenBefore = authzVersionStore.getMaxGen("nonexistentUid", Set.of(roleId));
+    long epochBefore = authzVersionStore.getEpoch();
+
+    assertStatus(
+        HttpStatus.OK,
+        PUT("/userRoles/" + roleId, "{'name':'RoleA','authorities':['F_DATAVALUE_DELETE']}"));
+
+    assertTrue(
+        authzVersionStore.getMaxGen("nonexistentUid", Set.of(roleId)) > roleGenBefore,
+        "authority change must bump the role gen");
+    assertTrue(authzVersionStore.getEpoch() > epochBefore, "role bump must advance the epoch");
+  }
+
+  @Test
+  void roleDeleteBumpRunsOnH2() {
+    String roleId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST("/userRoles", "{'name':'RoleB','authorities':['F_DATAVALUE_ADD']}"));
+
+    long epochBefore = authzVersionStore.getEpoch();
+
+    assertStatus(HttpStatus.OK, DELETE("/userRoles/" + roleId));
+
+    assertTrue(
+        authzVersionStore.getMaxGen("nonexistentUid", Set.of(roleId)) > 0,
+        "role delete must bump the deleted role's gen");
+    assertTrue(authzVersionStore.getEpoch() > epochBefore, "role delete must advance the epoch");
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/apikey/ApiTokenAuthManager.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/apikey/ApiTokenAuthManager.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.security.apikey.ApiTokenService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.authz.AuthzService;
 import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
@@ -56,13 +57,18 @@ import org.springframework.stereotype.Service;
 public class ApiTokenAuthManager implements AuthenticationManager {
   private final ApiTokenService apiTokenService;
   private final UserService userService;
+  private final AuthzService authzService;
 
   private final Cache<ApiTokenAuthenticationToken> apiTokenCache;
 
   public ApiTokenAuthManager(
-      ApiTokenService apiTokenService, CacheProvider cacheProvider, @Lazy UserService userService) {
+      ApiTokenService apiTokenService,
+      CacheProvider cacheProvider,
+      @Lazy UserService userService,
+      AuthzService authzService) {
     this.userService = userService;
     this.apiTokenService = apiTokenService;
+    this.authzService = authzService;
     this.apiTokenCache = cacheProvider.createApiKeyCache();
   }
 
@@ -78,8 +84,20 @@ public class ApiTokenAuthManager implements AuthenticationManager {
     final Optional<ApiTokenAuthenticationToken> cachedToken = apiTokenCache.getIfPresent(tokenKey);
 
     if (cachedToken.isPresent()) {
-      validateTokenExpiry(cachedToken.get().getToken().getExpire());
-      return cachedToken.get();
+      ApiTokenAuthenticationToken cached = cachedToken.get();
+      validateTokenExpiry(cached.getToken().getExpire());
+      UserDetails cachedDetails = cached.getPrincipal();
+      if (cachedDetails != null) {
+        UserDetails freshDetails = authzService.getFreshUserDetails(cachedDetails.getUsername());
+        if (freshDetails != null && freshDetails != cachedDetails) {
+          // identity: same instance == unchanged epoch
+          ApiTokenAuthenticationToken refreshed =
+              new ApiTokenAuthenticationToken(cached.getToken(), freshDetails);
+          apiTokenCache.put(tokenKey, refreshed);
+          return refreshed;
+        }
+      }
+      return cached;
     } else {
       ApiToken apiToken = apiTokenService.getByKey(tokenKey);
       if (apiToken == null) {
@@ -109,7 +127,7 @@ public class ApiTokenAuthManager implements AuthenticationManager {
     // User lookup and UserDetails creation must happen within a single transaction, so that lazy
     // collections (e.g. User.userRoles) are accessible. This code can run on endpoints excluded
     // from open-session-in-view, where no Hibernate session is otherwise available.
-    UserDetails userDetails = userService.createUserDetailsByUsername(createdBy.getUsername());
+    UserDetails userDetails = authzService.getFreshUserDetails(createdBy.getUsername());
     if (userDetails == null) {
       throw new ApiTokenAuthenticationException(
           ApiTokenErrors.invalidToken("The API token owner does not exists."));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/authz/SoftRefreshSecurityContextRepository.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/authz/SoftRefreshSecurityContextRepository.java
@@ -32,12 +32,9 @@ package org.hisp.dhis.webapi.security.authz;
 import static org.hisp.dhis.user.authz.AuthzConstants.SESSION_AUTHZ_EPOCH_ATTR;
 import static org.hisp.dhis.user.authz.AuthzConstants.SESSION_AUTHZ_GEN_ATTR;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import java.io.IOException;
 import java.util.Map;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -47,25 +44,29 @@ import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.authz.AuthzService;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.DeferredSecurityContext;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.context.SecurityContextRepository;
-import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
- * Soft-refreshes the session-bound {@link UserDetails} principal when the authz generation/epoch
- * has advanced since the last check.
+ * Decorates the session-backed {@link SecurityContextRepository} to soft-refresh the {@link
+ * UserDetails} principal when the authz generation/epoch has advanced since the last check.
+ *
+ * <p>Decorating the repository (instead of adding a filter) makes the refresh session-only <em>by
+ * construction</em>: JWT, PAT, and other stateless authentications never pass through {@link
+ * HttpSessionSecurityContextRepository}, so no token-type conversion or accidental session creation
+ * is possible. Wrapping the {@link DeferredSecurityContext} means the check only runs when the
+ * request actually accesses authentication.
  *
  * <p>Eligibility gates:
  *
  * <ul>
- *   <li>Session-only: JWT, PAT, and basic-stateless authentications have their own refresh paths
- *       and must never be converted or given sessions by this filter.
  *   <li>Token type: only {@link UsernamePasswordAuthenticationToken} and {@link
- *       OAuth2AuthenticationToken} carry a mutable session principal we can rebuild.
+ *       OAuth2AuthenticationToken} carry a session principal we can rebuild.
  *   <li>No impersonation: {@link SwitchUserGrantedAuthority} carries the original Authentication; a
  *       rebuild would drop it.
  * </ul>
@@ -73,82 +74,130 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * @author Morten Svanæs
  */
 @Slf4j
-public class UserDetailsSoftRefreshFilter extends OncePerRequestFilter {
+public class SoftRefreshSecurityContextRepository implements SecurityContextRepository {
 
+  private final SecurityContextRepository delegate;
   private final AuthzService authzService;
-  private final SecurityContextRepository securityContextRepository;
 
-  /**
-   * Default repository matches the app's session persistence; the chain's
-   * DelegatingSecurityContextRepository only adds a request-attribute layer we already cover by
-   * setting the SecurityContextHolder.
-   */
-  public UserDetailsSoftRefreshFilter(AuthzService authzService) {
-    this(authzService, new HttpSessionSecurityContextRepository());
-  }
-
-  public UserDetailsSoftRefreshFilter(
-      AuthzService authzService, SecurityContextRepository securityContextRepository) {
+  public SoftRefreshSecurityContextRepository(
+      SecurityContextRepository delegate, AuthzService authzService) {
+    this.delegate = delegate;
     this.authzService = authzService;
-    this.securityContextRepository = securityContextRepository;
   }
 
   @Override
-  protected void doFilterInternal(
-      @Nonnull HttpServletRequest request,
-      @Nonnull HttpServletResponse response,
-      @Nonnull FilterChain chain)
-      throws ServletException, IOException {
-    HttpSession session = request.getSession(false);
-    if (session == null) {
-      chain.doFilter(request, response);
-      return;
+  public DeferredSecurityContext loadDeferredContext(HttpServletRequest request) {
+    return new SoftRefreshDeferredContext(delegate.loadDeferredContext(request), request, this);
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public SecurityContext loadContext(
+      org.springframework.security.web.context.HttpRequestResponseHolder requestResponseHolder) {
+    return delegate.loadContext(requestResponseHolder);
+  }
+
+  @Override
+  public void saveContext(
+      SecurityContext context, HttpServletRequest request, HttpServletResponse response) {
+    delegate.saveContext(context, request, response);
+  }
+
+  @Override
+  public boolean containsContext(HttpServletRequest request) {
+    return delegate.containsContext(request);
+  }
+
+  /** Defers the freshness check until the request actually accesses its authentication. */
+  private static final class SoftRefreshDeferredContext implements DeferredSecurityContext {
+
+    private final DeferredSecurityContext delegate;
+    private final HttpServletRequest request;
+    private final SoftRefreshSecurityContextRepository repository;
+
+    private SecurityContext result;
+
+    private SoftRefreshDeferredContext(
+        DeferredSecurityContext delegate,
+        HttpServletRequest request,
+        SoftRefreshSecurityContextRepository repository) {
+      this.delegate = delegate;
+      this.request = request;
+      this.repository = repository;
     }
 
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    @Override
+    public SecurityContext get() {
+      if (result == null) {
+        result = repository.maybeRefresh(delegate.get(), request);
+      }
+      return result;
+    }
+
+    @Override
+    public boolean isGenerated() {
+      return delegate.isGenerated();
+    }
+  }
+
+  /**
+   * Returns {@code context} unchanged when fresh (or not eligible), otherwise a new context with a
+   * rebuilt principal, persisted to the session.
+   */
+  private SecurityContext maybeRefresh(SecurityContext context, HttpServletRequest request) {
+    HttpSession session = request.getSession(false);
+    if (session == null || context == null) {
+      return context;
+    }
+    Authentication auth = context.getAuthentication();
     if (!isEligible(auth)) {
-      chain.doFilter(request, response);
-      return;
+      return context;
     }
 
     long epoch = authzService.currentEpoch();
     long checkedEpoch = readLongAttr(session, SESSION_AUTHZ_EPOCH_ATTR);
-    if (epoch != checkedEpoch) {
-      UserDetails current = extractUserDetails(auth);
-      if (current != null) {
-        long gen = authzService.effectiveGen(current); // pre-read BEFORE rebuild
-        long sessionGen = readLongAttr(session, SESSION_AUTHZ_GEN_ATTR);
-        if (gen != sessionGen) {
-          UserDetails fresh = authzService.getFreshUserDetails(current.getUsername());
-          if (fresh != null) {
-            Authentication replacement = rebuildAuthentication(auth, fresh);
-            if (replacement != null) {
-              SecurityContext context = SecurityContextHolder.createEmptyContext();
-              context.setAuthentication(replacement);
-              SecurityContextHolder.setContext(context);
-              securityContextRepository.saveContext(context, request, response);
-              session.setAttribute(SESSION_AUTHZ_GEN_ATTR, gen); // pre-read value, NEVER re-read
-              log.debug(
-                  "Soft-refreshed session UserDetails for {} (gen {} -> {})",
-                  current.getUsername(),
-                  sessionGen,
-                  gen);
-            }
-          }
-        } else {
-          session.setAttribute(SESSION_AUTHZ_GEN_ATTR, gen);
-        }
-        session.setAttribute(SESSION_AUTHZ_EPOCH_ATTR, epoch);
-      }
+    if (epoch == checkedEpoch) {
+      return context;
+    }
+    UserDetails current = extractUserDetails(auth);
+    if (current == null) {
+      return context;
     }
 
-    chain.doFilter(request, response);
+    SecurityContext result = context;
+    long gen = authzService.effectiveGen(current); // pre-read BEFORE rebuild, never re-read
+    long sessionGen = readLongAttr(session, SESSION_AUTHZ_GEN_ATTR);
+    if (gen != sessionGen) {
+      UserDetails fresh = authzService.getFreshUserDetails(current.getUsername());
+      if (fresh != null) {
+        Authentication replacement = rebuildAuthentication(auth, fresh);
+        if (replacement != null) {
+          SecurityContext refreshed = SecurityContextHolder.createEmptyContext();
+          refreshed.setAuthentication(replacement);
+          // Equivalent of HttpSessionSecurityContextRepository.saveContextInHttpSession: under
+          // requireExplicitSave, SecurityContextHolderFilter never saves, so the refresh
+          // persists itself for subsequent requests.
+          session.setAttribute(
+              HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, refreshed);
+          session.setAttribute(SESSION_AUTHZ_GEN_ATTR, gen); // pre-read value, NEVER re-read
+          result = refreshed;
+          log.debug(
+              "Soft-refreshed session UserDetails for {} (gen {} -> {})",
+              current.getUsername(),
+              sessionGen,
+              gen);
+        }
+      }
+    } else {
+      session.setAttribute(SESSION_AUTHZ_GEN_ATTR, gen);
+    }
+    session.setAttribute(SESSION_AUTHZ_EPOCH_ATTR, epoch);
+    return result;
   }
 
   /**
-   * Session-only (JWT/PAT/basic-stateless have their own refresh paths and must never be converted
-   * or given sessions); impersonation carries the original Authentication inside {@link
-   * SwitchUserGrantedAuthority} which a rebuild would drop.
+   * Impersonation carries the original Authentication inside {@link SwitchUserGrantedAuthority}
+   * which a rebuild would drop; only session-native token types are rebuildable.
    */
   private static boolean isEligible(@CheckForNull Authentication auth) {
     return auth != null

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/authz/UserDetailsSoftRefreshFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/authz/UserDetailsSoftRefreshFilter.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.authz;
+
+import static org.hisp.dhis.user.authz.AuthzConstants.SESSION_AUTHZ_EPOCH_ATTR;
+import static org.hisp.dhis.user.authz.AuthzConstants.SESSION_AUTHZ_GEN_ATTR;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.Map;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.security.oidc.DhisOidcUser;
+import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.authz.AuthzService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Soft-refreshes the session-bound {@link UserDetails} principal when the authz generation/epoch
+ * has advanced since the last check.
+ *
+ * <p>Eligibility gates:
+ *
+ * <ul>
+ *   <li>Session-only: JWT, PAT, and basic-stateless authentications have their own refresh paths
+ *       and must never be converted or given sessions by this filter.
+ *   <li>Token type: only {@link UsernamePasswordAuthenticationToken} and {@link
+ *       OAuth2AuthenticationToken} carry a mutable session principal we can rebuild.
+ *   <li>No impersonation: {@link SwitchUserGrantedAuthority} carries the original Authentication; a
+ *       rebuild would drop it.
+ * </ul>
+ *
+ * @author Morten Svanæs
+ */
+@Slf4j
+public class UserDetailsSoftRefreshFilter extends OncePerRequestFilter {
+
+  private final AuthzService authzService;
+  private final SecurityContextRepository securityContextRepository;
+
+  /**
+   * Default repository matches the app's session persistence; the chain's
+   * DelegatingSecurityContextRepository only adds a request-attribute layer we already cover by
+   * setting the SecurityContextHolder.
+   */
+  public UserDetailsSoftRefreshFilter(AuthzService authzService) {
+    this(authzService, new HttpSessionSecurityContextRepository());
+  }
+
+  public UserDetailsSoftRefreshFilter(
+      AuthzService authzService, SecurityContextRepository securityContextRepository) {
+    this.authzService = authzService;
+    this.securityContextRepository = securityContextRepository;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      @Nonnull HttpServletRequest request,
+      @Nonnull HttpServletResponse response,
+      @Nonnull FilterChain chain)
+      throws ServletException, IOException {
+    HttpSession session = request.getSession(false);
+    if (session == null) {
+      chain.doFilter(request, response);
+      return;
+    }
+
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (!isEligible(auth)) {
+      chain.doFilter(request, response);
+      return;
+    }
+
+    long epoch = authzService.currentEpoch();
+    long checkedEpoch = readLongAttr(session, SESSION_AUTHZ_EPOCH_ATTR);
+    if (epoch != checkedEpoch) {
+      UserDetails current = extractUserDetails(auth);
+      if (current != null) {
+        long gen = authzService.effectiveGen(current); // pre-read BEFORE rebuild
+        long sessionGen = readLongAttr(session, SESSION_AUTHZ_GEN_ATTR);
+        if (gen != sessionGen) {
+          UserDetails fresh = authzService.getFreshUserDetails(current.getUsername());
+          if (fresh != null) {
+            Authentication replacement = rebuildAuthentication(auth, fresh);
+            if (replacement != null) {
+              SecurityContext context = SecurityContextHolder.createEmptyContext();
+              context.setAuthentication(replacement);
+              SecurityContextHolder.setContext(context);
+              securityContextRepository.saveContext(context, request, response);
+              session.setAttribute(SESSION_AUTHZ_GEN_ATTR, gen); // pre-read value, NEVER re-read
+              log.debug(
+                  "Soft-refreshed session UserDetails for {} (gen {} -> {})",
+                  current.getUsername(),
+                  sessionGen,
+                  gen);
+            }
+          }
+        } else {
+          session.setAttribute(SESSION_AUTHZ_GEN_ATTR, gen);
+        }
+        session.setAttribute(SESSION_AUTHZ_EPOCH_ATTR, epoch);
+      }
+    }
+
+    chain.doFilter(request, response);
+  }
+
+  /**
+   * Session-only (JWT/PAT/basic-stateless have their own refresh paths and must never be converted
+   * or given sessions); impersonation carries the original Authentication inside {@link
+   * SwitchUserGrantedAuthority} which a rebuild would drop.
+   */
+  private static boolean isEligible(@CheckForNull Authentication auth) {
+    return auth != null
+        && auth.isAuthenticated()
+        && (auth instanceof UsernamePasswordAuthenticationToken
+            || auth instanceof OAuth2AuthenticationToken)
+        && auth.getAuthorities().stream().noneMatch(SwitchUserGrantedAuthority.class::isInstance);
+  }
+
+  @CheckForNull
+  private static UserDetails extractUserDetails(@Nonnull Authentication auth) {
+    Object principal = auth.getPrincipal();
+    if (principal instanceof DhisOidcUser oidcUser) {
+      org.springframework.security.core.userdetails.UserDetails nested = oidcUser.getUser();
+      if (nested instanceof UserDetails dhisUserDetails) {
+        return dhisUserDetails;
+      }
+      return null;
+    }
+    if (principal instanceof UserDetails userDetails) {
+      return userDetails;
+    }
+    return null;
+  }
+
+  @CheckForNull
+  private static Authentication rebuildAuthentication(
+      @Nonnull Authentication existing, @Nonnull UserDetails fresh) {
+    if (existing instanceof OAuth2AuthenticationToken oauth2
+        && oauth2.getPrincipal() instanceof DhisOidcUser oidcUser) {
+      Map<String, Object> attributes = oidcUser.getAttributes();
+      if (attributes.isEmpty()) {
+        return null;
+      }
+      DhisOidcUser newPrincipal =
+          new DhisOidcUser(
+              fresh, attributes, resolveNameAttributeKey(oidcUser), oidcUser.getIdToken());
+      OAuth2AuthenticationToken token =
+          new OAuth2AuthenticationToken(
+              newPrincipal, fresh.getAuthorities(), oauth2.getAuthorizedClientRegistrationId());
+      token.setDetails(existing.getDetails());
+      return token;
+    }
+    if (existing instanceof UsernamePasswordAuthenticationToken
+        && existing.getPrincipal() instanceof UserDetails) {
+      UsernamePasswordAuthenticationToken token =
+          UsernamePasswordAuthenticationToken.authenticated(
+              fresh, existing.getCredentials(), fresh.getAuthorities());
+      token.setDetails(existing.getDetails());
+      return token;
+    }
+    return null;
+  }
+
+  /**
+   * {@link org.springframework.security.oauth2.core.user.DefaultOAuth2User} requires the name
+   * attribute key to exist in attributes. {@link DhisOidcUser} does not override {@code getName()},
+   * so the value returned by {@code getName()} is the original name attribute's value and can be
+   * used to recover the key.
+   */
+  @Nonnull
+  static String resolveNameAttributeKey(@Nonnull DhisOidcUser oidcUser) {
+    Map<String, Object> attributes = oidcUser.getAttributes();
+    String name = null;
+    try {
+      name = oidcUser.getName();
+    } catch (RuntimeException ignored) {
+      // odd principal states; fall through to defaults
+    }
+    if (name != null) {
+      for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+        if (entry.getValue() != null && name.equals(String.valueOf(entry.getValue()))) {
+          return entry.getKey();
+        }
+      }
+    }
+    if (attributes.containsKey("sub")) {
+      return "sub";
+    }
+    return attributes.keySet().iterator().next();
+  }
+
+  private static long readLongAttr(@Nonnull HttpSession session, @Nonnull String name) {
+    Object value = session.getAttribute(name);
+    if (value instanceof Long longValue) {
+      return longValue;
+    }
+    if (value instanceof Number number) {
+      return number.longValue();
+    }
+    if (value instanceof String stringValue) {
+      try {
+        return Long.parseLong(stringValue);
+      } catch (NumberFormatException ignored) {
+        return 0L;
+      }
+    }
+    return 0L;
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.security.oidc.DhisOidcLogoutSuccessHandler;
 import org.hisp.dhis.security.oidc.DhisOidcProviderRepository;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationProvider;
 import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetailsSource;
+import org.hisp.dhis.user.authz.AuthzService;
 import org.hisp.dhis.webapi.filter.CspFilter;
 import org.hisp.dhis.webapi.filter.DhisCorsProcessor;
 import org.hisp.dhis.webapi.filter.SessionTimeoutHeaderFilter;
@@ -65,6 +66,7 @@ import org.hisp.dhis.webapi.security.FormLoginBasicAuthenticationEntryPoint;
 import org.hisp.dhis.webapi.security.Http401LoginUrlAuthenticationEntryPoint;
 import org.hisp.dhis.webapi.security.apikey.ApiTokenAuthManager;
 import org.hisp.dhis.webapi.security.apikey.Dhis2ApiTokenFilter;
+import org.hisp.dhis.webapi.security.authz.UserDetailsSoftRefreshFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -151,6 +153,8 @@ public class DhisWebApiWebSecurityConfig {
   @Autowired private DhisAuthorizationCodeTokenResponseClient jwtPrivateCodeTokenResponseClient;
 
   @Autowired private RequestCache requestCache;
+
+  @Autowired private AuthzService authzService;
 
   private static class CustomRequestMatcher implements RequestMatcher {
     private static final Pattern p1 = Pattern.compile("^/api/apps/.+", Pattern.CASE_INSENSITIVE);
@@ -265,6 +269,8 @@ public class DhisWebApiWebSecurityConfig {
     configureOAuthTokenFilters(http);
 
     http.addFilterAfter(new SessionTimeoutHeaderFilter(), SessionManagementFilter.class);
+    http.addFilterAfter(
+        new UserDetailsSoftRefreshFilter(authzService), SessionTimeoutHeaderFilter.class);
 
     setHttpHeaders(http);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -66,7 +66,7 @@ import org.hisp.dhis.webapi.security.FormLoginBasicAuthenticationEntryPoint;
 import org.hisp.dhis.webapi.security.Http401LoginUrlAuthenticationEntryPoint;
 import org.hisp.dhis.webapi.security.apikey.ApiTokenAuthManager;
 import org.hisp.dhis.webapi.security.apikey.Dhis2ApiTokenFilter;
-import org.hisp.dhis.webapi.security.authz.UserDetailsSoftRefreshFilter;
+import org.hisp.dhis.webapi.security.authz.SoftRefreshSecurityContextRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -86,7 +86,9 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.context.DelegatingSecurityContextRepository;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
@@ -269,9 +271,6 @@ public class DhisWebApiWebSecurityConfig {
     configureOAuthTokenFilters(http);
 
     http.addFilterAfter(new SessionTimeoutHeaderFilter(), SessionManagementFilter.class);
-    http.addFilterAfter(
-        new UserDetailsSoftRefreshFilter(authzService), SessionTimeoutHeaderFilter.class);
-
     setHttpHeaders(http);
 
     return http.build();
@@ -299,9 +298,18 @@ public class DhisWebApiWebSecurityConfig {
   }
 
   private void configureMatchers(HttpSecurity http) throws Exception {
+    // Replicates the configurer's default repository pair, with the HttpSession delegate
+    // decorated for authz soft-refresh (session-only by construction; JWT/PAT never load
+    // through it).
     http.securityContext(
-        httpSecuritySecurityContextConfigurer ->
-            httpSecuritySecurityContextConfigurer.requireExplicitSave(true));
+        securityContext ->
+            securityContext
+                .requireExplicitSave(true)
+                .securityContextRepository(
+                    new DelegatingSecurityContextRepository(
+                        new RequestAttributeSecurityContextRepository(),
+                        new SoftRefreshSecurityContextRepository(
+                            new HttpSessionSecurityContextRepository(), authzService))));
 
     Set<String> providerIds = dhisOidcProviderRepository.getAllRegistrationId();
     http.authorizeHttpRequests(

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/security/authz/SoftRefreshSecurityContextRepositoryTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/security/authz/SoftRefreshSecurityContextRepositoryTest.java
@@ -37,13 +37,13 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.web.context.HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY;
 
-import jakarta.servlet.FilterChain;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -53,181 +53,174 @@ import org.hisp.dhis.security.apikey.ApiTokenAuthenticationToken;
 import org.hisp.dhis.security.oidc.DhisOidcUser;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.authz.AuthzService;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.DeferredSecurityContext;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority;
-import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 
 /**
- * Unit tests for {@link UserDetailsSoftRefreshFilter}.
+ * Unit tests for {@link SoftRefreshSecurityContextRepository}, using a real {@link
+ * HttpSessionSecurityContextRepository} delegate so contexts load the way they do in production.
  *
  * @author Morten Svanæs
  */
 @ExtendWith(MockitoExtension.class)
-class UserDetailsSoftRefreshFilterTest {
+class SoftRefreshSecurityContextRepositoryTest {
 
   @Mock private AuthzService authzService;
-  @Mock private SecurityContextRepository securityContextRepository;
-  @Mock private FilterChain filterChain;
 
-  private UserDetailsSoftRefreshFilter filter;
+  private SoftRefreshSecurityContextRepository repository;
   private MockHttpServletRequest request;
-  private MockHttpServletResponse response;
 
   @BeforeEach
   void setUp() {
-    filter = new UserDetailsSoftRefreshFilter(authzService, securityContextRepository);
+    repository =
+        new SoftRefreshSecurityContextRepository(
+            new HttpSessionSecurityContextRepository(), authzService);
     request = new MockHttpServletRequest("GET", "/api/me");
-    response = new MockHttpServletResponse();
-    SecurityContextHolder.clearContext();
-  }
-
-  @AfterEach
-  void tearDown() {
-    SecurityContextHolder.clearContext();
   }
 
   @Test
-  void noSessionPerformsZeroAuthzServiceCalls() throws Exception {
-    // no session created
-    filter.doFilter(request, response, filterChain);
+  void noSessionPerformsZeroAuthzServiceCalls() {
+    repository.loadDeferredContext(request).get();
 
-    verify(filterChain).doFilter(request, response);
     verifyNoInteractions(authzService);
-    verifyNoInteractions(securityContextRepository);
   }
 
   @Test
-  void patTokenWithSessionIsSkipped() throws Exception {
+  void loadWithoutAccessPerformsZeroAuthzServiceCalls() {
     MockHttpSession session = new MockHttpSession();
     request.setSession(session);
+    storeContext(
+        session,
+        UsernamePasswordAuthenticationToken.authenticated(
+            userDetails("alice", "F_USER"), "n/a", List.of()));
 
+    repository.loadDeferredContext(request); // never call get()
+
+    verifyNoInteractions(authzService);
+  }
+
+  @Test
+  void patTokenContextIsUntouched() {
+    MockHttpSession session = new MockHttpSession();
+    request.setSession(session);
     UserDetails principal = userDetails("pat-user", "F_PAT");
     ApiTokenAuthenticationToken pat = new ApiTokenAuthenticationToken(new ApiToken(), principal);
     pat.setAuthenticated(true);
-    SecurityContextHolder.getContext().setAuthentication(pat);
+    SecurityContext stored = storeContext(session, pat);
 
-    filter.doFilter(request, response, filterChain);
+    SecurityContext loaded = repository.loadDeferredContext(request).get();
 
-    verify(filterChain).doFilter(request, response);
+    assertSame(stored, loaded);
     verifyNoInteractions(authzService);
-    assertSame(pat, SecurityContextHolder.getContext().getAuthentication());
-    verifyNoInteractions(securityContextRepository);
   }
 
   @Test
-  void switchUserAuthorityIsSkipped() throws Exception {
+  void switchUserAuthorityIsSkipped() {
     MockHttpSession session = new MockHttpSession();
     request.setSession(session);
-
     Authentication original =
         UsernamePasswordAuthenticationToken.authenticated(
             userDetails("admin", "ALL"), "n/a", List.of(new SimpleGrantedAuthority("ALL")));
-    UserDetails impersonated = userDetails("alice", "F_USER");
     SwitchUserGrantedAuthority switchAuth =
         new SwitchUserGrantedAuthority("F_PREVIOUS_IMPERSONATOR_AUTHORITY", original);
     UsernamePasswordAuthenticationToken auth =
         UsernamePasswordAuthenticationToken.authenticated(
-            impersonated, "n/a", List.of(switchAuth, new SimpleGrantedAuthority("F_USER")));
-    SecurityContextHolder.getContext().setAuthentication(auth);
+            userDetails("alice", "F_USER"),
+            "n/a",
+            List.of(switchAuth, new SimpleGrantedAuthority("F_USER")));
+    SecurityContext stored = storeContext(session, auth);
 
-    filter.doFilter(request, response, filterChain);
+    SecurityContext loaded = repository.loadDeferredContext(request).get();
 
-    verify(filterChain).doFilter(request, response);
+    assertSame(stored, loaded);
     verifyNoInteractions(authzService);
-    assertSame(auth, SecurityContextHolder.getContext().getAuthentication());
   }
 
   @Test
-  void matchingEpochNeverCallsEffectiveGen() throws Exception {
+  void matchingEpochNeverCallsEffectiveGen() {
     MockHttpSession session = new MockHttpSession();
     session.setAttribute(SESSION_AUTHZ_EPOCH_ATTR, 7L);
     request.setSession(session);
-
-    setUsernamePasswordAuth(userDetails("alice", "F_USER"));
+    SecurityContext stored = storeUsernamePasswordContext(session, userDetails("alice", "F_USER"));
 
     when(authzService.currentEpoch()).thenReturn(7L);
 
-    filter.doFilter(request, response, filterChain);
+    SecurityContext loaded = repository.loadDeferredContext(request).get();
 
-    verify(filterChain).doFilter(request, response);
+    assertSame(stored, loaded);
     verify(authzService).currentEpoch();
     verify(authzService, never()).effectiveGen(any());
     verify(authzService, never()).getFreshUserDetails(any());
-    verifyNoInteractions(securityContextRepository);
   }
 
   @Test
-  void epochDiffersGenMatchesUpdatesAttrsWithoutRebuild() throws Exception {
+  void epochDiffersGenMatchesUpdatesAttrsWithoutRebuild() {
     MockHttpSession session = new MockHttpSession();
     session.setAttribute(SESSION_AUTHZ_EPOCH_ATTR, 1L);
     session.setAttribute(SESSION_AUTHZ_GEN_ATTR, 5L);
     request.setSession(session);
-
     UserDetails current = userDetails("alice", "F_USER");
-    Authentication original = setUsernamePasswordAuth(current);
+    SecurityContext stored = storeUsernamePasswordContext(session, current);
 
     when(authzService.currentEpoch()).thenReturn(2L);
     when(authzService.effectiveGen(current)).thenReturn(5L);
 
-    filter.doFilter(request, response, filterChain);
+    SecurityContext loaded = repository.loadDeferredContext(request).get();
 
-    verify(filterChain).doFilter(request, response);
+    assertSame(stored, loaded);
     verify(authzService, never()).getFreshUserDetails(any());
-    verifyNoInteractions(securityContextRepository);
-    assertSame(original, SecurityContextHolder.getContext().getAuthentication());
     assertEquals(5L, session.getAttribute(SESSION_AUTHZ_GEN_ATTR));
     assertEquals(2L, session.getAttribute(SESSION_AUTHZ_EPOCH_ATTR));
   }
 
   @Test
-  void epochAndGenDifferRebuildsPrincipalAndSavesContext() throws Exception {
+  void epochAndGenDifferRebuildAndPersistRefreshedContext() {
     MockHttpSession session = new MockHttpSession();
     session.setAttribute(SESSION_AUTHZ_EPOCH_ATTR, 1L);
     session.setAttribute(SESSION_AUTHZ_GEN_ATTR, 3L);
     request.setSession(session);
-
     UserDetails stale = userDetails("alice", "F_OLD");
-    setUsernamePasswordAuth(stale);
+    SecurityContext stored = storeUsernamePasswordContext(session, stale);
     UserDetails fresh = userDetails("alice", "F_NEW");
 
     when(authzService.currentEpoch()).thenReturn(9L);
     when(authzService.effectiveGen(stale)).thenReturn(8L);
     when(authzService.getFreshUserDetails("alice")).thenReturn(fresh);
 
-    filter.doFilter(request, response, filterChain);
+    SecurityContext loaded = repository.loadDeferredContext(request).get();
 
-    verify(filterChain).doFilter(request, response);
-    Authentication after = SecurityContextHolder.getContext().getAuthentication();
+    assertNotSame(stored, loaded);
+    Authentication after = loaded.getAuthentication();
     assertInstanceOf(UsernamePasswordAuthenticationToken.class, after);
     assertSame(fresh, after.getPrincipal());
     assertTrue(after.getAuthorities().stream().anyMatch(a -> "F_NEW".equals(a.getAuthority())));
-    verify(securityContextRepository)
-        .saveContext(eq(SecurityContextHolder.getContext()), eq(request), eq(response));
+    // The refresh persists itself: subsequent requests must load the refreshed context.
+    assertSame(loaded, session.getAttribute(SPRING_SECURITY_CONTEXT_KEY));
     assertEquals(8L, session.getAttribute(SESSION_AUTHZ_GEN_ATTR));
     assertEquals(9L, session.getAttribute(SESSION_AUTHZ_EPOCH_ATTR));
   }
 
   @Test
-  void oidcTokenRebuildsDhisOidcUserPrincipal() throws Exception {
+  void oidcTokenRebuildsDhisOidcUserPrincipal() {
     MockHttpSession session = new MockHttpSession();
     session.setAttribute(SESSION_AUTHZ_EPOCH_ATTR, 0L);
     session.setAttribute(SESSION_AUTHZ_GEN_ATTR, 0L);
     request.setSession(session);
-
     UserDetails stale = userDetails("oidc-user", "F_OLD");
     UserDetails fresh = userDetails("oidc-user", "F_NEW");
     Map<String, Object> attributes = Map.of("sub", "subject-1", "email", "u@example.com");
@@ -240,16 +233,15 @@ class UserDetailsSoftRefreshFilterTest {
     DhisOidcUser oidcUser = new DhisOidcUser(stale, attributes, "sub", idToken);
     OAuth2AuthenticationToken oauth2 =
         new OAuth2AuthenticationToken(oidcUser, stale.getAuthorities(), "google");
-    SecurityContextHolder.getContext().setAuthentication(oauth2);
+    storeContext(session, oauth2);
 
     when(authzService.currentEpoch()).thenReturn(4L);
     when(authzService.effectiveGen(stale)).thenReturn(2L);
     when(authzService.getFreshUserDetails("oidc-user")).thenReturn(fresh);
 
-    filter.doFilter(request, response, filterChain);
+    SecurityContext loaded = repository.loadDeferredContext(request).get();
 
-    verify(filterChain).doFilter(request, response);
-    Authentication after = SecurityContextHolder.getContext().getAuthentication();
+    Authentication after = loaded.getAuthentication();
     assertInstanceOf(OAuth2AuthenticationToken.class, after);
     OAuth2AuthenticationToken replaced = (OAuth2AuthenticationToken) after;
     assertEquals("google", replaced.getAuthorizedClientRegistrationId());
@@ -257,17 +249,46 @@ class UserDetailsSoftRefreshFilterTest {
     DhisOidcUser newPrincipal = (DhisOidcUser) replaced.getPrincipal();
     assertSame(fresh, newPrincipal.getUser());
     assertNotSame(oidcUser, newPrincipal);
-    verify(securityContextRepository).saveContext(any(), eq(request), eq(response));
+    assertSame(loaded, session.getAttribute(SPRING_SECURITY_CONTEXT_KEY));
     assertEquals(2L, session.getAttribute(SESSION_AUTHZ_GEN_ATTR));
     assertEquals(4L, session.getAttribute(SESSION_AUTHZ_EPOCH_ATTR));
   }
 
-  private static Authentication setUsernamePasswordAuth(UserDetails principal) {
-    UsernamePasswordAuthenticationToken auth =
+  @Test
+  void repeatedAccessIsCachedAndChecksOnce() {
+    MockHttpSession session = new MockHttpSession();
+    session.setAttribute(SESSION_AUTHZ_EPOCH_ATTR, 1L);
+    request.setSession(session);
+    UserDetails stale = userDetails("alice", "F_OLD");
+    storeUsernamePasswordContext(session, stale);
+    UserDetails fresh = userDetails("alice", "F_NEW");
+
+    when(authzService.currentEpoch()).thenReturn(2L);
+    when(authzService.effectiveGen(stale)).thenReturn(1L);
+    when(authzService.getFreshUserDetails("alice")).thenReturn(fresh);
+
+    DeferredSecurityContext deferred = repository.loadDeferredContext(request);
+    SecurityContext first = deferred.get();
+    SecurityContext second = deferred.get();
+
+    assertSame(first, second);
+    verify(authzService, times(1)).currentEpoch();
+    verify(authzService, times(1)).getFreshUserDetails("alice");
+  }
+
+  private static SecurityContext storeUsernamePasswordContext(
+      MockHttpSession session, UserDetails principal) {
+    return storeContext(
+        session,
         UsernamePasswordAuthenticationToken.authenticated(
-            principal, "n/a", principal.getAuthorities());
-    SecurityContextHolder.getContext().setAuthentication(auth);
-    return auth;
+            principal, "n/a", principal.getAuthorities()));
+  }
+
+  private static SecurityContext storeContext(MockHttpSession session, Authentication auth) {
+    SecurityContext context = SecurityContextHolder.createEmptyContext();
+    context.setAuthentication(auth);
+    session.setAttribute(SPRING_SECURITY_CONTEXT_KEY, context);
+    return context;
   }
 
   private static UserDetails userDetails(String username, String authority) {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/security/authz/UserDetailsSoftRefreshFilterTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/security/authz/UserDetailsSoftRefreshFilterTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.authz;
+
+import static org.hisp.dhis.user.authz.AuthzConstants.SESSION_AUTHZ_EPOCH_ATTR;
+import static org.hisp.dhis.user.authz.AuthzConstants.SESSION_AUTHZ_GEN_ATTR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.hisp.dhis.security.apikey.ApiToken;
+import org.hisp.dhis.security.apikey.ApiTokenAuthenticationToken;
+import org.hisp.dhis.security.oidc.DhisOidcUser;
+import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.authz.AuthzService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority;
+import org.springframework.security.web.context.SecurityContextRepository;
+
+/**
+ * Unit tests for {@link UserDetailsSoftRefreshFilter}.
+ *
+ * @author Morten Svanæs
+ */
+@ExtendWith(MockitoExtension.class)
+class UserDetailsSoftRefreshFilterTest {
+
+  @Mock private AuthzService authzService;
+  @Mock private SecurityContextRepository securityContextRepository;
+  @Mock private FilterChain filterChain;
+
+  private UserDetailsSoftRefreshFilter filter;
+  private MockHttpServletRequest request;
+  private MockHttpServletResponse response;
+
+  @BeforeEach
+  void setUp() {
+    filter = new UserDetailsSoftRefreshFilter(authzService, securityContextRepository);
+    request = new MockHttpServletRequest("GET", "/api/me");
+    response = new MockHttpServletResponse();
+    SecurityContextHolder.clearContext();
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void noSessionPerformsZeroAuthzServiceCalls() throws Exception {
+    // no session created
+    filter.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    verifyNoInteractions(authzService);
+    verifyNoInteractions(securityContextRepository);
+  }
+
+  @Test
+  void patTokenWithSessionIsSkipped() throws Exception {
+    MockHttpSession session = new MockHttpSession();
+    request.setSession(session);
+
+    UserDetails principal = userDetails("pat-user", "F_PAT");
+    ApiTokenAuthenticationToken pat = new ApiTokenAuthenticationToken(new ApiToken(), principal);
+    pat.setAuthenticated(true);
+    SecurityContextHolder.getContext().setAuthentication(pat);
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    verifyNoInteractions(authzService);
+    assertSame(pat, SecurityContextHolder.getContext().getAuthentication());
+    verifyNoInteractions(securityContextRepository);
+  }
+
+  @Test
+  void switchUserAuthorityIsSkipped() throws Exception {
+    MockHttpSession session = new MockHttpSession();
+    request.setSession(session);
+
+    Authentication original =
+        UsernamePasswordAuthenticationToken.authenticated(
+            userDetails("admin", "ALL"), "n/a", List.of(new SimpleGrantedAuthority("ALL")));
+    UserDetails impersonated = userDetails("alice", "F_USER");
+    SwitchUserGrantedAuthority switchAuth =
+        new SwitchUserGrantedAuthority("F_PREVIOUS_IMPERSONATOR_AUTHORITY", original);
+    UsernamePasswordAuthenticationToken auth =
+        UsernamePasswordAuthenticationToken.authenticated(
+            impersonated, "n/a", List.of(switchAuth, new SimpleGrantedAuthority("F_USER")));
+    SecurityContextHolder.getContext().setAuthentication(auth);
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    verifyNoInteractions(authzService);
+    assertSame(auth, SecurityContextHolder.getContext().getAuthentication());
+  }
+
+  @Test
+  void matchingEpochNeverCallsEffectiveGen() throws Exception {
+    MockHttpSession session = new MockHttpSession();
+    session.setAttribute(SESSION_AUTHZ_EPOCH_ATTR, 7L);
+    request.setSession(session);
+
+    setUsernamePasswordAuth(userDetails("alice", "F_USER"));
+
+    when(authzService.currentEpoch()).thenReturn(7L);
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    verify(authzService).currentEpoch();
+    verify(authzService, never()).effectiveGen(any());
+    verify(authzService, never()).getFreshUserDetails(any());
+    verifyNoInteractions(securityContextRepository);
+  }
+
+  @Test
+  void epochDiffersGenMatchesUpdatesAttrsWithoutRebuild() throws Exception {
+    MockHttpSession session = new MockHttpSession();
+    session.setAttribute(SESSION_AUTHZ_EPOCH_ATTR, 1L);
+    session.setAttribute(SESSION_AUTHZ_GEN_ATTR, 5L);
+    request.setSession(session);
+
+    UserDetails current = userDetails("alice", "F_USER");
+    Authentication original = setUsernamePasswordAuth(current);
+
+    when(authzService.currentEpoch()).thenReturn(2L);
+    when(authzService.effectiveGen(current)).thenReturn(5L);
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    verify(authzService, never()).getFreshUserDetails(any());
+    verifyNoInteractions(securityContextRepository);
+    assertSame(original, SecurityContextHolder.getContext().getAuthentication());
+    assertEquals(5L, session.getAttribute(SESSION_AUTHZ_GEN_ATTR));
+    assertEquals(2L, session.getAttribute(SESSION_AUTHZ_EPOCH_ATTR));
+  }
+
+  @Test
+  void epochAndGenDifferRebuildsPrincipalAndSavesContext() throws Exception {
+    MockHttpSession session = new MockHttpSession();
+    session.setAttribute(SESSION_AUTHZ_EPOCH_ATTR, 1L);
+    session.setAttribute(SESSION_AUTHZ_GEN_ATTR, 3L);
+    request.setSession(session);
+
+    UserDetails stale = userDetails("alice", "F_OLD");
+    setUsernamePasswordAuth(stale);
+    UserDetails fresh = userDetails("alice", "F_NEW");
+
+    when(authzService.currentEpoch()).thenReturn(9L);
+    when(authzService.effectiveGen(stale)).thenReturn(8L);
+    when(authzService.getFreshUserDetails("alice")).thenReturn(fresh);
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    Authentication after = SecurityContextHolder.getContext().getAuthentication();
+    assertInstanceOf(UsernamePasswordAuthenticationToken.class, after);
+    assertSame(fresh, after.getPrincipal());
+    assertTrue(after.getAuthorities().stream().anyMatch(a -> "F_NEW".equals(a.getAuthority())));
+    verify(securityContextRepository)
+        .saveContext(eq(SecurityContextHolder.getContext()), eq(request), eq(response));
+    assertEquals(8L, session.getAttribute(SESSION_AUTHZ_GEN_ATTR));
+    assertEquals(9L, session.getAttribute(SESSION_AUTHZ_EPOCH_ATTR));
+  }
+
+  @Test
+  void oidcTokenRebuildsDhisOidcUserPrincipal() throws Exception {
+    MockHttpSession session = new MockHttpSession();
+    session.setAttribute(SESSION_AUTHZ_EPOCH_ATTR, 0L);
+    session.setAttribute(SESSION_AUTHZ_GEN_ATTR, 0L);
+    request.setSession(session);
+
+    UserDetails stale = userDetails("oidc-user", "F_OLD");
+    UserDetails fresh = userDetails("oidc-user", "F_NEW");
+    Map<String, Object> attributes = Map.of("sub", "subject-1", "email", "u@example.com");
+    OidcIdToken idToken =
+        new OidcIdToken(
+            "token-value",
+            Instant.now().minusSeconds(60),
+            Instant.now().plusSeconds(3600),
+            attributes);
+    DhisOidcUser oidcUser = new DhisOidcUser(stale, attributes, "sub", idToken);
+    OAuth2AuthenticationToken oauth2 =
+        new OAuth2AuthenticationToken(oidcUser, stale.getAuthorities(), "google");
+    SecurityContextHolder.getContext().setAuthentication(oauth2);
+
+    when(authzService.currentEpoch()).thenReturn(4L);
+    when(authzService.effectiveGen(stale)).thenReturn(2L);
+    when(authzService.getFreshUserDetails("oidc-user")).thenReturn(fresh);
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    Authentication after = SecurityContextHolder.getContext().getAuthentication();
+    assertInstanceOf(OAuth2AuthenticationToken.class, after);
+    OAuth2AuthenticationToken replaced = (OAuth2AuthenticationToken) after;
+    assertEquals("google", replaced.getAuthorizedClientRegistrationId());
+    assertInstanceOf(DhisOidcUser.class, replaced.getPrincipal());
+    DhisOidcUser newPrincipal = (DhisOidcUser) replaced.getPrincipal();
+    assertSame(fresh, newPrincipal.getUser());
+    assertNotSame(oidcUser, newPrincipal);
+    verify(securityContextRepository).saveContext(any(), eq(request), eq(response));
+    assertEquals(2L, session.getAttribute(SESSION_AUTHZ_GEN_ATTR));
+    assertEquals(4L, session.getAttribute(SESSION_AUTHZ_EPOCH_ATTR));
+  }
+
+  private static Authentication setUsernamePasswordAuth(UserDetails principal) {
+    UsernamePasswordAuthenticationToken auth =
+        UsernamePasswordAuthenticationToken.authenticated(
+            principal, "n/a", principal.getAuthorities());
+    SecurityContextHolder.getContext().setAuthentication(auth);
+    return auth;
+  }
+
+  private static UserDetails userDetails(String username, String authority) {
+    return UserDetails.empty()
+        .uid("uid-" + username)
+        .username(username)
+        .authorities(List.of(new SimpleGrantedAuthority(authority)))
+        .allAuthorities(Set.of(authority))
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary
Stacked on #24493 (base is that PR's branch, so this diff shows only the restructure — same behavior, one commit).

- Replace `UserDetailsSoftRefreshFilter` with `SoftRefreshSecurityContextRepository`, decorating the `HttpSession` delegate of the standard `DelegatingSecurityContextRepository` pair.
- Session-only refresh becomes structural instead of gate-guarded: JWT/PAT/stateless authentications never load through `HttpSessionSecurityContextRepository`, so token-type conversion or accidental session creation is impossible by construction, and the filter-ordering concern disappears.
- `DeferredSecurityContext` wrapping runs the freshness check only when a request actually accesses its authentication; under `requireExplicitSave` the refresh persists itself via the session attribute (`SecurityContextHolderFilter` never saves — verified against Spring Security 6.5.10 sources).
- Decision flow, eligibility gates (impersonation skip), and OIDC principal rebuild are moved verbatim from the filter; tests ported to load-through-repository semantics plus new laziness and caching cases.

## Test plan
- [x] Unit: `SoftRefreshSecurityContextRepositoryTest` (9: PAT/impersonation skip, epoch fast path, gen refresh + self-persistence, OIDC rebuild, deferred laziness, get() caching)
- [x] H2 web-api: `UserControllerTest` 52/52, `AuthzSoftRefreshH2CompatTest` 3/3, `MeControllerTest` 28/28
- [x] Live server (fresh DB): grant and revoke visible on the next request of the same session, JSESSIONID unchanged, disable still hard-kicks

AI Assisted