### PR TITLE
fix: skip getter invocation/recursion for PropertyTransformer fields in field filtering [DHIS2-21867]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -242,6 +242,13 @@ public class FieldPathHelper {
 
     if (property == null) return;
 
+    // A property with a PropertyTransformer (e.g. UserPropertyTransformer) always serializes a
+    // fixed shape regardless of what's requested underneath, so nothing below this point can ever
+    // reach the response -- invoking the getter here would only force needless (and, for
+    // Hibernate-backed collections, N+1-inducing) materialization to compute mutations that can
+    // never be observed (DHIS2-21867).
+    if (property.hasPropertyTransformer()) return;
+
     if (property.isCollection()) {
       Collection<?> c = safeInvoke(object, property.getGetterMethod());
       if (c == null || c.isEmpty()) return;

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperVisitFieldPathTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperVisitFieldPathTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.fieldfiltering;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.query.planner.PropertyPath;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaDescriptor;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers DHIS2-21867: {@link FieldPathHelper#visitFieldPath} must not invoke the getter (or recurse
+ * further) for a property annotated with {@code @PropertyTransformer}, since the transformer
+ * serializes a fixed shape independent of any nested field selection -- invoking the getter for
+ * such a property is exactly what forces the N+1 Hibernate lazy-load storm described in the ticket.
+ */
+class FieldPathHelperVisitFieldPathTest {
+
+  /** Stands in for a Hibernate-backed member whose collection must never be touched. */
+  public static class Member extends BaseIdentifiableObject {}
+
+  public static class Root extends BaseIdentifiableObject {
+    boolean membersGetterInvoked;
+
+    public Set<Member> getMembers() {
+      membersGetterInvoked = true;
+      return Set.of();
+    }
+  }
+
+  private FieldPathHelper fieldPathHelper;
+  private Root root;
+
+  @BeforeEach
+  void setUp() throws NoSuchMethodException {
+    Property membersProperty = new Property(Set.class, Root.class.getMethod("getMembers"), null);
+    membersProperty.setName("members");
+    membersProperty.setCollection(true);
+    membersProperty.setItemKlass(Member.class);
+    membersProperty.setPropertyTransformer(UserPropertyTransformer.class);
+
+    Schema rootSchema = new Schema(Root.class, "root", "roots");
+    rootSchema.addProperty(membersProperty);
+
+    fieldPathHelper = new FieldPathHelper(new StubSchemaService(rootSchema));
+    root = new Root();
+  }
+
+  @Test
+  void visitPathsDoesNotInvokeGetterForPropertyWithTransformer() {
+    fieldPathHelper.visitPaths(root, List.of(FieldPath.of("members.access")), (obj, path) -> {});
+
+    assertFalse(
+        root.membersGetterInvoked,
+        "getter for a property with a PropertyTransformer must not be invoked -- its subtree is "
+            + "serialized as a fixed shape regardless of what's requested underneath");
+  }
+
+  private record StubSchemaService(Schema rootSchema) implements SchemaService {
+    @Override
+    public void register(SchemaDescriptor descriptor) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Schema getSchema(Class<?> klass) {
+      return klass == Root.class ? rootSchema : null;
+    }
+
+    @Override
+    public Schema getSchemaBySingularName(String name) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Schema getSchemaByPluralName(String name) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Schema> getSchemas() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Schema> getSortedSchemas() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Schema> getMetadataSchemas() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<String> collectAuthorities() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PropertyPath getPropertyPath(Class<?> klass, String path) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/dhis-2/dhis-test-performance/README.md
+++ b/dhis-2/dhis-test-performance/README.md
@@ -157,6 +157,31 @@ Available properties:
 | `patchUserCount` | `6` | Users included after the PATCH replace |
 | `putUserCount` | `9` | Users included after the PUT full replace |
 
+### OrganisationUnitUsersFieldFilterPerformanceTest
+
+Regression guard for DHIS2-21867: `GET /api/organisationUnits/{uid}?fields=id,name,users[id,name,userRoles[id,name]]`
+used to force an N+1 lazy-load storm (250,054 JDBC queries / ~70s on the platform-perf DB's root org
+unit) because `FieldPathHelper.visitFieldPath` walked into every requested sub-path under a
+`@PropertyTransformer` property, invoking `getUserRoles()` on every member user while looking for
+`access`/`sharing` segments a transformer-backed subtree can never contain. Fixed in #24514.
+
+```sh
+mvn gatling:test -Dgatling.simulationClass=org.hisp.dhis.test.platform.OrganisationUnitUsersFieldFilterPerformanceTest \
+  --file dhis-2/pom.xml -pl dhis-test-performance
+```
+
+Available properties:
+
+| Property | Default | Description |
+|:---|:---|:---|
+| `configFile` | — | Path to a `.properties` file |
+| `baseUrl` | `http://localhost:8080` | DHIS2 base URL |
+| `username` | `admin` | API username |
+| `password` | `district` | API password |
+| `orgUnitUid` | `VCCdfC9pvMA` | Org unit UID (platform-perf root org unit, ~250k users) |
+| `fields` | `id,name,users[id,name,userRoles[id,name]]` | `fields` query param (the DHIS2-21867 repro) |
+| `iterations` | `3` | Requests to run |
+
 ## Tracker Tests
 
 The `tracker` package (`org.hisp.dhis.test.tracker`) tests the Tracker API using three Sierra Leone

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/OrganisationUnitUsersFieldFilterPerformanceTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/OrganisationUnitUsersFieldFilterPerformanceTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.test.platform;
+
+import static io.gatling.javaapi.core.CoreDsl.*;
+import static io.gatling.javaapi.http.HttpDsl.*;
+
+import io.gatling.javaapi.core.ChainBuilder;
+import io.gatling.javaapi.core.ClosedInjectionStep;
+import io.gatling.javaapi.core.ScenarioBuilder;
+import io.gatling.javaapi.core.Simulation;
+import io.gatling.javaapi.http.HttpProtocolBuilder;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Regression guard for DHIS2-21867: {@code FieldPathHelper.visitFieldPath} used to walk into every
+ * requested sub-path under a {@code @PropertyTransformer} property (e.g. {@code
+ * OrganisationUnit.users}, serialized via {@code UserPropertyTransformer}), invoking {@code
+ * getUserRoles()} on every member user while looking for {@code access}/{@code sharing} segments
+ * that a transformer-backed subtree can never contain. On an org unit with many users this was an
+ * N+1 lazy-load storm (250,054 JDBC queries / ~70s on the platform-perf DB's root org unit, fixed
+ * by PR #24514).
+ *
+ * <p>Targets the platform-perf DB (~250k users) by default, using the same root org unit UID as
+ * {@link UsersPerformanceTest}.
+ *
+ * <pre>{@code
+ * mvn gatling:test \
+ *   -Dgatling.simulationClass=org.hisp.dhis.test.platform.OrganisationUnitUsersFieldFilterPerformanceTest \
+ *   --file dhis-2/pom.xml -pl dhis-test-performance
+ * }</pre>
+ *
+ * Available properties:
+ *
+ * <ul>
+ *   <li>{@code configFile} — path to a {@code .properties} file (optional)
+ *   <li>{@code baseUrl} (default: {@code http://localhost:8080})
+ *   <li>{@code username} (default: {@code admin})
+ *   <li>{@code password} (default: {@code district})
+ *   <li>{@code orgUnitUid} (default: {@code VCCdfC9pvMA} — platform-perf root org unit)
+ *   <li>{@code fields} (default: {@code id,name,users[id,name,userRoles[id,name]]} — the exact
+ *       DHIS2-21867 repro)
+ *   <li>{@code iterations} (default: {@code 3})
+ * </ul>
+ */
+public class OrganisationUnitUsersFieldFilterPerformanceTest extends Simulation {
+
+  private static final Properties CONFIG = loadConfig();
+
+  private static Properties loadConfig() {
+    String path = System.getProperty("configFile");
+    Properties props = new Properties();
+    if (path != null) {
+      try (FileInputStream fis = new FileInputStream(path)) {
+        props.load(fis);
+        System.out.println(
+            "[OrganisationUnitUsersFieldFilterPerformanceTest] Loaded config from: " + path);
+      } catch (IOException e) {
+        System.err.println(
+            "[OrganisationUnitUsersFieldFilterPerformanceTest] Warning: could not load configFile="
+                + path
+                + ": "
+                + e.getMessage());
+      }
+    }
+    return props;
+  }
+
+  private static String prop(String key, String defaultValue) {
+    String sys = System.getProperty(key);
+    if (sys != null) return sys;
+    String file = CONFIG.getProperty(key);
+    return file != null ? file : defaultValue;
+  }
+
+  private static final String BASE_URL = prop("baseUrl", "http://localhost:8080");
+  private static final String USERNAME = prop("username", "admin");
+  private static final String PASSWORD = prop("password", "district");
+  private static final String ORG_UNIT_UID = prop("orgUnitUid", "VCCdfC9pvMA");
+  private static final String FIELDS = prop("fields", "id,name,users[id,name,userRoles[id,name]]");
+  private static final int ITERATIONS = Integer.parseInt(prop("iterations", "3"));
+
+  private static final String GET_REQUEST = "GET OrganisationUnit - users+userRoles field filter";
+
+  public OrganisationUnitUsersFieldFilterPerformanceTest() {
+    HttpProtocolBuilder httpProtocol =
+        http.baseUrl(BASE_URL)
+            .acceptHeader("application/json")
+            .disableCaching()
+            .basicAuth(USERNAME, PASSWORD);
+
+    ChainBuilder workflow =
+        exec(
+            http(GET_REQUEST)
+                .get("/api/organisationUnits/" + ORG_UNIT_UID)
+                .queryParam("fields", FIELDS)
+                .check(status().is(200)));
+
+    ScenarioBuilder scenario =
+        scenario("OrganisationUnit users/userRoles field filter (DHIS2-21867)")
+            .exec(flushCookieJar())
+            .repeat(ITERATIONS)
+            .on(workflow);
+
+    ClosedInjectionStep singleUser = rampConcurrentUsers(0).to(1).during(1);
+
+    // Generous ceiling: not a tight latency target (a separate, unfixed bottleneck --
+    // OrganisationUnit.users still fully materializes via Hibernate, plus Ehcache
+    // putFromLoad's per-entity serialization cost -- keeps this endpoint far from "fast" even
+    // post-fix). This threshold exists only to catch a regression back to the N+1 storm this
+    // test guards against (250,054 queries / ~70s pre-fix), not to enforce a performance target.
+    setUp(scenario.injectClosed(singleUser))
+        .protocols(httpProtocol)
+        .assertions(
+            details(GET_REQUEST).responseTime().percentile(95).lt(30_000),
+            details(GET_REQUEST).successfulRequests().percent().is(100D));
+  }
+}

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/OrganisationUnitUsersFieldFilterPerformanceTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/OrganisationUnitUsersFieldFilterPerformanceTest.java
@@ -136,12 +136,16 @@ public class OrganisationUnitUsersFieldFilterPerformanceTest extends Simulation 
     // Generous ceiling: not a tight latency target (a separate, unfixed bottleneck --
     // OrganisationUnit.users still fully materializes via Hibernate, plus Ehcache
     // putFromLoad's per-entity serialization cost -- keeps this endpoint far from "fast" even
-    // post-fix). This threshold exists only to catch a regression back to the N+1 storm this
-    // test guards against (250,054 queries / ~70s pre-fix), not to enforce a performance target.
+    // post-fix, and its own 2nd-level-cache-warmth-dependent variance is real). This threshold
+    // exists only to catch a regression back to the N+1 storm this test guards against, not to
+    // enforce a performance target. Calibrated from a real baseline-vs-candidate CI run (perf
+    // runner, platform-perf DB, 10 iterations, DHIS2-21867/#24514): master (unfixed) was a flat
+    // ~51-52s every request (min 50,773ms / p95 52,212ms); this fix ranged 21,597-42,634ms
+    // (p95 42,634ms). 48s sits with headroom above the fixed range and below master's floor.
     setUp(scenario.injectClosed(singleUser))
         .protocols(httpProtocol)
         .assertions(
-            details(GET_REQUEST).responseTime().percentile(95).lt(30_000),
+            details(GET_REQUEST).responseTime().percentile(95).lt(48_000),
             details(GET_REQUEST).successfulRequests().percent().is(100D));
   }
 }

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/OrganisationUnitUsersFieldFilterPerformanceTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/OrganisationUnitUsersFieldFilterPerformanceTest.java
@@ -39,6 +39,8 @@ import io.gatling.javaapi.core.Simulation;
 import io.gatling.javaapi.http.HttpProtocolBuilder;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Properties;
 
 /**
@@ -105,6 +107,9 @@ public class OrganisationUnitUsersFieldFilterPerformanceTest extends Simulation 
   private static final String BASE_URL = prop("baseUrl", "http://localhost:8080");
   private static final String USERNAME = prop("username", "admin");
   private static final String PASSWORD = prop("password", "district");
+  private static final String BASIC_AUTH =
+      Base64.getEncoder()
+          .encodeToString((USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
   private static final String ORG_UNIT_UID = prop("orgUnitUid", "VCCdfC9pvMA");
   private static final String FIELDS = prop("fields", "id,name,users[id,name,userRoles[id,name]]");
   private static final int ITERATIONS = Integer.parseInt(prop("iterations", "3"));
@@ -112,11 +117,22 @@ public class OrganisationUnitUsersFieldFilterPerformanceTest extends Simulation 
   private static final String GET_REQUEST = "GET OrganisationUnit - users+userRoles field filter";
 
   public OrganisationUnitUsersFieldFilterPerformanceTest() {
+    // No protocol-level basicAuth. DHIS2 is stateful (SessionCreationPolicy.IF_REQUIRED +
+    // HttpSessionSecurityContextRepository), so once a session exists Spring Security reuses the
+    // SecurityContext and skips re-authentication; bcrypt password verification (~70ms) is only
+    // paid on the FIRST request that establishes the session. Authenticate once per virtual user
+    // via a separately-named request instead, so the measured GET reflects endpoint cost only --
+    // same pattern as UsersPerformanceTest.
     HttpProtocolBuilder httpProtocol =
-        http.baseUrl(BASE_URL)
-            .acceptHeader("application/json")
-            .disableCaching()
-            .basicAuth(USERNAME, PASSWORD);
+        http.baseUrl(BASE_URL).acceptHeader("application/json").disableCaching();
+
+    ChainBuilder authenticate =
+        exec(flushCookieJar())
+            .exec(
+                http("Authenticate (session login)")
+                    .get("/api/me")
+                    .header("Authorization", "Basic " + BASIC_AUTH)
+                    .check(status().is(200)));
 
     ChainBuilder workflow =
         exec(
@@ -127,7 +143,7 @@ public class OrganisationUnitUsersFieldFilterPerformanceTest extends Simulation 
 
     ScenarioBuilder scenario =
         scenario("OrganisationUnit users/userRoles field filter (DHIS2-21867)")
-            .exec(flushCookieJar())
+            .exec(authenticate)
             .repeat(ITERATIONS)
             .on(workflow);
 


### PR DESCRIPTION
## Summary
- `FieldPathHelper.visitFieldPath` (used by `FieldFilterService.applyAccess`/`applySharingDisplayNames`) had no short-circuit for properties annotated with `@PropertyTransformer` (e.g. `UserPropertyTransformer`, used on `OrganisationUnit.users`, `UserRole.users`, `UserGroup.members`, `createdBy`/`lastUpdatedBy`/`user`, and ~10 other sites).
- Those properties always serialize a fixed 5-field DTO regardless of what's requested underneath, so walking into every sub-path to compute `Access`/sharing-display-name mutations was pure waste — and on a Hibernate-backed collection it forced full lazy-association materialization (N+1) just to throw the result away.
- Fix: short-circuit in `visitFieldPath` via `property.hasPropertyTransformer()`, which is already tracked on the schema. Closes this for every `@PropertyTransformer` site with one change.
- Related: found while reviewing #24512 (DHIS2-21860), which fixed the same class of N+1 for `UserRole`/`UserGroup` members specifically, but only as a side effect of substituting a transient `User` — it didn't fix the general `visitFieldPath` behavior, so sites like `OrganisationUnit.users` remained exposed.

Jira: https://dhis2.atlassian.net/browse/DHIS2-21867

## Measured impact

Glowroot trace, `GET /api/organisationUnits/{id}?fields=id,name,users[id,name,userRoles[id,name]]` on an org unit with many users, before vs. after this fix (same data, same server, only this change applied):

| | Before | After |
|---|--:|--:|
| Duration | 69.65s | 18.6s (**3.7x**) |
| JDBC queries | **250,054** | **3** (**~83,000x fewer**) |
| Main-thread CPU | 51.7s | 17.2s |
| Bytes allocated | 30.3GB | 14.7GB |

The query-count collapse confirms the root cause: `visitFieldPath` was calling `user.getUserRoles()` once per user while walking the `users.userRoles.id`/`users.userRoles.name` leaves looking for `access`/`sharing` segments that were never there, triggering one lazy-load per user. Post-fix, 0 CPU profile samples land in `FieldPathHelper` at all (was 8/684 pre-fix, and the query storm it triggered dominated the rest).

**Not in scope for this PR:** the remaining 18.6s is now dominated by (a) the one legitimate `getUsers()` call Jackson still needs to serialize the `users` array — `OrganisationUnit.users` never got the `applyUserSummaries`-style raw-SQL projection that #24512 gave `UserRole`/`UserGroup`, so that collection still fully materializes via Hibernate — and (b) Ehcache 2nd-level-cache `putFromLoad` paying a full Java-serialization round-trip per cached `User` entity (`ObjectInputStream`/`SerializingCopier`, ~73% of post-fix CPU samples). Both predate this change (visible as a smaller share of the much larger pre-fix profile) and are being tracked as a separate follow-up.

### CI comparison (Gatling, perf runner)

Independent confirmation on real, isolated CI hardware (not a locally-instrumented trace): [`performance-tests-compare.yml` run](https://github.com/dhis2/dhis2-core/actions/runs/29818034135), `dhis2/core-dev:latest` (master) vs. `dhis2/core-pr:24514` (this branch), platform-perf DB, `OrganisationUnitUsersFieldFilterPerformanceTest`, 10 iterations each (excluding warmup):

| | Baseline (master) | Candidate (this branch) |
|---|--:|--:|
| min | 50,773ms | 21,597ms |
| mean | 51,574ms | 30,999ms |
| p50 | 51,600ms | 39,053ms |
| p95 / max | 52,212ms | 42,634ms |

Master is a flat ~51–52s on every one of the 10 requests (the N+1 storm is deterministic). The branch ranges 21.6–42.6s, consistent with the remaining, separately-tracked bottleneck above being sensitive to 2nd-level-cache warmth between requests.

## Test plan
- [x] New unit test `FieldPathHelperVisitFieldPathTest` reproduces the bug (getter invoked despite a `PropertyTransformer` on the property) against unfixed code, and passes after the fix.
- [x] `dhis-service-field-filtering` module test suite passes.
- [x] `OrganisationUnitControllerTest`, `UserControllerTest`, `FieldFilterServiceTest`, `SharingControllerTest` (dhis-test-web-api) and `DefaultFieldFilterServiceTest` (dhis-service-dxf2) pass unchanged — output JSON is unaffected since the transformer already discarded that subtree; only the wasted lazy-load work is removed.
- [x] Verified against a live Glowroot-instrumented server (see Measured impact above).
- [x] New Gatling regression guard `OrganisationUnitUsersFieldFilterPerformanceTest` (dhis-test-performance) added, and used to produce the CI comparison above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)