### PR TITLE
fix: stop treating PWA icon filenames as content-hashed assets [DHIS2-21879]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlService.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import lombok.RequiredArgsConstructor;
@@ -63,6 +64,8 @@ public class StaticCacheControlService {
 
   private static final Pattern VITE_HASH =
       Pattern.compile("[-_]([a-zA-Z0-9_-]{7,12})\\.[a-z0-9]{2,5}$");
+
+  private static final Pattern DIMENSIONS_TOKEN = Pattern.compile("\\d+x\\d+");
 
   private final DhisConfigurationProvider config;
   private final AppManager appManager;
@@ -218,7 +221,24 @@ public class StaticCacheControlService {
    */
   static boolean looksLikeHashedFilename(String uri) {
     if (WEBPACK_HASH.matcher(uri).find()) return true;
-    return VITE_HASH.matcher(uri).find();
+    Matcher matcher = VITE_HASH.matcher(uri);
+    return matcher.find() && !isFalsePositiveHashToken(matcher.group(1));
+  }
+
+  /**
+   * Filters out common unhashed filename patterns that happen to fit the Vite hash shape, such as
+   * PWA icon names like {@code apple-touch-icon.png} (lowercase word chains) and {@code
+   * mstile-150x150.png} (pixel dimensions). See DHIS2-21879.
+   */
+  private static boolean isFalsePositiveHashToken(String token) {
+    if (DIMENSIONS_TOKEN.matcher(token).matches()) return true;
+    boolean hasSeparator = token.indexOf('-') >= 0 || token.indexOf('_') >= 0;
+    if (!hasSeparator) return false;
+    for (int i = 0; i < token.length(); i++) {
+      char c = token.charAt(i);
+      if (Character.isDigit(c) || Character.isUpperCase(c)) return false;
+    }
+    return true;
   }
 
   private boolean isHtmlPath(String uri) {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/HtmlCacheBustingServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/HtmlCacheBustingServiceTest.java
@@ -412,6 +412,27 @@ class HtmlCacheBustingServiceTest {
   }
 
   @Test
+  @DisplayName("Rewrites PWA icon links that resemble hashed filenames")
+  void rewritesPwaIconLinks() throws IOException {
+    String html =
+        "<html><head>"
+            + "<link href=\"apple-touch-icon.png\" rel=\"apple-touch-icon\">"
+            + "<link href=\"safari-pinned-tab.svg\" rel=\"mask-icon\">"
+            + "<link href=\"mstile-150x150.png\" rel=\"icon\">"
+            + "<script src=\"assets/main-Dhu2pmiS.js\"></script>"
+            + "</head></html>";
+    App app = appWithCacheBustKey("abc123");
+
+    String result = rewrite(html, app, "/apps/my-app/index.html");
+
+    assertThat(result, containsString("href=\"apple-touch-icon.png?v=abc123\""));
+    assertThat(result, containsString("href=\"safari-pinned-tab.svg?v=abc123\""));
+    assertThat(result, containsString("href=\"mstile-150x150.png?v=abc123\""));
+    assertThat(result, containsString("src=\"assets/main-Dhu2pmiS.js\""));
+    assertThat(result, not(containsString("main-Dhu2pmiS.js?v=")));
+  }
+
+  @Test
   @DisplayName("invalidateAll clears the cache")
   void invalidateAllClearsCache() {
     service.invalidateAll();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlServiceTest.java
@@ -47,6 +47,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -191,13 +193,22 @@ class StaticCacheControlServiceTest {
     assertThat(cc, containsString("immutable"));
   }
 
-  @Test
-  @DisplayName("Normal multi-dash filename is NOT treated as hashed")
-  void multiDash_normalFilename_notHashed() {
+  @ParameterizedTest(name = "Unhashed filename {0} is NOT treated as hashed")
+  @ValueSource(
+      strings = {
+        "/apps/dashboard/app-dashboard-plugin.js",
+        "/apps/login/apple-touch-icon.png",
+        "/apps/login/safari-pinned-tab.svg",
+        "/apps/mstile-150x150.png",
+        "/apps/android-chrome-192x192.png"
+      })
+  void unhashedFilename_notTreatedAsHashed(String uri) {
     MockHttpServletResponse response = new MockHttpServletResponse();
-    service.setHeaders(response, "/apps/dashboard/app-dashboard-plugin.js", null, null);
+    service.setHeaders(response, uri, null, null);
 
-    assertThat(response.getHeader("Cache-Control"), containsString("max-age=3600"));
+    String cc = response.getHeader("Cache-Control");
+    assertThat(cc, not(containsString("immutable")));
+    assertThat(cc, containsString("max-age=3600"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes false-positive content-hash detection for common PWA icon filenames in the static cache layer.

## Problem

The Vite hash regex matched ordinary hyphenated names like `apple-touch-icon.png` (capture `touch-icon`), `safari-pinned-tab.svg` (`pinned-tab`) and `mstile-150x150.png` (`150x150`). These unhashed icons got `max-age=31536000, immutable` AND were excluded from the `?v=` HTML cache busting (skip from #23554), so a changed icon could stay stale in browsers for up to a year after an upgrade. Verified live on play.im.dhis2.org/dev.

## Fix

`looksLikeHashedFilename` now rejects capture tokens that are pixel dimensions (`\d+x\d+`) or lowercase word chains (contain `-`/`_` but no digit and no uppercase). Real Vite hashes (`Dhu2pmiS`, `D-tfNpnx`, `B6NG_BIY`, `zwggxcug`) still match. The HTML busting skip is intentionally kept tag-agnostic so `modulepreload` links keep matching the import graph exactly.

## Testing

New unit tests for the four icon names (Cache-Control) and icon link busting (HTML rewrite); all failed before the fix, green after. Full `StaticCacheControlServiceTest` + `HtmlCacheBustingServiceTest` pass.

JIRA: [DHIS2-21879](https://dhis2.atlassian.net/browse/DHIS2-21879) (relates to [DHIS2-21125](https://dhis2.atlassian.net/browse/DHIS2-21125))


[DHIS2-21879]: https://dhis2.atlassian.net/browse/DHIS2-21879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ