### PR TITLE
test: authorization-outcome matrix across auth mechanisms and impersonation e2e

### DIFF
--- a/dhis-2/dhis-test-e2e/config/dhis2_home/dhis.conf
+++ b/dhis-2/dhis-test-e2e/config/dhis2_home/dhis.conf
@@ -24,6 +24,12 @@ analytics.table.unlogged = on
 login.security.totp_2fa.enabled = on
 login.security.email_2fa.enabled = on
 
+# User impersonation (ImpersonationTest). The IP allowlist is an exact string
+# match: 172.30.0.10 = test container (fixed via compose ipam), 172.30.0.1 =
+# network gateway (host-run tests against the containerized server).
+switch_user_feature.enabled = on
+switch_user_allow_listed_ips = localhost,127.0.0.1,[0:0:0:0:0:0:0:1],0:0:0:0:0:0:0:1,172.30.0.10,172.30.0.1
+
 oauth2.server.enabled = on
 server.base.url = http://web:8080/
 oidc.jwt.token.authentication.enabled = on

--- a/dhis-2/dhis-test-e2e/docker-compose.e2e.yml
+++ b/dhis-2/dhis-test-e2e/docker-compose.e2e.yml
@@ -11,6 +11,10 @@ services:
       - surefire-reports:/target/surefire-reports
     depends_on:
       - web
+    networks:
+      # Deterministic IP: switch_user_allow_listed_ips in dhis.conf is an exact match
+      default:
+        ipv4_address: 172.30.0.10
 
   reports-processor:
     profiles: ["reports"]

--- a/dhis-2/dhis-test-e2e/docker-compose.yml
+++ b/dhis-2/dhis-test-e2e/docker-compose.yml
@@ -63,3 +63,11 @@ services:
     ports:
       - "4444"
       - "7900"
+
+# Fixed subnet so the test container can have a deterministic IP: the impersonation
+# feature's IP allowlist (switch_user_allow_listed_ips) is an exact string match.
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/security/AuthMechanism.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/security/AuthMechanism.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import org.hisp.dhis.BaseE2ETest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * The API authentication mechanisms exercised by the authorization matrix tests. Each constant
+ * turns (username, password) into {@link HttpHeaders} that authenticate subsequent requests via
+ * that mechanism, so authorization outcomes can be asserted identically across mechanisms.
+ *
+ * <p>Not covered here: OAuth2/JWT bearer (needs the authorization-code dance, covered in {@code
+ * OAuth2Test} and the auth-idp Keycloak suite) and OIDC/LDAP sessions (auth-idp suite).
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public enum AuthMechanism {
+  /** Form login via /api/auth/login, then the session cookie. */
+  SESSION_COOKIE,
+  /** Preemptive HTTP Basic. */
+  BASIC,
+  /** Personal access token: created via /api/apiTokens, sent as "Authorization: ApiToken ...". */
+  PAT;
+
+  /** Returns headers that authenticate the given user via this mechanism. */
+  public HttpHeaders authenticate(String username, String password) {
+    HttpHeaders headers = BaseE2ETest.jsonHeaders();
+    switch (this) {
+      case SESSION_COOKIE ->
+          headers.set("Cookie", BaseE2ETest.performInitialLogin(username, password));
+      case BASIC -> headers.set(HttpHeaders.AUTHORIZATION, basicAuthHeader(username, password));
+      case PAT ->
+          headers.set(HttpHeaders.AUTHORIZATION, "ApiToken " + createPat(username, password));
+    }
+    return headers;
+  }
+
+  private static String basicAuthHeader(String username, String password) {
+    return "Basic "
+        + Base64.getEncoder()
+            .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+  }
+
+  /** The plaintext PAT key is only returned on creation. */
+  private static String createPat(String username, String password) {
+    String cookie = BaseE2ETest.performInitialLogin(username, password);
+    ResponseEntity<String> response = BaseE2ETest.postWithCookie("/apiTokens", Map.of(), cookie);
+    if (response.getStatusCode() != HttpStatus.CREATED) {
+      throw new IllegalStateException("PAT creation failed: " + response.getBody());
+    }
+    try {
+      JsonNode json = BaseE2ETest.objectMapper.readTree(response.getBody());
+      JsonNode key = json.get("response").get("key");
+      assertNotNull(key, "no PAT key in response: " + response.getBody());
+      return key.asText();
+    } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/security/AuthorizationMatrixTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/security/AuthorizationMatrixTest.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.BaseE2ETest;
+import org.hisp.dhis.login.CodeGenerator;
+import org.hisp.dhis.login.LoginTest;
+import org.hisp.dhis.test.e2e.helpers.config.TestConfiguration;
+import org.jboss.aerogear.security.otp.Totp;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+
+/**
+ * Authorization-outcome matrix over the non-interactive API authentication mechanisms ({@link
+ * AuthMechanism}: session cookie, basic, PAT). Every outcome must be IDENTICAL regardless of how
+ * the request authenticated; a divergence means an authentication filter is leaking into
+ * authorization decisions.
+ *
+ * <p>Pinned contracts: the exact {@code @RequiresAuthority} 403 message, the implicit ALL bypass,
+ * metadata sharing (private objects are invisible to others), org-unit capture scoping on data
+ * value writes, and basic-auth rejection for TOTP-2FA-enabled users.
+ *
+ * <p>Bearer-token variants of the 403 contract live in {@code OAuth2Test} and the auth-idp
+ * Keycloak/LDAP suites, which own the required token infrastructure.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@Slf4j
+class AuthorizationMatrixTest extends BaseE2ETest {
+
+  private static final String PW = "Test123###...";
+  private static final String MAINTENANCE_PATH = "/maintenance/categoryOptionComboUpdate";
+  private static final String DENIED_MESSAGE =
+      "Access is denied, requires one Authority from [F_PERFORM_MAINTENANCE]";
+
+  private static String orgUnitB;
+  private static String privateDataElement;
+  private static String publicDataElement;
+  private static String dataSet;
+
+  @BeforeAll
+  static void setup() throws JsonProcessingException {
+    serverApiUrl = TestConfiguration.get().baseUrl();
+    serverHostUrl = serverApiUrl.replace("/api", "");
+    orgUnitUID = createOrgUnit(); // capture org unit "A"
+    orgUnitB = createOrgUnit(); // outside the capture user's hierarchy
+
+    String emptyRole = createRole("matrixEmptyRole");
+    String maintRole = createRole("matrixMaintRole", "F_PERFORM_MAINTENANCE");
+    String ownerRole = createRole("matrixOwnerRole", "F_DATAELEMENT_PRIVATE_ADD");
+    String captureRole = createRole("matrixCaptureRole", "F_DATAVALUE_ADD");
+
+    createUser("matrixnoauth", emptyRole, orgUnitUID);
+    createUser("matrixmaint", maintRole, orgUnitUID);
+    createSuperuser("matrixsuper", PW, orgUnitUID);
+    createUser("matrixowner", ownerRole, orgUnitUID);
+    createUser("matrixother", emptyRole, orgUnitUID);
+    createUser("matrixcapture", captureRole, orgUnitUID);
+
+    privateDataElement = createPrivateDataElementAsOwner();
+    setupAggregateData();
+  }
+
+  // ---------------------------------------------------------------------------
+  // @RequiresAuthority outcomes, identical across mechanisms
+  // ---------------------------------------------------------------------------
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(AuthMechanism.class)
+  void requiresAuthorityDeniedWithExactMessage(AuthMechanism mechanism)
+      throws JsonProcessingException {
+    HttpHeaders headers = mechanism.authenticate("matrixnoauth", PW);
+
+    ResponseEntity<String> response = exchange(HttpMethod.POST, MAINTENANCE_PATH, headers);
+
+    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode(), "body: " + response.getBody());
+    JsonNode json = objectMapper.readTree(response.getBody());
+    assertEquals(DENIED_MESSAGE, json.get("message").asText());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(AuthMechanism.class)
+  void requiresAuthorityGranted(AuthMechanism mechanism) {
+    HttpHeaders headers = mechanism.authenticate("matrixmaint", PW);
+
+    ResponseEntity<String> response = exchange(HttpMethod.POST, MAINTENANCE_PATH, headers);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode(), "body: " + response.getBody());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(AuthMechanism.class)
+  void requiresAuthoritySuperuserAllBypass(AuthMechanism mechanism) {
+    HttpHeaders headers = mechanism.authenticate("matrixsuper", PW);
+
+    ResponseEntity<String> response = exchange(HttpMethod.POST, MAINTENANCE_PATH, headers);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode(), "body: " + response.getBody());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sharing ACL, identical across mechanisms
+  // ---------------------------------------------------------------------------
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(AuthMechanism.class)
+  void sharingHidesPrivateMetadataFromOthers(AuthMechanism mechanism) {
+    String path = "/dataElements/" + privateDataElement;
+
+    // PIN: no metadata read access presents as 404, not 403
+    ResponseEntity<String> other =
+        exchange(HttpMethod.GET, path, mechanism.authenticate("matrixother", PW));
+    assertEquals(HttpStatus.NOT_FOUND, other.getStatusCode(), "body: " + other.getBody());
+
+    // write attempt by a non-reader is equally invisible
+    ResponseEntity<String> otherDelete =
+        exchange(HttpMethod.DELETE, path, mechanism.authenticate("matrixother", PW));
+    assertEquals(HttpStatus.NOT_FOUND, otherDelete.getStatusCode());
+
+    ResponseEntity<String> owner =
+        exchange(HttpMethod.GET, path, mechanism.authenticate("matrixowner", PW));
+    assertEquals(HttpStatus.OK, owner.getStatusCode(), "body: " + owner.getBody());
+
+    ResponseEntity<String> superuser =
+        exchange(HttpMethod.GET, path, mechanism.authenticate("matrixsuper", PW));
+    assertEquals(HttpStatus.OK, superuser.getStatusCode());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Org-unit capture scope (mechanism-independent service layer; exercised via basic)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void orgUnitCaptureScopeEnforcedOnDataValueWrite() throws JsonProcessingException {
+    HttpHeaders headers = AuthMechanism.BASIC.authenticate("matrixcapture", PW);
+
+    // outside the user's capture hierarchy -> rejected
+    ResponseEntity<String> outside = postDataValue(headers, orgUnitB);
+    assertNotNull(outside.getBody());
+    // PIN: capture-scope rejection is conflict E8011
+    assertTrue(
+        outside.getBody().contains("Current user cannot enter data for org unit"),
+        "expected E8011 capture-scope conflict, got: " + outside.getBody());
+    assertTrue(outside.getBody().contains("\"errorCode\":\"E8011\""), "body: " + outside.getBody());
+    assertFalse(isImported(outside.getBody()), "value outside hierarchy must not be imported");
+
+    // inside the capture hierarchy -> imported
+    ResponseEntity<String> inside = postDataValue(headers, orgUnitUID);
+    assertTrue(isImported(inside.getBody()), "expected import success, got: " + inside.getBody());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Basic auth vs TOTP 2FA
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void basicAuthRejectedForTotpEnabledUser() throws JsonProcessingException {
+    String username = CodeGenerator.generateCode(8).toLowerCase();
+    createSuperuser(username, PW, orgUnitUID);
+
+    String cookie = performInitialLogin(username, PW);
+    String secret = LoginTest.enrollTOTP2FA(cookie);
+    // completing a 2FA login activates TOTP for the account
+    loginWith2FA(username, PW, new Totp(secret).now());
+
+    ResponseEntity<String> response =
+        exchange(HttpMethod.GET, "/me", AuthMechanism.BASIC.authenticate(username, PW));
+
+    // PIN: basic auth carries no 2FA code and must be rejected once TOTP is enabled
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode(), "body: " + response.getBody());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static ResponseEntity<String> exchange(
+      HttpMethod method, String path, HttpHeaders headers) {
+    try {
+      return restTemplate.exchange(
+          serverApiUrl + path, method, new HttpEntity<>("", headers), String.class);
+    } catch (HttpClientErrorException e) {
+      return ResponseEntity.status(e.getStatusCode()).body(e.getResponseBodyAsString());
+    }
+  }
+
+  private static ResponseEntity<String> postDataValue(HttpHeaders headers, String orgUnit) {
+    Map<String, Object> payload =
+        Map.of(
+            "dataSet",
+            dataSet,
+            // previous month: the current period has not ended yet and would need
+            // openFuturePeriods > 0 (E8030), while expiryDays=0 keeps past periods open
+            "period",
+            YearMonth.now().minusMonths(1).format(DateTimeFormatter.ofPattern("yyyyMM")),
+            "orgUnit",
+            orgUnit,
+            "dataValues",
+            List.of(Map.of("dataElement", publicDataElement, "value", "1")));
+    try {
+      return restTemplate.exchange(
+          serverApiUrl + "/dataValueSets",
+          HttpMethod.POST,
+          new HttpEntity<>(payload, headers),
+          String.class);
+    } catch (HttpClientErrorException e) {
+      return ResponseEntity.status(e.getStatusCode()).body(e.getResponseBodyAsString());
+    }
+  }
+
+  /** dataValueSets counts a first-time write as "updated", so check both counters. */
+  private static boolean isImported(String importResponseBody) throws JsonProcessingException {
+    JsonNode json = objectMapper.readTree(importResponseBody);
+    JsonNode summary = json.has("response") ? json.get("response") : json;
+    JsonNode importCount = summary.get("importCount");
+    return importCount != null
+        && importCount.get("imported").asInt() + importCount.get("updated").asInt() > 0;
+  }
+
+  private static String createRole(String name, String... authorities)
+      throws JsonProcessingException {
+    ResponseEntity<String> response =
+        postWithAdminBasicAuth(
+            "/userRoles", Map.of("name", name, "authorities", List.of(authorities)));
+    assertEquals(
+        HttpStatus.CREATED,
+        response.getStatusCode(),
+        "role creation failed: " + response.getBody());
+    return objectMapper.readTree(response.getBody()).get("response").get("uid").asText();
+  }
+
+  private static void createUser(String username, String roleId, String orgUnit)
+      throws JsonProcessingException {
+    Map<String, Object> userMap =
+        Map.of(
+            "username",
+            username,
+            "password",
+            PW,
+            "email",
+            username + "@dhis2.org",
+            "firstName",
+            "Matrix",
+            "surname",
+            "User",
+            "userRoles",
+            List.of(Map.of("id", roleId)),
+            "organisationUnits",
+            List.of(Map.of("id", orgUnit)));
+    ResponseEntity<String> response = postWithAdminBasicAuth("/users", userMap);
+    assertEquals(
+        HttpStatus.CREATED,
+        response.getStatusCode(),
+        "user creation failed: " + response.getBody());
+  }
+
+  /** Created by matrixowner with public access "--------": visible to the owner and supers only. */
+  private static String createPrivateDataElementAsOwner() throws JsonProcessingException {
+    String cookie = performInitialLogin("matrixowner", PW);
+    Map<String, Object> payload =
+        Map.of(
+            "name", "MatrixPrivateDE",
+            "shortName", "MatrixPrivateDE",
+            "valueType", "INTEGER",
+            "aggregationType", "SUM",
+            "domainType", "AGGREGATE",
+            "sharing", Map.of("public", "--------"));
+    ResponseEntity<String> response = postWithCookie("/dataElements", payload, cookie);
+    assertEquals(
+        HttpStatus.CREATED, response.getStatusCode(), "DE creation failed: " + response.getBody());
+    return objectMapper.readTree(response.getBody()).get("response").get("uid").asText();
+  }
+
+  /** Public data element + data set (data-writable by all) assigned to org units A and B. */
+  private static void setupAggregateData() throws JsonProcessingException {
+    Map<String, Object> dePayload =
+        Map.of(
+            "name", "MatrixPublicDE",
+            "shortName", "MatrixPublicDE",
+            "valueType", "INTEGER",
+            "aggregationType", "SUM",
+            "domainType", "AGGREGATE",
+            "sharing", Map.of("public", "rwrw----"));
+    ResponseEntity<String> deResponse = postWithAdminBasicAuth("/dataElements", dePayload);
+    assertEquals(HttpStatus.CREATED, deResponse.getStatusCode(), "body: " + deResponse.getBody());
+    publicDataElement =
+        objectMapper.readTree(deResponse.getBody()).get("response").get("uid").asText();
+
+    Map<String, Object> dsPayload =
+        Map.of(
+            "name",
+            "MatrixDataSet",
+            "shortName",
+            "MatrixDataSet",
+            "periodType",
+            "Monthly",
+            "dataSetElements",
+            List.of(Map.of("dataElement", Map.of("id", publicDataElement))),
+            "organisationUnits",
+            List.of(Map.of("id", orgUnitUID), Map.of("id", orgUnitB)),
+            "sharing",
+            Map.of("public", "rwrw----"));
+    ResponseEntity<String> dsResponse = postWithAdminBasicAuth("/dataSets", dsPayload);
+    assertEquals(HttpStatus.CREATED, dsResponse.getStatusCode(), "body: " + dsResponse.getBody());
+    dataSet = objectMapper.readTree(dsResponse.getBody()).get("response").get("uid").asText();
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/security/ImpersonationTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/security/ImpersonationTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.BaseE2ETest;
+import org.hisp.dhis.login.LoginRequest;
+import org.hisp.dhis.test.e2e.helpers.config.TestConfiguration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * End-to-end impersonation flow over a real session (cookie jar). Requires {@code
+ * switch_user_feature.enabled = on} and the test container's IP in {@code
+ * switch_user_allow_listed_ips} (see config/dhis2_home/dhis.conf + the fixed compose subnet).
+ *
+ * <p>Pinned contracts: the {@code /api/me} {@code impersonation} field carries the impersonator
+ * USERNAME; authority checks while impersonating apply to the TARGET user; exit restores the
+ * impersonator; impersonation state does NOT survive a re-login in the same browser session (see
+ * {@link #reLoginDuringImpersonationInvalidatesExit()}).
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@Slf4j
+class ImpersonationTest extends BaseE2ETest {
+
+  private static final String PW = "Test123###...";
+  private static final String MAINTENANCE_PATH = "/maintenance/categoryOptionComboUpdate";
+
+  @BeforeAll
+  static void setup() throws JsonProcessingException {
+    serverApiUrl = TestConfiguration.get().baseUrl();
+    serverHostUrl = serverApiUrl.replace("/api", "");
+    orgUnitUID = createOrgUnit();
+
+    createSuperuser("impadmin", PW, orgUnitUID);
+    String emptyRole = createRole("impEmptyRole");
+    String impersonatorRole = createRole("impUserRole", "F_IMPERSONATE_USER");
+    createUser("imptarget", emptyRole);
+    createUser("impguest", emptyRole);
+    createUser("impuser", impersonatorRole);
+  }
+
+  @Test
+  void impersonateActExitFullFlow() throws JsonProcessingException {
+    String cookie = performInitialLogin("impadmin", PW);
+
+    // enter impersonation
+    ResponseEntity<String> enter =
+        postWithCookie("/auth/impersonate?username=imptarget", null, cookie);
+    assertEquals(HttpStatus.OK, enter.getStatusCode(), "body: " + enter.getBody());
+    JsonNode enterJson = objectMapper.readTree(enter.getBody());
+    assertEquals("IMPERSONATION_SUCCESS", enterJson.get("status").asText());
+    assertEquals("imptarget", enterJson.get("username").asText());
+
+    // /me shows the target AND the impersonator USERNAME (not display name)
+    JsonNode me = getMe(cookie);
+    assertEquals("imptarget", me.get("username").asText());
+    assertEquals("impadmin", me.get("impersonation").asText());
+    assertNull(me.get("canImpersonate"), "target has no impersonation authority");
+
+    // authority checks apply to the TARGET while impersonating
+    ResponseEntity<String> denied = postWithCookie(MAINTENANCE_PATH, null, cookie);
+    assertEquals(HttpStatus.FORBIDDEN, denied.getStatusCode(), "body: " + denied.getBody());
+
+    // exit restores the impersonator
+    ResponseEntity<String> exit = postWithCookie("/auth/impersonateExit", null, cookie);
+    assertEquals(HttpStatus.OK, exit.getStatusCode(), "body: " + exit.getBody());
+    JsonNode exitJson = objectMapper.readTree(exit.getBody());
+    assertEquals("IMPERSONATION_EXIT_SUCCESS", exitJson.get("status").asText());
+
+    JsonNode meAfter = getMe(cookie);
+    assertEquals("impadmin", meAfter.get("username").asText());
+    assertNull(meAfter.get("impersonation"), "impersonation field must be gone after exit");
+    assertTrue(meAfter.get("canImpersonate").asBoolean(), "feature on + ALL -> canImpersonate");
+  }
+
+  @Test
+  void impersonateWithoutAuthorityDeniedWithMessageContract() throws JsonProcessingException {
+    String cookie = performInitialLogin("impguest", PW);
+
+    ResponseEntity<String> response =
+        postWithCookie("/auth/impersonate?username=imptarget", null, cookie);
+
+    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode(), "body: " + response.getBody());
+    JsonNode json = objectMapper.readTree(response.getBody());
+    assertEquals(
+        "Access is denied, requires one Authority from [F_IMPERSONATE_USER]",
+        json.get("message").asText());
+  }
+
+  @Test
+  void nonSuperuserCannotImpersonateSuperuser() throws JsonProcessingException {
+    String cookie = performInitialLogin("impuser", PW);
+
+    ResponseEntity<String> response =
+        postWithCookie("/auth/impersonate?username=impadmin", null, cookie);
+
+    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    assertMessage(response, "Forbidden, reason: User is not authorized to impersonate super user");
+  }
+
+  @Test
+  void impersonateSelfIsRejected() throws JsonProcessingException {
+    String cookie = performInitialLogin("impadmin", PW);
+
+    ResponseEntity<String> response =
+        postWithCookie("/auth/impersonate?username=impadmin", null, cookie);
+
+    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    assertMessage(response, "Forbidden, reason: User can not impersonate itself");
+  }
+
+  @Test
+  void exitWithoutImpersonatingIsBadRequest() throws JsonProcessingException {
+    String cookie = performInitialLogin("impadmin", PW);
+
+    ResponseEntity<String> response = postWithCookie("/auth/impersonateExit", null, cookie);
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertMessage(response, "User not impersonating anyone, user: impadmin");
+  }
+
+  /**
+   * PIN: impersonation state lives in the SecurityContext and is atomically replaced when someone
+   * re-authenticates in the same browser session; the new principal cannot "exit" into the old
+   * impersonator. A redesign that stores the impersonator elsewhere (e.g. a session attribute) MUST
+   * NOT change this outcome.
+   */
+  @Test
+  void reLoginDuringImpersonationInvalidatesExit() throws JsonProcessingException {
+    String cookie = performInitialLogin("impadmin", PW);
+
+    ResponseEntity<String> enter =
+        postWithCookie("/auth/impersonate?username=imptarget", null, cookie);
+    assertEquals(HttpStatus.OK, enter.getStatusCode());
+
+    // re-authenticate as an unprivileged user within the same session/cookie jar
+    ResponseEntity<String> reLogin =
+        postWithCookie(
+            "/auth/login",
+            LoginRequest.builder().username("impguest").password(PW).build(),
+            cookie);
+    assertEquals(HttpStatus.OK, reLogin.getStatusCode(), "body: " + reLogin.getBody());
+    // re-login sets several cookies (SESSION_EXPIRE, JSESSIONID); pick the session one
+    List<String> setCookies = reLogin.getHeaders().get(HttpHeaders.SET_COOKIE);
+    String newCookie =
+        setCookies == null
+            ? null
+            : setCookies.stream().filter(c -> c.startsWith("JSESSIONID")).findFirst().orElse(null);
+    String effectiveCookie = newCookie != null ? newCookie : cookie;
+
+    JsonNode me = getMe(effectiveCookie);
+    assertEquals("impguest", me.get("username").asText());
+
+    // the fresh principal has no impersonation state or authority -> exit is denied
+    ResponseEntity<String> exit = postWithCookie("/auth/impersonateExit", null, effectiveCookie);
+    assertEquals(HttpStatus.FORBIDDEN, exit.getStatusCode(), "body: " + exit.getBody());
+    JsonNode exitJson = objectMapper.readTree(exit.getBody());
+    assertEquals(
+        "Access is denied, requires one Authority from [F_IMPERSONATE_USER,"
+            + " F_PREVIOUS_IMPERSONATOR_AUTHORITY]",
+        exitJson.get("message").asText());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static JsonNode getMe(String cookie) throws JsonProcessingException {
+    ResponseEntity<String> me =
+        getWithCookie("/me?fields=username,impersonation,canImpersonate", cookie);
+    assertEquals(HttpStatus.OK, me.getStatusCode(), "body: " + me.getBody());
+    JsonNode json = objectMapper.readTree(me.getBody());
+    assertNotNull(json);
+    return json;
+  }
+
+  private static String createRole(String name, String... authorities)
+      throws JsonProcessingException {
+    ResponseEntity<String> response =
+        postWithAdminBasicAuth(
+            "/userRoles", Map.of("name", name, "authorities", List.of(authorities)));
+    assertEquals(
+        HttpStatus.CREATED,
+        response.getStatusCode(),
+        "role creation failed: " + response.getBody());
+    return objectMapper.readTree(response.getBody()).get("response").get("uid").asText();
+  }
+
+  private static void createUser(String username, String roleId) throws JsonProcessingException {
+    Map<String, Object> userMap =
+        Map.of(
+            "username",
+            username,
+            "password",
+            PW,
+            "email",
+            username + "@dhis2.org",
+            "firstName",
+            "Impersonation",
+            "surname",
+            "User",
+            "userRoles",
+            List.of(Map.of("id", roleId)),
+            "organisationUnits",
+            List.of(Map.of("id", orgUnitUID)));
+    ResponseEntity<String> response = postWithAdminBasicAuth("/users", userMap);
+    assertEquals(
+        HttpStatus.CREATED,
+        response.getStatusCode(),
+        "user creation failed: " + response.getBody());
+  }
+}


### PR DESCRIPTION
## Summary

E2e tests (default profile, every PR) asserting authorization outcomes are IDENTICAL regardless of authentication mechanism, plus full impersonation flow coverage. Part of the auth coverage initiative preceding the UserDetails/interceptor refactoring; companion to #24497.

- **`AuthMechanism`**: turns credentials into authenticated request headers for SESSION_COOKIE, BASIC, PAT.
- **`AuthorizationMatrixTest`** (parameterized over mechanisms): exact `@RequiresAuthority` 403 message contract, authority-granted, implicit ALL bypass, sharing ACL (private metadata 404 to others); plus org-unit capture scope on data value writes (E8011 pin) and basic-auth rejection for TOTP-2FA users.
- **`ImpersonationTest`** (cookie jar): impersonate -> act as target -> `/me` shows impersonator USERNAME -> exit; negative cases with exact message contracts; pin that re-login in the same session invalidates impersonation state.
- Infra: impersonation enabled in the e2e dhis.conf; fixed compose subnet + static test-container IP (the IP allowlist is an exact string match).

## Testing

Verified against the local compose stack: 20/20 green, ~6s added to the default profile.

AI Assisted