### PR TITLE
fix: avoid full User materialization for userRole/userGroup members projection [DHIS2-21860]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/transformer/UserPropertyTransformer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/transformer/UserPropertyTransformer.java
@@ -102,6 +102,21 @@ public class UserPropertyTransformer extends AbstractPropertyTransformer<User> {
     return builder.build();
   }
 
+  /**
+   * Raw {@code userinfo} columns a SQL projection must select to build a transient, session-less
+   * {@link User} that renders identically to {@link #buildUserDto}/{@link JacksonSerialize} without
+   * going through Hibernate. Mirrors exactly what {@link User#getUid()}, {@link User#getCode()},
+   * {@link User#getUsername()}, and {@link User#getName()}/{@link User#getDisplayName()} read --
+   * the latter two fall back to {@code firstname + " " + surname} when the persisted {@code name}
+   * column is null (see {@link User#getName()}).
+   *
+   * <p>Kept next to {@link UserDto} so a change to either field set is visible in the same file as
+   * any SQL bypass mirroring it (see {@code UserSummaryRowMapper} in dhis-service-core,
+   * DHIS2-21860).
+   */
+  public static final List<String> SUMMARY_SQL_COLUMNS =
+      List.of("uid", "code", "username", "firstname", "surname", "name");
+
   @Data
   @Builder
   @OpenApi.Identifiable(as = User.class)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroup.java
@@ -186,6 +186,10 @@ public class UserGroup extends BaseIdentifiableObject implements MetadataObject 
     this.userSummaries = userSummaries;
   }
 
+  public boolean hasUserSummaries() {
+    return userSummaries != null;
+  }
+
   @JsonProperty("managedGroups")
   @JsonSerialize(contentAs = BaseIdentifiableObject.class)
   @JacksonXmlElementWrapper(localName = "managedGroups", namespace = DxfNamespaces.DXF_2_0)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroup.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.user;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -62,6 +63,15 @@ public class UserGroup extends BaseIdentifiableObject implements MetadataObject 
 
   /** Set of related users */
   private Set<User> members = new HashSet<>();
+
+  /**
+   * Set by {@code FieldFilterService.applyUserSummaries} to a lightweight SQL projection of {@link
+   * #members} before serialization, so {@link #getMembers()} doesn't force Hibernate to fully
+   * materialize every {@link User} in the group just to serialize 5 fields per user (DHIS2-21860).
+   * Transient: never Hibernate-mapped, never persisted. Every other caller of {@link #getMembers()}
+   * leaves this {@code null} and gets the original {@link #members}-derived value unchanged.
+   */
+  @JsonIgnore private transient Set<User> userSummaries;
 
   /** User groups (if any) that members of this user group can manage the members within. */
   private Set<UserGroup> managedGroups = new HashSet<>();
@@ -165,11 +175,15 @@ public class UserGroup extends BaseIdentifiableObject implements MetadataObject 
   @JacksonXmlElementWrapper(localName = "users", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "user", namespace = DxfNamespaces.DXF_2_0)
   public Set<User> getMembers() {
-    return members;
+    return userSummaries != null ? userSummaries : members;
   }
 
   public void setMembers(Set<User> members) {
     this.members = members;
+  }
+
+  public void setUserSummaries(Set<User> userSummaries) {
+    this.userSummaries = userSummaries;
   }
 
   @JsonProperty("managedGroups")

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupStore.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.user;
 
+import java.util.List;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.common.UID;
@@ -70,4 +71,16 @@ public interface UserGroupStore extends IdentifiableObjectStore<UserGroup> {
    * @param userUid the UID of the user being removed from all groups
    */
   void removeAllMemberships(@Nonnull UID userUid);
+
+  /**
+   * Returns a lightweight, transient summary (uid, code, username, firstName, surname, name) of
+   * every member of the given group, without loading the full {@link User} entities via Hibernate.
+   * The returned {@link User} instances are not managed by the persistence context and must not be
+   * passed to any Hibernate session operation.
+   *
+   * @param userGroupUid the UID of the group
+   * @return summary members, empty list if the group has none or does not exist
+   */
+  @Nonnull
+  List<User> getUserSummaries(@Nonnull UID userGroupUid);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserRole.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserRole.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.user;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -61,6 +62,15 @@ public class UserRole extends BaseIdentifiableObject implements MetadataObject {
   private Set<String> restrictions = new HashSet<>();
 
   private Set<User> members = new HashSet<>();
+
+  /**
+   * Set by {@code FieldFilterService.applyUserSummaries} to a lightweight SQL projection of {@link
+   * #members} before serialization, so {@link #getUsers()} doesn't force Hibernate to fully
+   * materialize every {@link User} in the role just to serialize 5 fields per user (DHIS2-21860).
+   * Transient: never Hibernate-mapped, never persisted. Every other caller of {@link #getUsers()}
+   * leaves this {@code null} and gets the original {@link #members}-derived computation unchanged.
+   */
+  @JsonIgnore private transient List<User> userSummaries;
 
   public UserRole() {
     setAutoFields();
@@ -129,6 +139,10 @@ public class UserRole extends BaseIdentifiableObject implements MetadataObject {
   @JacksonXmlElementWrapper(localName = "users", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "userObject", namespace = DxfNamespaces.DXF_2_0)
   public List<User> getUsers() {
+    if (userSummaries != null) {
+      return userSummaries;
+    }
+
     List<User> users = new ArrayList<>();
 
     for (User user : members) {
@@ -138,5 +152,9 @@ public class UserRole extends BaseIdentifiableObject implements MetadataObject {
     }
 
     return users;
+  }
+
+  public void setUserSummaries(List<User> userSummaries) {
+    this.userSummaries = userSummaries;
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserRole.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserRole.java
@@ -157,4 +157,8 @@ public class UserRole extends BaseIdentifiableObject implements MetadataObject {
   public void setUserSummaries(List<User> userSummaries) {
     this.userSummaries = userSummaries;
   }
+
+  public boolean hasUserSummaries() {
+    return userSummaries != null;
+  }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserRoleStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserRoleStore.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.user;
 
+import java.util.List;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.common.UID;
@@ -62,4 +63,16 @@ public interface UserRoleStore extends IdentifiableObjectStore<UserRole> {
    * @param targetUserUid UID of the user to copy to
    */
   void copyRoleMemberships(@Nonnull UID sourceUserUid, @Nonnull UID targetUserUid);
+
+  /**
+   * Returns a lightweight, transient summary (uid, code, username, firstName, surname, name) of
+   * every member of the given role, without loading the full {@link User} entities via Hibernate.
+   * The returned {@link User} instances are not managed by the persistence context and must not be
+   * passed to any Hibernate session operation.
+   *
+   * @param userRoleUid the UID of the role
+   * @return summary members, empty list if the role has none or does not exist
+   */
+  @Nonnull
+  List<User> getUserSummaries(@Nonnull UID userRoleUid);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserGroupStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserGroupStore.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.user.UserGroupStore;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Repository("org.hisp.dhis.user.UserGroupStore")
 public class HibernateUserGroupStore extends HibernateIdentifiableObjectStore<UserGroup>
@@ -155,7 +156,19 @@ public class HibernateUserGroupStore extends HibernateIdentifiableObjectStore<Us
     // methods above). Those changes stay unflushed in the session until Hibernate decides to
     // flush, so this raw JDBC read -- on a separate path that bypasses the session entirely --
     // would otherwise miss them and return stale membership.
-    getSession().flush();
+    //
+    // Only flush inside an active, writable transaction: this method also runs from read-only
+    // GET paths (e.g. metadata export, single-object GET streaming serialization), where either
+    // there is no active transaction bound to the thread at all (raises "No EntityManager with
+    // actual transaction available"), or Postgres has the connection genuinely in a read-only
+    // transaction and rejects any DML flush() might emit ("cannot execute UPDATE in a read-only
+    // transaction") -- neither of which H2 (used by the unit tests) enforces, so this only
+    // surfaced in Postgres-backed E2E CI. In both cases there is nothing of ours to flush: our
+    // own membership writes never happen from within a read-only or transaction-less context.
+    if (TransactionSynchronizationManager.isActualTransactionActive()
+        && !TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+      getSession().flush();
+    }
     String sql =
         "select "
             + UserSummaryRowMapper.SELECT_COLUMNS

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserGroupStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserGroupStore.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.user.hibernate;
 
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
@@ -144,6 +145,25 @@ public class HibernateUserGroupStore extends HibernateIdentifiableObjectStore<Us
     jdbcTemplate.update(
         "DELETE FROM usergroupmembers WHERE userid = (SELECT userinfoid FROM userinfo WHERE uid = ?)",
         userUid.getValue());
+  }
+
+  @Nonnull
+  @Override
+  public List<User> getUserSummaries(@Nonnull UID userGroupUid) {
+    // Membership can also change via plain ORM (e.g. DefaultCollectionService add/remove, which
+    // mutates the managed `members` PersistentSet in place without going through the SQL bypass
+    // methods above). Those changes stay unflushed in the session until Hibernate decides to
+    // flush, so this raw JDBC read -- on a separate path that bypasses the session entirely --
+    // would otherwise miss them and return stale membership.
+    getSession().flush();
+    String sql =
+        "select "
+            + UserSummaryRowMapper.SELECT_COLUMNS
+            + " from userinfo u"
+            + " join usergroupmembers m on m.userid = u.userinfoid"
+            + " join usergroup ug on ug.usergroupid = m.usergroupid"
+            + " where ug.uid = ?";
+    return jdbcTemplate.query(sql, UserSummaryRowMapper.INSTANCE, userGroupUid.getValue());
   }
 
   //  @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserRoleStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserRoleStore.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.user.UserRoleStore;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -101,7 +102,19 @@ public class HibernateUserRoleStore extends HibernateIdentifiableObjectStore<Use
     // UserObjectBundleHook#postCommit calling user.setUserRoles(...)), which stays unflushed in
     // the session until Hibernate decides to flush. This raw JDBC read bypasses the session
     // entirely, so without an explicit flush first it could return stale membership.
-    getSession().flush();
+    //
+    // Only flush inside an active, writable transaction: this method also runs from read-only
+    // GET paths (e.g. metadata export, single-object GET streaming serialization), where either
+    // there is no active transaction bound to the thread at all (raises "No EntityManager with
+    // actual transaction available"), or Postgres has the connection genuinely in a read-only
+    // transaction and rejects any DML flush() might emit ("cannot execute UPDATE in a read-only
+    // transaction") -- neither of which H2 (used by the unit tests) enforces, so this only
+    // surfaced in Postgres-backed E2E CI. In both cases there is nothing of ours to flush: our
+    // own membership writes never happen from within a read-only or transaction-less context.
+    if (TransactionSynchronizationManager.isActualTransactionActive()
+        && !TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+      getSession().flush();
+    }
     String sql =
         "select "
             + UserSummaryRowMapper.SELECT_COLUMNS

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserRoleStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserRoleStore.java
@@ -30,12 +30,14 @@
 package org.hisp.dhis.user.hibernate;
 
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import javax.annotation.Nonnull;
 import org.hibernate.query.Query;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.user.UserRoleStore;
 import org.springframework.context.ApplicationEventPublisher;
@@ -90,5 +92,23 @@ public class HibernateUserRoleStore extends HibernateIdentifiableObjectStore<Use
     query.setParameter("dataSet", dataSet);
 
     return query.getSingleResult().intValue();
+  }
+
+  @Nonnull
+  @Override
+  public List<User> getUserSummaries(@Nonnull UID userRoleUid) {
+    // Role membership is normally changed via plain ORM (User.userRoles is the owning side, e.g.
+    // UserObjectBundleHook#postCommit calling user.setUserRoles(...)), which stays unflushed in
+    // the session until Hibernate decides to flush. This raw JDBC read bypasses the session
+    // entirely, so without an explicit flush first it could return stale membership.
+    getSession().flush();
+    String sql =
+        "select "
+            + UserSummaryRowMapper.SELECT_COLUMNS
+            + " from userinfo u"
+            + " join userrolemembers m on m.userid = u.userinfoid"
+            + " join userrole ur on ur.userroleid = m.userroleid"
+            + " where ur.uid = ?";
+    return jdbcTemplate.query(sql, UserSummaryRowMapper.INSTANCE, userRoleUid.getValue());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/UserSummaryRowMapper.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/UserSummaryRowMapper.java
@@ -31,11 +31,13 @@ package org.hisp.dhis.user.hibernate;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.stream.Collectors;
+import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
 import org.hisp.dhis.user.User;
 import org.springframework.jdbc.core.RowMapper;
 
 /**
- * Maps a {@code uid, code, username, firstname, surname, name} projection to a transient,
+ * Maps a {@link UserPropertyTransformer#SUMMARY_SQL_COLUMNS} projection to a transient,
  * session-less {@link User}. Used by {@link HibernateUserRoleStore#getUserSummaries} and {@link
  * HibernateUserGroupStore#getUserSummaries} to avoid loading full {@link User} entities via
  * Hibernate just to serialize a handful of fields. The returned instances are never attached to a
@@ -44,7 +46,15 @@ import org.springframework.jdbc.core.RowMapper;
 class UserSummaryRowMapper implements RowMapper<User> {
   static final UserSummaryRowMapper INSTANCE = new UserSummaryRowMapper();
 
-  static final String SELECT_COLUMNS = "u.uid, u.code, u.username, u.firstname, u.surname, u.name";
+  /**
+   * Selects exactly the columns {@link UserPropertyTransformer#SUMMARY_SQL_COLUMNS} declares are
+   * needed, so this SQL bypass can't silently drift out of sync with the DTO shape it's meant to
+   * reproduce (DHIS2-21860).
+   */
+  static final String SELECT_COLUMNS =
+      UserPropertyTransformer.SUMMARY_SQL_COLUMNS.stream()
+          .map(column -> "u." + column)
+          .collect(Collectors.joining(", "));
 
   @Override
   public User mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/UserSummaryRowMapper.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/UserSummaryRowMapper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user.hibernate;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.hisp.dhis.user.User;
+import org.springframework.jdbc.core.RowMapper;
+
+/**
+ * Maps a {@code uid, code, username, firstname, surname, name} projection to a transient,
+ * session-less {@link User}. Used by {@link HibernateUserRoleStore#getUserSummaries} and {@link
+ * HibernateUserGroupStore#getUserSummaries} to avoid loading full {@link User} entities via
+ * Hibernate just to serialize a handful of fields. The returned instances are never attached to a
+ * Hibernate session and must not be passed to any session operation.
+ */
+class UserSummaryRowMapper implements RowMapper<User> {
+  static final UserSummaryRowMapper INSTANCE = new UserSummaryRowMapper();
+
+  static final String SELECT_COLUMNS = "u.uid, u.code, u.username, u.firstname, u.surname, u.name";
+
+  @Override
+  public User mapRow(ResultSet rs, int rowNum) throws SQLException {
+    User user = new User();
+    user.setUid(rs.getString("uid"));
+    user.setCode(rs.getString("code"));
+    user.setUsername(rs.getString("username"));
+    user.setFirstName(rs.getString("firstname"));
+    user.setSurname(rs.getString("surname"));
+    user.setName(rs.getString("name"));
+    return user;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/UserGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/UserGroup.hbm.xml
@@ -32,7 +32,13 @@
       enumeration of all members of a group is uncommon in production. The overhead of
       manual cache eviction after every SQL bypass outweighs the benefit.
     -->
-    <set name="members" table="usergroupmembers">
+    <!--
+      access="field": getMembers() is overridden (DHIS2-21860) to transparently return a
+      lightweight transient projection during JSON serialization. Hibernate must read/write the
+      raw `members` field directly for its own persistence/dirty-checking, or it would see that
+      projection instead of the real collection and try to cascade-save its unpersisted contents.
+    -->
+    <set name="members" table="usergroupmembers" access="field">
       <key column="usergroupid" foreign-key="fk_usergroupmembers_usergroupid" />
       <many-to-many column="userid" class="org.hisp.dhis.user.User" foreign-key="fk_usergroupmembers_userid" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/hibernate/UserSummaryRowMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/hibernate/UserSummaryRowMapperTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user.hibernate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@link UserSummaryRowMapper}'s transient {@link User} projection (the DHIS2-21860 SQL
+ * bypass) to the same wire shape {@link UserPropertyTransformer.JacksonSerialize} produces for a
+ * real, Hibernate-loaded {@link User}. If either the SQL column list ({@link
+ * UserPropertyTransformer#SUMMARY_SQL_COLUMNS}) or the DTO field set drifts out of sync, this fails
+ * instead of silently serving a stale or incomplete summary.
+ */
+class UserSummaryRowMapperTest {
+
+  @Test
+  void selectColumnsIsDerivedFromTheSharedDtoColumnList() {
+    assertEquals(
+        "u.uid, u.code, u.username, u.firstname, u.surname, u.name",
+        UserSummaryRowMapper.SELECT_COLUMNS);
+  }
+
+  @Test
+  void summaryUserRendersIdenticallyToDtoContract() throws SQLException {
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.getString("uid")).thenReturn("abcdefghijk");
+    when(rs.getString("code")).thenReturn("CODE1");
+    when(rs.getString("username")).thenReturn("jdoe");
+    when(rs.getString("firstname")).thenReturn("Jane");
+    when(rs.getString("surname")).thenReturn("Doe");
+    when(rs.getString("name")).thenReturn(null);
+
+    User summary = UserSummaryRowMapper.INSTANCE.mapRow(rs, 0);
+
+    ObjectMapper mapper = new ObjectMapper();
+    SimpleModule module = new SimpleModule();
+    module.addSerializer(User.class, new UserPropertyTransformer.JacksonSerialize());
+    mapper.registerModule(module);
+
+    JsonNode json = mapper.valueToTree(summary);
+
+    assertEquals(5, json.size(), "summary User must render as exactly the UserDto field set");
+    assertEquals("abcdefghijk", json.get("id").asText());
+    assertEquals("CODE1", json.get("code").asText());
+    assertEquals("jdoe", json.get("username").asText());
+    // name column was null: getName() must fall back to "firstname surname"
+    assertEquals("Jane Doe", json.get("name").asText());
+    assertEquals("Jane Doe", json.get("displayName").asText());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -49,6 +49,7 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -59,6 +60,7 @@ import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.PropertyPath;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.fieldfiltering.transformers.IsEmptyFieldTransformer;
 import org.hisp.dhis.fieldfiltering.transformers.IsNotEmptyFieldTransformer;
 import org.hisp.dhis.fieldfiltering.transformers.KeyByFieldTransformer;
@@ -71,7 +73,11 @@ import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserGroupService;
+import org.hisp.dhis.user.UserGroupStore;
+import org.hisp.dhis.user.UserRole;
+import org.hisp.dhis.user.UserRoleStore;
 import org.hisp.dhis.user.UserService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.OrderComparator;
@@ -98,6 +104,10 @@ public class FieldFilterService {
 
   private final AttributeService attributeService;
 
+  private final UserRoleStore userRoleStore;
+
+  private final UserGroupStore userGroupStore;
+
   public FieldFilterService(
       FieldPathHelper fieldPathHelper,
       ObjectMapper jsonMapper,
@@ -105,14 +115,18 @@ public class FieldFilterService {
       AclService aclService,
       UserGroupService userGroupService,
       UserService userService,
-      AttributeService attributeService) {
+      AttributeService attributeService,
+      UserRoleStore userRoleStore,
+      UserGroupStore userGroupStore) {
     this.fieldPathHelper = fieldPathHelper;
-    this.jsonMapper = configureFieldFilterObjectMapper(jsonMapper);
     this.schemaService = schemaService;
     this.aclService = aclService;
     this.userGroupService = userGroupService;
     this.userService = userService;
     this.attributeService = attributeService;
+    this.userRoleStore = userRoleStore;
+    this.userGroupStore = userGroupStore;
+    this.jsonMapper = configureFieldFilterObjectMapper(jsonMapper);
   }
 
   private ObjectMapper configureFieldFilterObjectMapper(ObjectMapper objectMapper) {
@@ -243,6 +257,15 @@ public class FieldFilterService {
     Map<String, ObjectNode> attributeProperties = new HashMap<>();
 
     for (Object object : objects) {
+      // Must run before applyAccess/applySharingDisplayNames: both walk the *entire* requested
+      // field tree (e.g. "users.groups", "users.organisationUnits" from a "users[*]" wildcard),
+      // and that walk calls getUsers()/getMembers() itself while descending. If the real,
+      // Hibernate-backed member list is still in place when that walk happens, it forces full
+      // materialization of every User and its associations -- exactly the N+1 this projection is
+      // meant to avoid. Installing the lightweight summary first means every later caller in this
+      // loop (including applyAccess's own traversal and Jackson's serialization) observes it
+      // instead (DHIS2-21860; found via Glowroot trace showing 583k queries on a single request).
+      applyUserSummaries(object, paths);
       applyAccess(object, paths, isSkipSharing, currentUserDetails);
       applySharingDisplayNames(object, paths, isSkipSharing);
 
@@ -251,6 +274,7 @@ public class FieldFilterService {
           object, objectNode, relativeAttributePaths, attributeProperties);
       applyAttributeAsPropertyFields(object, objectNode, paths);
       applyTransformers(objectNode, fieldTransformers);
+      clearUserSummaries(object);
 
       if (excludeDefaults) removeEmptyObjects(objectNode);
 
@@ -553,5 +577,63 @@ public class FieldFilterService {
             object.setAccess(aclService.getAccess(object, userDetails));
           }
         });
+  }
+
+  /**
+   * Fetches a lightweight SQL projection of {@code UserRole.users} / {@code UserGroup.members} and
+   * stashes it on a transient field, instead of letting Jackson invoke the real getter (which would
+   * force Hibernate to fully materialize every {@code User} in the membership set just to serialize
+   * 5 fields per user). Only runs when the field is actually requested (DHIS2-21860).
+   *
+   * <p>Deliberately does NOT use {@link #applyFieldPathVisitor}/{@link FieldPathHelper#visitPaths}
+   * like {@link #applyAccess} and {@link #applySharingDisplayNames} do. That visitor calls {@code
+   * visitFieldPath} once per *leaf* {@link FieldPath} independently (e.g. {@code users.groups},
+   * {@code users.organisationUnits} are each their own top-level entries for a {@code users[*]}
+   * wildcard, alongside a bare {@code users} entry) -- each one re-fetches {@code getUsers()} from
+   * the *root* to descend, and the callback only fires at the leaf, with the leaf's own segment
+   * name, never "users" itself. So a check for {@code path.segment().equals("users")} only ever
+   * matches the bare {@code users} entry, and {@code paths} is built from a {@code HashMap} with no
+   * defined iteration order -- whether that entry is visited before or after {@code users.groups}
+   * etc. is unpredictable. When it loses that race, every "users.X" leaf materializes the real,
+   * Hibernate-backed member set and its associations before the summary is ever installed --
+   * confirmed via a Glowroot trace showing 230k+ per-member queries despite this method having
+   * already run. Checking {@code paths} directly for a "users"-headed entry sidesteps the race
+   * entirely: the summary is set (or not) in one pass, before any leaf is visited.
+   */
+  private void applyUserSummaries(Object root, List<FieldPath> paths) {
+    if (!(root instanceof UserRole) && !(root instanceof UserGroup)) {
+      return;
+    }
+    // UserGroup.getMembers() is exposed via @JsonProperty("users") -- the schema/field-path
+    // property name is "users" for both UserRole and UserGroup, not "members".
+    boolean usersRequested =
+        paths.stream().anyMatch(path -> path.getPath().head().contentEquals("users"));
+    if (!usersRequested) {
+      return;
+    }
+    if (root instanceof UserRole role) {
+      role.setUserSummaries(userRoleStore.getUserSummaries(UID.of(role.getUid())));
+    } else if (root instanceof UserGroup group) {
+      group.setUserSummaries(
+          new LinkedHashSet<>(userGroupStore.getUserSummaries(UID.of(group.getUid()))));
+    }
+  }
+
+  /**
+   * Resets the transient override set by {@link #applyUserSummaries}, immediately after the object
+   * has been serialized. Without this, the override stays set on the managed entity for the rest of
+   * its session lifetime -- harmless for read-only use, but if the same managed instance is later
+   * touched by a write path within the same transaction (e.g. a subsequent update that inspects
+   * {@code getMembers()}/{@code getUsers()} expecting the real, persisted collection), it would see
+   * the lightweight transient {@code User} projection instead and could feed those never-persisted
+   * instances into a Hibernate cascade (DHIS2-21860; caught via a real {@code
+   * TransientObjectException} regression in {@code UserControllerTest} during implementation).
+   */
+  private void clearUserSummaries(Object object) {
+    if (object instanceof UserRole role) {
+      role.setUserSummaries(null);
+    } else if (object instanceof UserGroup group) {
+      group.setUserSummaries(null);
+    }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -611,9 +611,14 @@ public class FieldFilterService {
     if (!usersRequested) {
       return;
     }
-    if (root instanceof UserRole role) {
+    // May already be set by AbstractFullReadOnlyController#beforeLinkGeneration (see
+    // UserRoleController/UserGroupController) so that LinkService's href generation -- which
+    // reflectively calls this same getter *before* this method ever runs -- observes the
+    // summary too, instead of forcing full materialization of the real collection just to
+    // generate hrefs that are then discarded. Skip re-fetching in that case.
+    if (root instanceof UserRole role && !role.hasUserSummaries()) {
       role.setUserSummaries(userRoleStore.getUserSummaries(UID.of(role.getUid())));
-    } else if (root instanceof UserGroup group) {
+    } else if (root instanceof UserGroup group && !group.hasUserSummaries()) {
       group.setUserSummaries(
           new LinkedHashSet<>(userGroupStore.getUserSummaries(UID.of(group.getUid()))));
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -1464,12 +1464,20 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testGetUserRoleUsersAreTransformed() {
+    // UserRole.members is the Hibernate inverse side (owning side is User.userRoles) -- must add
+    // via user.getUserRoles() for the membership to actually be persisted to userrolemembers,
+    // not just mutate the in-memory role.members collection.
     UserRole role = createUserRole('X');
+    manager.save(role);
     User user = makeUser("Y");
     user.setEmail("y@y.org");
+    user.getUserRoles().add(role);
     userService.addUser(user);
-    role.getMembers().add(user);
-    manager.save(role);
+    // userService.addUser doesn't flush; the userrolemembers cascade insert stays pending in the
+    // Hibernate session until the next auto-flush (HQL/Criteria query) or explicit flush. The GET
+    // below queries userrolemembers directly via JDBC (DHIS2-21860 projection), which doesn't
+    // trigger Hibernate auto-flush, so without this the membership row isn't visible yet.
+    manager.flush();
 
     JsonObject userInRole =
         GET("/userRoles/{id}?fields=users[*]", role.getUid())
@@ -1479,6 +1487,30 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
 
     assertFalse(userInRole.has("email"), "email should not be exposed");
     assertEquals(user.getUid(), userInRole.getString("id").string());
+  }
+
+  @Test
+  void testGetUserGroupUsersAreTransformed() {
+    // Unlike UserRole.members, UserGroup.members is the Hibernate owning side (no
+    // inverse="true" in UserGroup.hbm.xml), so persisting via group.getMembers()/createUserGroup
+    // works directly -- no User-side workaround needed here.
+    User user = makeUser("Z");
+    user.setEmail("z@z.org");
+    userService.addUser(user);
+    UserGroup group = createUserGroup('X', Set.of(user));
+    manager.save(group);
+    manager.flush();
+
+    // UserGroup.getMembers() is exposed as JSON property "users" (@JsonProperty("users")), not
+    // "members" -- same API field name as UserRole.
+    JsonObject userInGroup =
+        GET("/userGroups/{id}?fields=users[*]", group.getUid())
+            .content(HttpStatus.OK)
+            .getArray("users")
+            .getObject(0);
+
+    assertFalse(userInGroup.has("email"), "email should not be exposed");
+    assertEquals(user.getUid(), userInGroup.getString("id").string());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -163,6 +163,17 @@ public abstract class AbstractFullReadOnlyController<
   protected void postProcessResponseEntity(T entity, GetObjectParams params) {}
 
   /**
+   * Override to prepare a single entity before {@link #handleLinksAndAccess}, i.e. before {@link
+   * LinkService#generateLinks} reflectively invokes every {@code IdentifiableObject} getter to
+   * stamp {@code href} on each value. Unlike {@link #postProcessResponseEntity}, which runs after
+   * link generation, this lets a subclass install a cheap transient stand-in for an expensive
+   * collection getter (see {@code UserRole}/{@code UserGroup}'s summary-projected {@code users}
+   * collection, DHIS2-21860) so link generation observes it too, instead of forcing full
+   * materialization of the real collection just to generate hrefs that are then discarded.
+   */
+  protected void beforeLinkGeneration(T entity, String fields) {}
+
+  /**
    * Allows to append further filters to the incoming ones. Recommended only on very specific cases
    * where forcing a new filter, programmatically, make sense. This is usually used to ensure that
    * some filters are always present.
@@ -242,6 +253,7 @@ public abstract class AbstractFullReadOnlyController<
       }
       entities = getEntityList(params, additionalFilters);
       postProcessResponseEntities(entities, params);
+      entities.forEach(e -> beforeLinkGeneration(e, fields));
       handleLinksAndAccess(entities, fields, false);
       if (params.isPaging()) totalCount = countGetObjectList(params, additionalFilters);
     }
@@ -443,6 +455,7 @@ public abstract class AbstractFullReadOnlyController<
     List<T> entities = queryService.query(query);
 
     String fields = params.getFieldsObject();
+    entities.forEach(e -> beforeLinkGeneration(e, fields));
     handleLinksAndAccess(entities, fields, true);
 
     entities.forEach(e -> postProcessResponseEntity(e, params));
@@ -493,6 +506,7 @@ public abstract class AbstractFullReadOnlyController<
     List<T> entities = queryService.query(query);
 
     String fields = params.getFieldsObject();
+    entities.forEach(e -> beforeLinkGeneration(e, fields));
     handleLinksAndAccess(entities, fields, true);
 
     entities.forEach(e -> postProcessResponseEntity(entity, params));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserGroupController.java
@@ -29,12 +29,15 @@
  */
 package org.hisp.dhis.webapi.controller.user;
 
+import java.util.LinkedHashSet;
 import org.hisp.dhis.common.IdentifiableObjects;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.query.GetObjectListParams;
 import org.hisp.dhis.user.UserGroup;
+import org.hisp.dhis.user.UserGroupStore;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -45,6 +48,24 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/api/userGroups")
 @OpenApi.Document(classifiers = {"team:platform", "purpose:metadata"})
 public class UserGroupController extends AbstractCrudController<UserGroup, GetObjectListParams> {
+
+  @Autowired private UserGroupStore userGroupStore;
+
+  /**
+   * Installs the summary-projected {@code users} collection (see {@link
+   * org.hisp.dhis.fieldfiltering.FieldFilterService}, DHIS2-21860) before {@code href} generation
+   * runs, so it observes the lightweight summary instead of forcing full materialization of the
+   * real, potentially huge {@code members} collection just to stamp an href on each entry that's
+   * then discarded. {@link org.hisp.dhis.fieldfiltering.FieldFilterService} skips its own fetch
+   * when this has already run.
+   */
+  @Override
+  protected void beforeLinkGeneration(UserGroup entity, String fields) {
+    if (fields != null && fields.contains("users")) {
+      entity.setUserSummaries(
+          new LinkedHashSet<>(userGroupStore.getUserSummaries(entity.getUID())));
+    }
+  }
 
   @Override
   protected void postUpdateEntity(UserGroup entity) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserRoleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserRoleController.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserRole;
+import org.hisp.dhis.user.UserRoleStore;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.http.HttpStatus;
@@ -65,6 +66,8 @@ public class UserRoleController
 
   private final UserService userService;
 
+  private final UserRoleStore userRoleStore;
+
   @Data
   @EqualsAndHashCode(callSuper = true)
   public static final class GetUserRoleObjectListParams extends GetObjectListParams {
@@ -80,6 +83,21 @@ public class UserRoleController
   protected List<UID> getPreQueryMatches(GetUserRoleObjectListParams params) {
     if (!params.isCanIssue()) return null;
     return userService.getRolesCurrentUserCanIssue();
+  }
+
+  /**
+   * Installs the summary-projected {@code users} collection (see {@link
+   * org.hisp.dhis.fieldfiltering.FieldFilterService}, DHIS2-21860) before {@code href} generation
+   * runs, so it observes the lightweight summary instead of forcing full materialization of the
+   * real, potentially huge {@code members} collection just to stamp an href on each entry that's
+   * then discarded. {@link org.hisp.dhis.fieldfiltering.FieldFilterService} skips its own fetch
+   * when this has already run.
+   */
+  @Override
+  protected void beforeLinkGeneration(UserRole entity, String fields) {
+    if (fields != null && fields.contains("users")) {
+      entity.setUserSummaries(userRoleStore.getUserSummaries(entity.getUID()));
+    }
   }
 
   @RequestMapping(


### PR DESCRIPTION
## Problem

`GET /api/userRoles/{id}?fields=users[*]` (and the equivalent `userGroups` endpoint) forced Hibernate to fully materialize every member `User` — plus every one of *their* own associations (org units, groups, roles, dimension constraints, ...) — just to serialize a handful of summary fields. On a role with ~83k members, a Glowroot trace of production traffic showed this as **583k+ SQL queries and 141s** for a single request.

## Fix

### Core N+1 (DHIS2-21860)
- `UserRoleStore`/`UserGroupStore` gain `getUserSummaries(UID)`, a raw SQL projection (`uid, code, username, firstName, surname, name`) via a new `UserSummaryRowMapper`, bypassing the ORM entirely.
- `UserRole`/`UserGroup` expose a transient `userSummaries` override that `getUsers()`/`getMembers()` prefer when set; every other caller (real Hibernate lifecycle, business logic elsewhere in the codebase) is unaffected since the override defaults to `null`.
- `FieldFilterService.applyUserSummaries` installs the projection only when `users` is actually requested, checked directly against the field-path list. This deliberately does **not** use the generic per-leaf field-path visitor that `applyAccess`/`applySharingDisplayNames` use — that visitor processes each requested leaf (`users.groups`, `users.organisationUnits`, ...) as an independent, unordered walk from the root (backed by a `HashMap` with no defined iteration order), so a leaf-based check for the bare `users` entry raced against those other leaves and lost more often than not, still materializing the real collection before the summary could be installed.
- `UserGroup.hbm.xml` maps `members` with `access="field"` so Hibernate's own flush-time dirty-checking reads/writes the raw field directly, bypassing the overridden getter — otherwise a write touching the same managed instance later in the same session could see the transient summary and throw `TransientObjectException` trying to cascade-save its unpersisted contents.

### Read-only/no-transaction flush guard
- `getUserSummaries()` flushes the session first, since membership can also change via plain ORM paths (`DefaultCollectionService` add/remove, `User`'s owning-side role assignment) that stay unflushed until Hibernate decides to — the raw JDBC read would otherwise return stale membership.
- That flush is guarded with `TransactionSynchronizationManager` (matching the existing idiom in `HibernatePeriodStore`) so it only runs inside an active, writable transaction. Without the guard, CI caught two failures neither of which surfaced in local H2-backed unit tests (H2 doesn't enforce either restriction the way Postgres does): a 409 on `GET /api/metadata` (`cannot execute UPDATE in a read-only transaction`), and a 409 on the userRoles GET itself (`No EntityManager with actual transaction available for current thread`) during deferred streaming JSON serialization.

### LinkService eager-load (DHIS2-21856)
- `LinkService.generateLinks()` reflectively calls `UserRole.getUsers()`/`UserGroup.getMembers()` to stamp `href` on each member, and runs in the controller *before* `FieldFilterService` ever gets a chance to install the summary projection — so it was still forcing full materialization of the real, potentially huge member collection just to generate hrefs that were then discarded once the summary swap happened later.
- `AbstractFullReadOnlyController` gains a `beforeLinkGeneration(T, String)` hook, called on single-object and list GET before link generation. Default no-op; zero behavior change for the ~85 other controllers extending this class.
- `UserRoleController`/`UserGroupController` override it to install the summary projection early when `users` is requested. `UserRole`/`UserGroup` gain `hasUserSummaries()` so `FieldFilterService`'s own `applyUserSummaries` skips a redundant fetch if the controller hook already populated it.

## Verification

Diagnosed and verified against a Glowroot trace on a local instance loaded with a synthetic role of 83,333 members (from the platform-perf dataset):

| | Before | After N+1 fix | After LinkService fix (final) |
|---|---|---|---|
| Duration | 141s | ~60-90s | **2.57s** |
| SQL queries | 583,335 | ~230k-3 | **2** |

268 tests pass locally (`UserControllerTest`, `AbstractCrudControllerTest`, `SharingControllerTest`, `MessageConversationControllerTest`, `MeControllerAclTest`, plus a broader sanity sweep across `DataElementControllerTest`, `OrganisationUnitControllerTest`, and several `Gist*ControllerTest`s given the change touches the shared `AbstractFullReadOnlyController`). Full CI (unit, all integration shards, H2 integration, API/E2E tests) is green.

## Out of scope

`href` does get computed on the transient summary objects by `LinkService` now, but does not currently survive into the serialized response for nested `users.X` paths — confirmed to be a separate, pre-existing field-filter issue unrelated to this change (`users[id]` and `users[*]` already returned identical output before any of this work, independently reproduced on the 2.43.0.1 stable play instance). Tracked separately.

That same investigation also found the identical-output behavior is not confined to `userRole`/`userGroup`: `UserPropertyTransformer` (the `id/code/name/displayName/username`-only serializer responsible for it) is wired onto ~15 sites platform-wide, including `createdBy`/`lastUpdatedBy` on every metadata object. `FieldFilterService`'s generic per-leaf visitor (`FieldPathHelper.visitFieldPath`) still fully walks and materializes requested sub-paths under any of those properties (e.g. `organisationUnits/{id}?fields=users[userRoles[id,name]]` still N+1s on `userRoles` even though it's never rendered) — this PR's fix only avoids that incidentally, for `UserRole`/`UserGroup`, because the transient summary's collections are plain empty in-memory sets rather than Hibernate proxies. A general fix (short-circuiting `visitFieldPath` when `Property.hasPropertyTransformer()` is set) is being tracked as a follow-up ticket rather than folded into this PR.

## Follow-up in this update

- `UserSummaryRowMapper.SELECT_COLUMNS` previously hardcoded its own copy of the raw columns needed to build the summary shape, independently of `UserPropertyTransformer.buildUserDto`/`JacksonSerialize` (the actual source of truth for that shape). Nothing tied the two together, so either could drift out of sync with no compiler signal.
- `UserPropertyTransformer` now exposes `SUMMARY_SQL_COLUMNS`, documented next to `UserDto`, and `UserSummaryRowMapper.SELECT_COLUMNS` is derived from it instead of a separately hand-maintained string.
- New `UserSummaryRowMapperTest` pins `SELECT_COLUMNS` to the constant and asserts a summary `User` serializes byte-identical to the DTO contract (including the `name`-null → `firstname surname` fallback). Verified by mutation (temporarily dropping a column from `SUMMARY_SQL_COLUMNS` failed the test for the expected reason, then reverted).

## Test plan
- [x] `UserControllerTest#testGetUserRoleUsersAreTransformed` (updated)
- [x] `UserControllerTest#testGetUserGroupUsersAreTransformed` (new)
- [x] `UserSummaryRowMapperTest` (new) — column-list/DTO-parity pinning, mutation-verified
- [x] Full local suite of 268 tests across the affected and adjacent controllers, all passing
- [x] Full CI green (unit, integration shards, H2 integration, api-test/E2E, SonarQube)
- [x] Manually verified against a local instance with an 83k-member role via Glowroot trace analysis at each stage of the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
