### PR TITLE
fix: prune PropertyTransformer-controlled subtrees at field-expansion time [DHIS2-21856]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -91,7 +91,34 @@ public class FieldPathHelper {
     List<FieldPath> exclusions = paths.stream().filter(FieldPath::isExclude).toList();
     applyExclusions(exclusions, inclusions);
 
+    pruneTransformerControlledSubtrees(inclusions, rootKlass);
+
     return List.copyOf(inclusions.values());
+  }
+
+  /**
+   * A property with a {@code @PropertyTransformer} (e.g. {@code UserPropertyTransformer}) always
+   * serializes a fixed shape independent of what's requested underneath it -- verified empirically
+   * (DHIS2-21856): {@code fields=users}, {@code fields=users[href]} and {@code fields=users[*]} all
+   * produce byte-identical responses. So any path beneath such a property is dead on arrival and is
+   * dropped here, before any consumer (ACL/sharing computation, href generation, ...) has a reason
+   * to walk into it -- rather than leaving every consumer to independently rediscover and skip the
+   * same pointless subtree.
+   */
+  private void pruneTransformerControlledSubtrees(
+      Map<PropertyPath, FieldPath> inclusions, Class<?> rootKlass) {
+    inclusions.keySet().removeIf(path -> isBeneathPropertyTransformer(path, rootKlass));
+  }
+
+  private boolean isBeneathPropertyTransformer(PropertyPath path, Class<?> rootKlass) {
+    for (PropertyPath ancestor = path.parent(); ancestor != null; ancestor = ancestor.parent()) {
+      Schema schema = getSchemaByPath(ancestor.parent(), rootKlass);
+      Property property = schema == null ? null : schema.getProperty(ancestor.segment().toString());
+      if (property != null && property.hasPropertyTransformer()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperPropertyTransformerPruningTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperPropertyTransformerPruningTest.java
@@ -41,7 +41,8 @@ import org.hisp.dhis.schema.SchemaDescriptor;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Covers DHIS2-21856: a property annotated with {@code @PropertyTransformer} always serializes a
@@ -98,25 +99,10 @@ class FieldPathHelperPropertyTransformerPruningTest {
     fieldPathHelper = new FieldPathHelper(schemaService);
   }
 
-  @Test
-  void wildcardUnderPropertyTransformerCollapsesToTheBarePath() {
-    List<FieldPath> result =
-        fieldPathHelper.apply(FieldFilterParser.parse("members[*]"), Root.class);
-
-    assertEquals(List.of("members"), result.stream().map(FieldPath::toString).toList());
-  }
-
-  @Test
-  void explicitSubFieldsUnderPropertyTransformerCollapseToTheBarePath() {
-    List<FieldPath> result =
-        fieldPathHelper.apply(FieldFilterParser.parse("members[id,extra]"), Root.class);
-
-    assertEquals(List.of("members"), result.stream().map(FieldPath::toString).toList());
-  }
-
-  @Test
-  void barePropertyTransformerFieldIsUnaffected() {
-    List<FieldPath> result = fieldPathHelper.apply(FieldFilterParser.parse("members"), Root.class);
+  @ParameterizedTest
+  @ValueSource(strings = {"members[*]", "members[id,extra]", "members"})
+  void fieldsUnderPropertyTransformerCollapseToTheBarePath(String fields) {
+    List<FieldPath> result = fieldPathHelper.apply(FieldFilterParser.parse(fields), Root.class);
 
     assertEquals(List.of("members"), result.stream().map(FieldPath::toString).toList());
   }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperPropertyTransformerPruningTest.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperPropertyTransformerPruningTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.fieldfiltering;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.query.planner.PropertyPath;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaDescriptor;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers DHIS2-21856: a property annotated with {@code @PropertyTransformer} always serializes a
+ * fixed shape regardless of what's requested underneath it (verified empirically: `fields=users`,
+ * `fields=users[href]` and `fields=users[*]` all produce byte-identical responses against a live
+ * server), so {@link FieldPathHelper#apply} should prune every descendant path of such a property
+ * rather than expanding presets/defaults into it -- the earlier, narrower fix (DHIS2-21867) only
+ * stopped {@code visitFieldPath} from *walking* those descendants; this stops them from being
+ * generated at all, which is what starves every consumer (not just the ACL/sharing visitor) of a
+ * reason to touch the real collection.
+ */
+class FieldPathHelperPropertyTransformerPruningTest {
+
+  /** Stands in for a Hibernate-backed member type with its own nested collection. */
+  public static class Member extends BaseIdentifiableObject {
+    public String getExtra() {
+      return "extra";
+    }
+  }
+
+  public static class Root extends BaseIdentifiableObject {
+    public Set<Member> getMembers() {
+      return Set.of();
+    }
+  }
+
+  private FieldPathHelper fieldPathHelper;
+
+  @BeforeEach
+  void setUp() throws NoSuchMethodException {
+    Property idProperty = new Property(String.class, Member.class.getMethod("getUid"), null);
+    idProperty.setName("id");
+    idProperty.setSimple(true);
+    idProperty.setPersisted(true);
+
+    Property extraProperty = new Property(String.class, Member.class.getMethod("getExtra"), null);
+    extraProperty.setName("extra");
+    extraProperty.setSimple(true);
+
+    Schema memberSchema = new Schema(Member.class, "member", "members");
+    memberSchema.addProperty(idProperty);
+    memberSchema.addProperty(extraProperty);
+
+    Property membersProperty = new Property(Set.class, Root.class.getMethod("getMembers"), null);
+    membersProperty.setName("members");
+    membersProperty.setCollection(true);
+    membersProperty.setItemKlass(Member.class);
+    membersProperty.setPropertyTransformer(UserPropertyTransformer.class);
+
+    Schema rootSchema = new Schema(Root.class, "root", "roots");
+    rootSchema.addProperty(membersProperty);
+
+    SchemaService schemaService = new StubSchemaService(rootSchema, memberSchema);
+    fieldPathHelper = new FieldPathHelper(schemaService);
+  }
+
+  @Test
+  void wildcardUnderPropertyTransformerCollapsesToTheBarePath() {
+    List<FieldPath> result =
+        fieldPathHelper.apply(FieldFilterParser.parse("members[*]"), Root.class);
+
+    assertEquals(List.of("members"), result.stream().map(FieldPath::toString).toList());
+  }
+
+  @Test
+  void explicitSubFieldsUnderPropertyTransformerCollapseToTheBarePath() {
+    List<FieldPath> result =
+        fieldPathHelper.apply(FieldFilterParser.parse("members[id,extra]"), Root.class);
+
+    assertEquals(List.of("members"), result.stream().map(FieldPath::toString).toList());
+  }
+
+  @Test
+  void barePropertyTransformerFieldIsUnaffected() {
+    List<FieldPath> result = fieldPathHelper.apply(FieldFilterParser.parse("members"), Root.class);
+
+    assertEquals(List.of("members"), result.stream().map(FieldPath::toString).toList());
+  }
+
+  private record StubSchemaService(Schema rootSchema, Schema memberSchema)
+      implements SchemaService {
+    @Override
+    public void register(SchemaDescriptor descriptor) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Schema getSchema(Class<?> klass) {
+      if (klass == Root.class) return rootSchema;
+      if (klass == Member.class) return memberSchema;
+      return null;
+    }
+
+    @Override
+    public Schema getSchemaBySingularName(String name) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Schema getSchemaByPluralName(String name) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Schema> getSchemas() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Schema> getSortedSchemas() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Schema> getMetadataSchemas() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<String> collectAuthorities() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PropertyPath getPropertyPath(Class<?> klass, String path) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fieldfiltering/FieldPathHelperTest.java
@@ -120,12 +120,22 @@ class FieldPathHelperTest extends PostgresIntegrationTestBase {
 
     // then only matching exclusions should have been applied
     // and fields starting with 'user' should still be present
-    assertEquals(58, result.size()); // all user properties
+    assertEquals(56, result.size()); // all user properties
     assertTrue(
         result.stream()
             .map(FieldPath::getPropertyName)
             .toList()
             .containsAll(List.of("username", "userRoles")));
+
+    // and @PropertyTransformer-controlled properties (createdBy/lastUpdatedBy use
+    // UserPropertyTransformer) keep their own bare path but not pruned descendant paths
+    // such as createdBy.id/lastUpdatedBy.id, since the transformer always serializes a
+    // fixed shape regardless of what's requested underneath it (DHIS2-21856)
+    List<String> paths = result.stream().map(fp -> fp.getPath().toString()).toList();
+    assertTrue(paths.contains("createdBy"));
+    assertTrue(paths.contains("lastUpdatedBy"));
+    assertFalse(paths.contains("createdBy.id"));
+    assertFalse(paths.contains("lastUpdatedBy.id"));
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -73,6 +73,7 @@ import org.hisp.dhis.test.webapi.json.domain.JsonUser;
 import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
+import org.hisp.dhis.user.UserRole;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -103,6 +104,66 @@ class AbstractCrudControllerTest extends H2ControllerIntegrationTestBase {
 
     assertTrue(userById.exists());
     assertEquals(id, userById.getId());
+  }
+
+  @Test
+  @DisplayName(
+      "GET single object: fields under a PropertyTransformer-controlled nested collection never"
+          + " change the response, however they're requested (DHIS2-21856)")
+  void testGetObjectPropertyTransformerFieldsAreInvariant() {
+    User user = makeUser("H");
+    user.setEmail("h@h.org");
+    userService.addUser(user);
+    UserGroup group = createUserGroup('H', Set.of(user));
+    manager.save(group);
+    manager.flush();
+
+    // UserPropertyTransformer always serializes id/code/name/displayName/username and nothing
+    // else -- verified against a live server to be byte-identical for "users", "users[href]" and
+    // "users[*]". This only pins output correctness; it can't detect the N+1 this ticket actually
+    // fixes (LinkService.generateLinks reflectively touching the real Hibernate collection before
+    // field-filtering runs), because that bug is invisible in the JSON response by construction --
+    // see FieldPathHelperPropertyTransformerPruningTest for the real regression guard, which
+    // asserts on the field-path list itself rather than on JSON content.
+    JsonObject baseline =
+        GET("/userGroups/{id}?fields=id,users", group.getUid())
+            .content(HttpStatus.OK)
+            .getArray("users")
+            .getObject(0);
+
+    for (String fields : List.of("users[href]", "users[*]", "users[id,name]")) {
+      JsonObject userInGroup =
+          GET("/userGroups/{id}?fields=id,{fields}", group.getUid(), fields)
+              .content(HttpStatus.OK)
+              .getArray("users")
+              .getObject(0);
+      assertEquals(baseline.toJson(), userInGroup.toJson());
+    }
+  }
+
+  @Test
+  @DisplayName(
+      "GET single object: href is still generated for a nested collection without a"
+          + " PropertyTransformer when explicitly requested (regression guard for the"
+          + " DHIS2-21856 hasHref rewrite)")
+  void testGetObjectHrefGeneratedForNonTransformerNestedCollection() {
+    UserRole role = createUserRole('H', "ALL");
+    manager.save(role);
+    User user = makeUser("H");
+    user.setEmail("h@h.org");
+    user.getUserRoles().add(role);
+    userService.addUser(user);
+    manager.flush();
+
+    JsonObject userRole =
+        GET("/users/{id}?fields=userRoles[*]", user.getUid())
+            .content(HttpStatus.OK)
+            .getArray("userRoles")
+            .getObject(0);
+
+    String href = userRole.getString("href").string();
+    assertNotNull(href);
+    assertTrue(href.endsWith("/userRoles/" + role.getUid()));
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -71,6 +71,8 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldFilterParams;
+import org.hisp.dhis.fieldfiltering.FieldFilterParser;
+import org.hisp.dhis.fieldfiltering.FieldPathHelper;
 import org.hisp.dhis.gist.GistBridge;
 import org.hisp.dhis.query.Filter;
 import org.hisp.dhis.query.Filters;
@@ -126,6 +128,8 @@ public abstract class AbstractFullReadOnlyController<
   @Autowired protected FieldFilterService oldFieldFilterService;
 
   @Autowired protected org.hisp.dhis.fieldfiltering.FieldFilterService fieldFilterService;
+
+  @Autowired protected FieldPathHelper fieldPathHelper;
 
   @Autowired protected LinkService linkService;
 
@@ -545,23 +549,31 @@ public abstract class AbstractFullReadOnlyController<
         ContextUtils.HEADER_CACHE_CONTROL, noCache().cachePrivate().getHeaderValue());
   }
 
+  /**
+   * Whether {@code href} would actually appear in the response for {@code fields}, at any depth --
+   * {@link LinkService#generateLinks} stamps {@code href} on every {@code IdentifiableObject}
+   * property it finds when {@code deep=true} (root object and nested collections alike), then
+   * field-filtering decides per-object whether it survives into the JSON; this is the coarse gate
+   * deciding whether that walk is worth attempting at all. Delegates to the real field-path
+   * expansion ({@link FieldPathHelper#apply}) instead of substring-matching the raw {@code fields}
+   * string: a property with a {@code @PropertyTransformer} (e.g. {@code UserPropertyTransformer})
+   * never has an {@code href} no matter how deeply nested or with what wildcard it's requested
+   * (DHIS2-21856), and {@code apply()} already prunes everything beneath such a property -- so any
+   * {@code href} path surviving here is one that could genuinely appear in the response. A raw
+   * {@code fields.contains("*")} check can't tell a top-level {@code *} from one four levels deep
+   * inside {@code users[*]}, which is what forced {@code generateLinks} to reflectively touch every
+   * {@code IdentifiableObject} getter on the schema, including large Hibernate-backed collections,
+   * purely to compute an {@code href} that field-filtering would discard anyway.
+   */
   private boolean hasHref(String fields) {
-    return fieldsContains("href", fields);
+    return fieldPathHelper.apply(FieldFilterParser.parse(fields), getEntityClass()).stream()
+        .anyMatch(fieldPath -> "href".contentEquals(fieldPath.getPath().segment()));
   }
 
   private void handleLinksAndAccess(List<T> entityList, String fields, boolean deep) {
     if (hasHref(fields)) {
       linkService.generateLinks(entityList, deep);
     }
-  }
-
-  private boolean fieldsContains(String match, String fields) {
-    return fields.contains("*")
-        || fields.contains(":all")
-        || fields.equals(match)
-        || fields.startsWith(match + ",")
-        || fields.endsWith("," + match)
-        || fields.contains("," + match + ",");
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Update (2026-07-22): this PR alone does not collapse the query count — see #24520

Live-validating this fix against a running server (not just CI) showed the motivating
`GET /api/userRoles/{id}?fields=users[*]` trace **unchanged** — still ~583k queries / 139.7s — even
with this PR's fix in place. Root cause: a *third*, independent bug in
`PropertyPropertyIntrospector` (schema introspection) meant `Property.hasPropertyTransformer()`
returned `false` for `UserRole.users` specifically, regardless of anything in this PR or #24514,
because that property is a read-only derived getter (`getUsers()`, computed from the `members`
field, no matching `setUsers()`) and the introspector only read `@PropertyTransformer` off
*writable* properties. Fixed separately in **#24520** (DHIS2-21872) — an independent bug with no
code overlap with this PR, so it doesn't belong in this diff.

**This PR's fix is still correct and still needed** — the unit-test evidence below holds — but the
pruning path in `FieldPathHelper.apply()` was silently a no-op for `UserRole.users` specifically
until #24520 also landed, since `hasPropertyTransformer()` never returned `true` for it. With all
three of #24520, #24514, and this PR in place, the same live request (role with 83,385 members)
went from 139.7s / ~583k queries to **5.76s**, confirmed by inspecting the Glowroot trace's query
breakdown directly, not just wall-clock timing.

**Recommended merge order:** #24520 first (standalone, no dependency on either of these two PRs),
then #24514 and this PR in either order.

---

## Summary

A property annotated `@PropertyTransformer` (e.g. `UserPropertyTransformer`, used on
`OrganisationUnit.users`, `UserRole.users`, `UserGroup.members`, `createdBy`/`lastUpdatedBy`/`user`,
and ~11 other sites) always serializes a fixed shape regardless of what's requested underneath it —
verified empirically against a live server:

```
GET /api/userRoles/{id}?fields=users            → 6.4s,   14,454,425 bytes
GET /api/userRoles/{id}?fields=users[href]       → 6.4s,   14,454,425 bytes   (byte-identical)
GET /api/userRoles/{id}?fields=users[*]          → 138.5s, 583,334 JDBC queries (same JSON shape)
```

Three independent subsystems were each rediscovering (or failing to discover) this fact on their
own, with each one only patched piecemeal so far:

1. `FieldFilterService.applyAccess`/`applySharingDisplayNames` (via `FieldPathHelper.visitFieldPath`)
   — fixed narrowly by #24514 (DHIS2-21867).
2. `DefaultLinkService.generateLink`, gated by `AbstractFullReadOnlyController.hasHref` — a raw
   substring check on the *unparsed* `fields` string (`fields.contains("*")`) that can't tell a
   top-level wildcard from one nested four levels deep inside `users[*]`. This is what produces the
   583k-query trace above: `generateLink` reflectively invokes **every** `IdentifiableObject`
   getter on the schema when `deep=true`, including `UserRole.getUsers()`, and runs *before*
   field-filtering ever gets a chance to matter. **Not fixed by #24514** (different class), **not
   fixed by #24512** (`LinkService` runs before that fix's insertion point — called out as
   explicitly out of scope in that PR's own commit message).
3. Jackson's actual serialization, which legitimately needs to enumerate the collection once — not
   addressed here, and not the source of the catastrophic cost.

## Root cause, generalized

`FieldPathHelper.apply()` generates descendant field paths under a transformer-controlled property
in the first place. Confirmed via `FieldFilterParser.parse("users[*]")` → `users`, `users.:all`,
which `apply()` then expands into one leaf per property on the *target* schema, recursively
(`users.organisationUnits.id`, `users.userRoles.id`, ...). Every consumer of the expanded list has
to independently re-derive "am I under a `PropertyTransformer`" and defensively skip it — which is
exactly the "too specific and hard to maintain" pattern the team flagged on #24512.

## Fix

- **`FieldPathHelper.apply()`** now prunes any path beneath a `PropertyTransformer`-annotated
  property as a final step, before any consumer ever sees the list. The property's own bare path
  always survives (`path.parent() == null` → loop never runs → not pruned). Confirmed safe for
  serialization: `UserPropertyTransformer`'s `UserDto` has no `@JsonFilter`, so its fields already
  serialized unconditionally regardless of what was in `includePaths` — pruning `users.id` etc.
  changes nothing observable, which is also *why* the earlier curl tests came back byte-identical.
- **`AbstractFullReadOnlyController.hasHref`** now asks the real, now-pruned field-path expansion
  instead of substring-matching — correct for every phrasing (`href`, `id,href`, `*`, `:all`,
  `:simple`, `users[href]`, `users[*]`) with no special-casing required. `fieldsContains` is
  deleted.

This makes #24514's `visitFieldPath` check redundant in practice (the paths it guards against no
longer exist to visit) but harmless to keep as defense-in-depth — no conflict, different methods in
the same file.

**Supersedes #24512** (DHIS2-21860), which the team judged too specific/hard to maintain (a
per-entity raw-SQL projection plus a `beforeLinkGeneration` controller hook, both needed per
entity type). This fixes the shared root for every `@PropertyTransformer` site with one change.
Recommend closing #24512 once this merges.

## Process notes (things I got wrong first, and how they were caught)

- First draft of `hasHref` only matched a *top-level* `href` path. That broke legitimate nested
  cases (`userRoles[*]` on `/users/{id}` stopped generating `href` on the role objects) —
  caught immediately by `testGetObjectHrefGeneratedForNonTransformerNestedCollection`. Root cause:
  `generateLink`'s `deepScan` stamps `href` on *every* `IdentifiableObject` property when
  `deep=true`, not just ones matching the request; `hasHref` is a coarse "is `href` needed
  anywhere" gate, not itself the per-object filter (`includePaths` handles that later). Fixed by
  checking `href` at any depth — safe because pruning already removed anything under a
  transformer property, so any surviving `href` path is one that could genuinely appear.
- First draft of the controller regression test asserted on JSON *content* (`href` absent). That
  test was **vacuous** — passed identically with the bug present or fixed, since
  `UserPropertyTransformer`'s output is byte-identical either way by construction (see the curl
  evidence above). Caught by mutation-testing the test itself (temporarily reverted the fix, test
  still passed). Replaced with an output-*invariance* test (correctness only, explicitly documented
  as not detecting the N+1) plus the mutation-verified positive case above, which does detect a
  broken rewrite.

## Test plan

- [x] `FieldPathHelperPropertyTransformerPruningTest` (new, `dhis-service-field-filtering`): `apply()`
  on a hand-built schema with a `@PropertyTransformer` property, fed `members[*]`,
  `members[id,extra]`, bare `members` — asserts the result is exactly `[members]` in all three
  cases. No Spring context needed (same pattern as #24514's `FieldPathHelperVisitFieldPathTest`).
- [x] `AbstractCrudControllerTest#testGetObjectPropertyTransformerFieldsAreInvariant` — output
  correctness only (documented as such; real regression protection is the unit test above).
- [x] `AbstractCrudControllerTest#testGetObjectHrefGeneratedForNonTransformerNestedCollection` —
  mutation-tested (fails when `hasHref` is stubbed to `false`, passes against the real fix).
- [x] Full regression pass: `dhis-service-field-filtering` suite, `AbstractCrudControllerTest`,
  `OrganisationUnitControllerTest`, `UserControllerTest`, `FieldFilterServiceTest`,
  `SharingControllerTest`, `DataSetControllerTest`, `DataElementControllerTest` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

