### PR TITLE
test: fix flaky AuditIntegrationTest await conditions [DHIS2-21858]

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/audit/AuditIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/audit/AuditIntegrationTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.auth.ApiHeadersAuthScheme;
@@ -142,7 +143,7 @@ class AuditIntegrationTest extends PostgresIntegrationTestBase {
     DataElement dataElement = createDataElement('A');
     dataElementService.addDataElement(dataElement);
     AuditQuery query = AuditQuery.builder().uid(Sets.newHashSet(dataElement.getUid())).build();
-    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 0);
+    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 1);
     List<Audit> audits = auditService.getAudits(query);
     assertEquals(1, audits.size());
     Audit audit = audits.get(0);
@@ -155,7 +156,9 @@ class AuditIntegrationTest extends PostgresIntegrationTestBase {
   @MethodSource("provideAuthSchemes")
   void testSaveRoute(AuthScheme authScheme) {
     Route route = new Route();
-    route.setUid(BASE_UID);
+    // each parameterized run needs its own UID: audits are written asynchronously
+    // outside the test transaction, so audits for a shared UID leak between runs
+    route.setUid(CodeGenerator.generateUid());
     route.setName("foo");
     route.setAuth(authScheme);
     route.setUrl("http://stub");
@@ -167,7 +170,7 @@ class AuditIntegrationTest extends PostgresIntegrationTestBase {
           return null;
         });
     AuditQuery query = AuditQuery.builder().uid(Sets.newHashSet(route.getUid())).build();
-    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 0);
+    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 1);
     List<Audit> audits = auditService.getAudits(query);
     assertEquals(1, audits.size());
     assertFalse(audits.get(0).getData().contains("passw0rd"));
@@ -185,7 +188,7 @@ class AuditIntegrationTest extends PostgresIntegrationTestBase {
     TrackedEntity trackedEntity = createTrackedEntity('A', ou, attribute, trackedEntityType);
     manager.save(trackedEntity);
     AuditQuery query = AuditQuery.builder().uid(Sets.newHashSet(trackedEntity.getUid())).build();
-    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 0);
+    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 1);
     List<Audit> audits = auditService.getAudits(query);
     assertEquals(1, audits.size());
     Audit audit = audits.get(0);
@@ -214,7 +217,7 @@ class AuditIntegrationTest extends PostgresIntegrationTestBase {
     attributes.put("attribute", attribute.getUid());
     attributes.put("trackedEntity", trackedEntity.getUid());
     AuditQuery query = AuditQuery.builder().auditAttributes(attributes).build();
-    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 0);
+    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 1);
     List<Audit> audits = auditService.getAudits(query);
     assertEquals(1, audits.size());
     Audit audit = audits.get(0);
@@ -283,7 +286,7 @@ class AuditIntegrationTest extends PostgresIntegrationTestBase {
     AuditAttributes attributes = new AuditAttributes();
     attributes.put("dataElement", dataElementA.getUid());
     AuditQuery query = AuditQuery.builder().auditAttributes(attributes).build();
-    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 0);
+    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 1);
     List<Audit> audits = auditService.getAudits(query);
     assertEquals(1, audits.size());
     Audit audit = audits.get(0);
@@ -308,7 +311,7 @@ class AuditIntegrationTest extends PostgresIntegrationTestBase {
     programStage.addDataElement(dataElement, 0);
     manager.save(programStage);
     AuditQuery query = AuditQuery.builder().uid(Sets.newHashSet(programStage.getUid())).build();
-    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 0);
+    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 1);
     List<Audit> audits = auditService.getAudits(query);
     assertEquals(1, audits.size());
     Audit audit = audits.get(0);
@@ -344,7 +347,7 @@ class AuditIntegrationTest extends PostgresIntegrationTestBase {
           return null;
         });
     AuditQuery query = AuditQuery.builder().uid(Sets.newHashSet(dataSet.getUid())).build();
-    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 0);
+    await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> auditService.countAudits(query) >= 1);
     List<Audit> audits = auditService.getAudits(query);
     assertEquals(1, audits.size());
     Audit audit = audits.get(0);


### PR DESCRIPTION
## Problem

`AuditIntegrationTest` regularly fails PR CI, e.g. `testSaveRoute(AuthScheme)[3]` expected 1 audit but was 0, `[4]` expected 1 but was 2 ([example run](https://github.com/dhis2/dhis2-core/actions/runs/29684369970/job/88185987246)).

Two bugs:
1. All seven await conditions used `countAudits(query) >= 0`, which is vacuously true - the tests never waited for the async Artemis audit consumer and raced it (`was 0`).
2. `testSaveRoute` reused the shared `BASE_UID` for every `AuthScheme` parameter run. Audit rows are written outside the test transaction and not rolled back, so a late audit from a previous run leaked into the next run's query (`was 2`).

## Fix

Await `countAudits(query) >= 1` and use a unique `CodeGenerator.generateUid()` per parameterized run.

## Verification

`mvn test -pl dhis-test-integration -Dtest=AuditIntegrationTest` (Testcontainers Postgres): 10/10 pass.

AI Assisted