### PR TITLE
fix: add JSON auth/updatePassword endpoint for expired passwords [DHIS2-21120] (2.41)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserAccountService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserAccountService.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.common.auth.RegistrationParams;
 import org.hisp.dhis.common.auth.UserInviteParams;
 import org.hisp.dhis.common.auth.UserRegistrationParams;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
 
 /**
  * Service that handles user account activities, e.g. create/update account. The Validation can be
@@ -81,4 +82,25 @@ public interface UserAccountService {
    */
   void validateInvitedUser(RegistrationParams params, String remoteIpAddress)
       throws BadRequestException, IOException;
+
+  /**
+   * Self-service change of an <b>expired</b> password. The caller is not logged in, so the method
+   * is self-guarding: it only proceeds for an expired account whose current password is supplied
+   * correctly. It deliberately does not establish a session; once the password is changed the
+   * account is no longer expired, and the caller logs in through the regular login endpoint.
+   *
+   * <p>The current-password check runs <b>before</b> the expiry check, so "Account is not expired"
+   * can only be observed by a caller who already knows the password (no username enumeration), and
+   * repeated attempts against one account are throttled via the shared account-recovery lockout
+   * (mirrors the forgot-password flow).
+   *
+   * @param username username identifying the account
+   * @param oldPassword the current (expired) password
+   * @param newPassword new password, subject to the password policy
+   * @throws BadRequestException when input is missing, credentials are wrong, the account is not
+   *     expired, or the new password is not acceptable
+   * @throws ForbiddenException when the account is temporarily locked due to too many attempts
+   */
+  void updateExpiredPassword(String username, String oldPassword, String newPassword)
+      throws BadRequestException, ForbiddenException;
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserAccountService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserAccountService.java
@@ -33,12 +33,15 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.auth.RegistrationParams;
 import org.hisp.dhis.common.auth.UserInviteParams;
 import org.hisp.dhis.common.auth.UserRegistrationParams;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.security.PasswordManager;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationProvider;
 import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetails;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -58,11 +61,20 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DefaultUserAccountService implements UserAccountService {
 
+  /**
+   * Valid bcrypt hash (of a random string, same cost as the configured encoder) used to spend one
+   * password verification on the unknown-username path of {@link #updateExpiredPassword}, so that
+   * unknown and known usernames respond in similar time (no enumeration via timing).
+   */
+  private static final String TIMING_EQUALIZATION_HASH =
+      "$2a$10$4TXauPu06PhCTK8Up3oHi.0Y7SXLeu8ISJ6jq1GYpaaQOsSL5FOxG";
+
   private final UserService userService;
   private final ConfigurationService configService;
   private final TwoFactorAuthenticationProvider twoFactorAuthProvider;
   private final SystemSettingManager systemSettingManager;
   private final PasswordValidationService passwordValidationService;
+  private final PasswordManager passwordManager;
 
   private static final int MAX_LENGTH = 80;
 
@@ -125,6 +137,85 @@ public class DefaultUserAccountService implements UserAccountService {
     log.info("User invitation accepted");
 
     authenticate(user.getUsername(), params.getPassword(), user.getAuthorities(), request);
+  }
+
+  @Override
+  @Transactional
+  public void updateExpiredPassword(String username, String oldPassword, String newPassword)
+      throws BadRequestException, ForbiddenException {
+    if (StringUtils.isBlank(username)
+        || StringUtils.isBlank(oldPassword)
+        || StringUtils.isBlank(newPassword)) {
+      throw new BadRequestException("Username, old password and new password are required");
+    }
+
+    User user = userService.getUserByUsername(username);
+    if (user == null) {
+      // Generic message on purpose: do not reveal whether the username exists. Spend one password
+      // verification (result deliberately ignored) so this path takes as long as the known-user
+      // path below and the timing does not reveal it either.
+      passwordManager.matches(oldPassword, TIMING_EQUALIZATION_HASH);
+      throw new BadRequestException("Invalid username or password");
+    }
+
+    // Throttle repeated attempts against a single account (brute-force protection), reusing the
+    // account-recovery lockout. Registers an attempt and rejects once the threshold is exceeded.
+    checkRecoveryLock(user.getUsername());
+
+    // Caller must know the current (expired) password. Checked before the expiry guard below so
+    // that "Account is not expired" can only be observed by someone who knows the password.
+    if (!passwordManager.matches(oldPassword, user.getPassword())) {
+      throw new BadRequestException("Invalid username or password");
+    }
+
+    // This self-service path is ONLY for expired accounts.
+    if (userService.userNonExpired(user)) {
+      throw new BadRequestException("Account is not expired");
+    }
+
+    // The old password was verified against the stored hash above, so plain equality is enough.
+    if (newPassword.equals(oldPassword)) {
+      throw new BadRequestException("New password must be different from the old password");
+    }
+
+    validateNewPassword(user, newPassword);
+
+    userService.encodeAndSetPassword(user, newPassword);
+    userService.updateUser(user, new SystemUser());
+
+    log.info("Expired password updated for user: {}", user.getUsername());
+  }
+
+  /** Rejects a new password that is equal to the username or fails the password policy. */
+  private void validateNewPassword(User user, String newPassword) throws BadRequestException {
+    if (newPassword.trim().equals(user.getUsername().trim())) {
+      throw new BadRequestException("Password cannot be equal to username");
+    }
+
+    PasswordValidationResult result =
+        passwordValidationService.validate(
+            CredentialsInfo.builder()
+                .username(user.getUsername())
+                .password(newPassword)
+                .email(StringUtils.trimToEmpty(user.getEmail()))
+                .newUser(false)
+                .build());
+    if (!result.isValid()) {
+      throw new BadRequestException(result.getErrorMessage());
+    }
+  }
+
+  /** Registers a recovery attempt and rejects once the account has exceeded the allowed rate. */
+  private void checkRecoveryLock(String username) throws ForbiddenException {
+    if (userService.isRecoveryLocked(username)) {
+      throw new ForbiddenException(
+          "The account recovery operation for the given user is temporarily locked due to too "
+              + "many calls to this endpoint in the last '"
+              + UserService.RECOVERY_LOCKOUT_MINS
+              + "' minutes. Username:"
+              + username);
+    }
+    userService.registerRecoveryAttempt(username);
   }
 
   private User validateRestoreLinkAndToken(UserInviteParams params) throws BadRequestException {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserAccountService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserAccountService.java
@@ -67,7 +67,7 @@ public class DefaultUserAccountService implements UserAccountService {
    * unknown and known usernames respond in similar time (no enumeration via timing).
    */
   private static final String TIMING_EQUALIZATION_HASH =
-      "$2a$10$4TXauPu06PhCTK8Up3oHi.0Y7SXLeu8ISJ6jq1GYpaaQOsSL5FOxG";
+      "$2a$10$4TXauPu06PhCTK8Up3oHi.0Y7SXLeu8ISJ6jq1GYpaaQOsSL5FOxG"; // NOSONAR not a secret
 
   private final UserService userService;
   private final ConfigurationService configService;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
@@ -90,7 +90,7 @@ class OpenApiControllerTest extends DhisControllerConvenienceTest {
     assertTrue(
         doc.getObject("paths")
             .has("/users/gist", "/users/invite", "/users/invites", "/users/sharing"));
-    assertLessOrEqual(152, doc.getObject("paths").size());
+    assertLessOrEqual(153, doc.getObject("paths").size());
     assertLessOrEqual(60, doc.getObject("components.schemas").size());
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import java.util.Calendar;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -179,6 +180,214 @@ class UserAccountControllerTest extends DhisControllerConvenienceTest {
     boolean passwordMatch = passwordEncoder.matches(newPassword, updatedUser.getPassword());
 
     assertTrue(passwordMatch);
+  }
+
+  @Test
+  @DisplayName("Expired user changes password via auth/updatePassword and it is persisted")
+  void testUpdatePasswordExpiredOk() {
+    String oldPassword = "Str0ng_old_1!";
+    String newPassword = "Str0ng_new_1!";
+    User user = createExpiredUser("expireda", oldPassword);
+    clearSecurityContext();
+
+    assertWebMessage(
+        "OK",
+        200,
+        "OK",
+        "Password updated",
+        POST(
+                "/auth/updatePassword",
+                "{'username':'%s','oldPassword':'%s','newPassword':'%s'}"
+                    .formatted(user.getUsername(), oldPassword, newPassword))
+            .content(HttpStatus.OK));
+
+    User updated = userService.getUserByUsername(user.getUsername());
+    assertTrue(passwordEncoder.matches(newPassword, updated.getPassword()));
+    // The account is no longer expired, so the frontend's follow-up auth/login will succeed.
+    assertTrue(userService.userNonExpired(updated));
+  }
+
+  @Test
+  @DisplayName("Non-expired account is rejected only when the correct password is supplied")
+  void testUpdatePasswordNonExpired() {
+    String oldPassword = "Str0ng_old_1!";
+    User user = createUserWithAuth("nonexpired");
+    userService.encodeAndSetPassword(user, oldPassword);
+    userService.updateUser(user);
+    clearSecurityContext();
+
+    assertWebMessage(
+        "Bad Request",
+        400,
+        "ERROR",
+        "Account is not expired",
+        POST(
+                "/auth/updatePassword",
+                "{'username':'%s','oldPassword':'%s','newPassword':'Str0ng_new_1!'}"
+                    .formatted(user.getUsername(), oldPassword))
+            .content(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  @DisplayName(
+      "Non-expired account with wrong password gets the generic message, not the expiry hint")
+  void testUpdatePasswordNonExpiredWrongPasswordIsGeneric() {
+    User user = createUserWithAuth("nonexpiredwrong");
+    userService.encodeAndSetPassword(user, "Str0ng_old_1!");
+    userService.updateUser(user);
+    clearSecurityContext();
+
+    assertWebMessage(
+        "Bad Request",
+        400,
+        "ERROR",
+        "Invalid username or password",
+        POST(
+                "/auth/updatePassword",
+                "{'username':'%s','oldPassword':'WR0ng_pw_9!','newPassword':'Str0ng_new_1!'}"
+                    .formatted(user.getUsername()))
+            .content(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  @DisplayName("Wrong old password is rejected with a generic message")
+  void testUpdatePasswordWrongOldPassword() {
+    User user = createExpiredUser("expiredb", "Str0ng_old_1!");
+    clearSecurityContext();
+
+    assertWebMessage(
+        "Bad Request",
+        400,
+        "ERROR",
+        "Invalid username or password",
+        POST(
+                "/auth/updatePassword",
+                "{'username':'%s','oldPassword':'WR0ng_pw_9!','newPassword':'Str0ng_new_1!'}"
+                    .formatted(user.getUsername()))
+            .content(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  @DisplayName("Unknown username is rejected with the same generic message (no enumeration)")
+  void testUpdatePasswordUnknownUser() {
+    clearSecurityContext();
+
+    assertWebMessage(
+        "Bad Request",
+        400,
+        "ERROR",
+        "Invalid username or password",
+        POST(
+                "/auth/updatePassword",
+                "{'username':'no_such_user','oldPassword':'x','newPassword':'Str0ng_new_1!'}")
+            .content(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  @DisplayName("Missing fields are rejected")
+  void testUpdatePasswordMissingFields() {
+    clearSecurityContext();
+
+    assertWebMessage(
+        "Bad Request",
+        400,
+        "ERROR",
+        "Username, old password and new password are required",
+        POST("/auth/updatePassword", "{'username':'admin'}").content(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  @DisplayName("New password equal to username is rejected")
+  void testUpdatePasswordEqualToUsername() {
+    String oldPassword = "Str0ng_old_1!";
+    User user = createExpiredUser("expiredc", oldPassword);
+    clearSecurityContext();
+
+    assertWebMessage(
+        "Bad Request",
+        400,
+        "ERROR",
+        "Password cannot be equal to username",
+        POST(
+                "/auth/updatePassword",
+                "{'username':'%s','oldPassword':'%s','newPassword':'%s'}"
+                    .formatted(user.getUsername(), oldPassword, user.getUsername()))
+            .content(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  @DisplayName("Weak new password is rejected by the password policy")
+  void testUpdatePasswordWeakNewPassword() {
+    String oldPassword = "Str0ng_old_1!";
+    User user = createExpiredUser("expiredd", oldPassword);
+    clearSecurityContext();
+
+    assertWebMessage(
+        "Bad Request",
+        400,
+        "ERROR",
+        "Password must have at least one digit",
+        POST(
+                "/auth/updatePassword",
+                "{'username':'%s','oldPassword':'%s','newPassword':'tester-dhis'}"
+                    .formatted(user.getUsername(), oldPassword))
+            .content(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  @DisplayName("New password equal to the old password is rejected")
+  void testUpdatePasswordSameAsOld() {
+    String oldPassword = "Str0ng_old_1!";
+    User user = createExpiredUser("expirede", oldPassword);
+    clearSecurityContext();
+
+    assertWebMessage(
+        "Bad Request",
+        400,
+        "ERROR",
+        "New password must be different from the old password",
+        POST(
+                "/auth/updatePassword",
+                "{'username':'%s','oldPassword':'%s','newPassword':'%s'}"
+                    .formatted(user.getUsername(), oldPassword, oldPassword))
+            .content(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  @DisplayName("Repeated wrong-password attempts are throttled via the recovery lockout")
+  void testUpdatePasswordLocksAfterRepeatedFailures() {
+    systemSettingManager.saveSystemSetting(SettingKey.LOCK_MULTIPLE_FAILED_LOGINS, true);
+    User user = createUserWithAuth("bruteforce");
+    clearSecurityContext();
+
+    String body =
+        "{'username':'%s','oldPassword':'WR0ng_pw_9!','newPassword':'Str0ng_new_1!'}"
+            .formatted(user.getUsername());
+
+    // RECOVER_MAX_ATTEMPTS = 5: the first 6 attempts still reach the generic password error,
+    // the next one is rejected as locked (403).
+    for (int i = 0; i < 6; i++) {
+      assertEquals(HttpStatus.BAD_REQUEST, POST("/auth/updatePassword", body).status());
+    }
+    assertEquals(HttpStatus.FORBIDDEN, POST("/auth/updatePassword", body).status());
+  }
+
+  /**
+   * Creates a persisted user whose password is {@code password} but whose password-last-updated
+   * date is 2 months in the past, combined with a 1-month credential-expiry policy, so the account
+   * counts as expired for {@link org.hisp.dhis.user.UserService#userNonExpired(User)}.
+   */
+  private User createExpiredUser(String username, String password) {
+    systemSettingManager.saveSystemSetting(SettingKey.CREDENTIALS_EXPIRES, 1);
+
+    User user = createUserWithAuth(username);
+    userService.encodeAndSetPassword(user, password);
+
+    Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.MONTH, -2);
+    user.setPasswordLastUpdated(calendar.getTime());
+    userService.updateUser(user);
+    return user;
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
@@ -27,10 +27,13 @@
  */
 package org.hisp.dhis.webapi.controller.security;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Calendar;
@@ -47,6 +50,7 @@ import org.jboss.aerogear.security.otp.api.Base32;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.session.SessionRegistry;
 
 /**
@@ -232,6 +236,34 @@ class AuthenticationControllerTest extends DhisAuthenticationApiTest {
   }
 
   // test redirect to login page when not logged in, remember url befire login...
+
+  /**
+   * Verifies that {@code POST /api/auth/updatePassword} is part of the unauthenticated {@code
+   * permitAll} allowlist in {@link
+   * org.hisp.dhis.webapi.security.config.DhisWebApiWebSecurityConfig}: a user with an expired
+   * password is by definition not logged in, so the endpoint must be reachable anonymously. It is
+   * safe to expose because {@link org.hisp.dhis.user.UserAccountService#updateExpiredPassword} only
+   * proceeds for an expired account whose current password is supplied correctly.
+   *
+   * <p>The request is issued with raw {@code mvc.perform(...)} (not the {@code POST(...)} helper,
+   * which would attach the admin session) so the real filter chain is evaluated anonymously. The
+   * body omits the passwords, so the endpoint short-circuits with 400 (required fields) before any
+   * user lookup, which proves it was reached; a 302 redirect to the login page would mean it is not
+   * on the allowlist.
+   */
+  @Test
+  void testUpdatePasswordReachableWithoutAuthentication() throws Exception {
+    clearSecurityContext();
+
+    mvc.perform(
+            post("/auth/updatePassword")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"admin\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(
+            content()
+                .string(containsString("Username, old password and new password are required")));
+  }
 
   private void validateTOTP(String secret) {
     Totp totp = new Totp(secret);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UpdatePasswordRequest.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UpdatePasswordRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.security;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class UpdatePasswordRequest {
+  @JsonProperty private String username;
+  @JsonProperty private String oldPassword;
+  @JsonProperty private String newPassword;
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
@@ -204,6 +204,15 @@ public class UserAccountController {
     return ok("Account updated");
   }
 
+  @PostMapping("/updatePassword")
+  @ResponseStatus(HttpStatus.OK)
+  public WebMessageResponse updatePassword(@RequestBody UpdatePasswordRequest request)
+      throws BadRequestException, ForbiddenException {
+    userAccountService.updateExpiredPassword(
+        request.getUsername(), request.getOldPassword(), request.getNewPassword());
+    return ok("Password updated");
+  }
+
   private void checkRecoveryLock(String username) throws ForbiddenException {
     if (userService.isRecoveryLocked(username)) {
       throw new ForbiddenException(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -459,6 +459,8 @@ public class DhisWebApiWebSecurityConfig {
           .permitAll()
           .antMatchers(apiContextPath + "/**/auth/invite")
           .permitAll()
+          .antMatchers(apiContextPath + "/**/auth/updatePassword")
+          .permitAll()
           .antMatchers(apiContextPath + "/**/authentication/login")
           .permitAll()
           .antMatchers(apiContextPath + "/**/account/recovery")


### PR DESCRIPTION
## What

Adds `POST /api/auth/updatePassword` (JSON, `auth/*` family) so the Login app can change an **expired** password on this release line. Additive-only backport of #24355 — the legacy form-param `POST /api/account/password` is deliberately **left in place** here (its removal is master-only, see the backport note in #24355).

## Why

The 2.41 Login-app security rewrite dropped the `permitAll` entry for `POST /api/account/password`, so a user whose password expired (anonymous by definition) gets a 302 to the login page instead of reaching the handler — an effective lockout unless email recovery is configured or an admin resets the password (DHIS2-21120).

## How

- `UserAccountService.updateExpiredPassword` — single transaction, self-guarding: required fields → unknown user rejected generically (with a constant-cost bcrypt verification so timing does not reveal existence) → per-account throttle via the existing account-recovery lockout → **current password verified before the expiry check** (so "Account is not expired" is only observable knowing the password) → account must actually be expired → new password != old and != username → shared password-policy validation.
- `UpdatePasswordRequest` DTO + thin controller delegate on `UserAccountController`.
- `permitAll` for `/**/auth/updatePassword` in `DhisWebApiWebSecurityConfig` (2.41 `antMatchers` style).
- No auto-login: after the change the account un-expires and the frontend calls the regular `auth/login`.

Line note: 2.41 has no `UserAccountServiceTest` mock base in dhis-service-core, so the service guards are covered through the controller tests on this line; the return type follows this line's `WebMessageResponse` convention.

## Tests

- `AuthenticationControllerTest` — anonymous reachability through the real filter chain (fails with 302 before this patch).
- `UserAccountControllerTest` — happy path + expiry/old-password/enumeration/new≠old/policy/lockout cases.

AI Assisted
