### PR TITLE
fix: use AOC from DS context for DS completion [DHIS2-21823] (2.42)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -706,7 +706,9 @@ public class DefaultDataValueSetService implements DataValueSetService {
           Date.from(completeDate.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant()),
           dataSetContext.getOuterPeriod(),
           dataSetContext.getOuterOrgUnit(),
-          dataSetContext.getFallbackCategoryOptionCombo(),
+          dataSetContext.getOuterAttrOptionCombo() != null
+              ? dataSetContext.getOuterAttrOptionCombo()
+              : dataSetContext.getFallbackCategoryOptionCombo(),
           context.getCurrentUserName(),
           context.getSummary());
     } else {


### PR DESCRIPTION
When handling DS completion the AOC from the DS context needs to be forwarded instead of always using the fallback AOC (the default).