### PR TITLE
fix: correct off-by-one header/row assertions in ENROLLMENT_OU e2e test (2.43)

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityQueryTest.java
@@ -1478,13 +1478,13 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
     response
         .validate()
         .statusCode(200)
-        .body("headers", hasSize(equalTo(16)))
+        .body("headers", hasSize(equalTo(17)))
         .body("rows", hasSize(equalTo(14)))
         .body("metaData.dimensions.ou", hasSize(equalTo(1)))
         .body("metaData.dimensions.ou", hasItem("BV4IomHvri4"))
         .body("height", equalTo(14))
-        .body("width", equalTo(16))
-        .body("headerWidth", equalTo(16));
+        .body("width", equalTo(17))
+        .body("headerWidth", equalTo(17));
 
     // Validate the first three rows, as samples (identical to the `ou` variant).
     validateRow(
@@ -1496,6 +1496,7 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             ",  ()",
             "2015-08-07 15:47:24.376",
             ",  ()",
+            "",
             "",
             "",
             "",
@@ -1520,6 +1521,7 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             "",
             "",
             "",
+            "",
             "Ahmadiyya Muslim Hospital",
             "OU_268246",
             "Sierra Leone / Tonkolili / Yoni / Ahmadiyya Muslim Hospital",
@@ -1538,6 +1540,7 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
             ",  ()",
             "2015-08-07 15:47:22.383",
             ",  ()",
+            "",
             "",
             "",
             "",


### PR DESCRIPTION
## Summary
- `TrackedEntityQueryTest.queryWithProgramAndFilterByEnrollmentOuKeyword` asserted **16** headers/row-columns for `dimension=<program>.ENROLLMENT_OU:<ou>`, one short of the **17** its sibling `queryWithProgramAndFilterByEnrollmentOrgUnit` correctly asserts for the equivalent `.ou` dimension.
- 2.43's `TrackedEntityStaticField` includes a `storedby` field that master's does not, so the 16-header expectation (correct where this test originated, on master) was stale once cherry-picked onto 2.43 in #24408.
- This is a test-authoring bug, not a product defect — the API returns the same, correct 17-header shape for both `.ou` and `.ENROLLMENT_OU` spellings, exactly as intended.
- No production code changes.

Discovered while investigating an apparently-unrelated CI failure on #24491 (`perf: pre-filter geoFeatures org units by geometry`, backport to 2.43) — that PR doesn't touch any tracked-entity analytics code and was unaffected by this. Confirmed via a trivial no-op test branch (#24505) that this failure is pre-existing on `2.43` regardless of any other PR content.

Full root-cause writeup: see the attached notes below (not yet filed as a Jira ticket).

<details>
<summary>Root cause detail</summary>

Diffing the two tests' expected row-value lists showed they were identical except the `ENROLLMENT_OU` variant was missing one blank `""` placeholder (for the `storedby` column) in each of the three sample rows, and the `headers`/`width`/`headerWidth` assertions were set to 16 instead of 17 to match. Confirmed on master (via a locally-built image + direct API probe) that both `.ou` and `ENROLLMENT_OU` correctly return 16 headers there (master has no `storedby` field), so master's version of this test needs no change.

</details>

## Test plan
- [x] Applied the same fix locally, built a `2.43` image from unmodified production code, and ran `queryWithProgramAndFilterByEnrollmentOuKeyword` against it with the Sierra Leone e2e dataset: `Tests run: 1, Failures: 0`.
- [x] Confirmed the corrected row-value lists are byte-for-byte identical to the passing sibling test `queryWithProgramAndFilterByEnrollmentOrgUnit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)