### PR TITLE
fix: set Cache-Control on core static resources under context-path deployments [DHIS2-21880]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/staticresource/StaticCacheInterceptor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/staticresource/StaticCacheInterceptor.java
@@ -39,7 +39,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
  * Spring MVC interceptor that sets {@code Cache-Control} headers for core DHIS2 static resources
  * served from classpath JARs ({@code /dhis-web-commons/**}, {@code /icons/**}, {@code /images/**},
  * etc.). These resources are handled by Spring's {@code ResourceHttpRequestHandler} and this
- * interceptor works in both embedded Tomcat and WAR deployment modes.
+ * interceptor works in both embedded Tomcat and WAR deployment modes. Paths are matched relative to
+ * the servlet context path so matching also works for deployments under a non-root context path.
  *
  * <p>App resources ({@code /apps/**}) are handled directly by {@code AppController} which calls
  * {@code StaticCacheControlService} itself, so this interceptor does not need to cover those paths.
@@ -53,11 +54,25 @@ public class StaticCacheInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
-    String uri = request.getRequestURI();
-    if (isCoreStaticPath(uri)) {
-      staticCacheControlService.setHeaders(response, uri, request.getQueryString(), null);
+    String path = getPathWithinApplication(request);
+    if (isCoreStaticPath(path)) {
+      staticCacheControlService.setHeaders(response, path, request.getQueryString(), null);
     }
     return true;
+  }
+
+  /**
+   * Returns the request URI relative to the servlet context path. The URI from {@link
+   * HttpServletRequest#getRequestURI()} includes the context path, which would break the core
+   * static path matching on deployments under a non-root context path (DHIS2-21880).
+   */
+  private static String getPathWithinApplication(HttpServletRequest request) {
+    String uri = request.getRequestURI();
+    String contextPath = request.getContextPath();
+    if (contextPath != null && !contextPath.isEmpty() && uri.startsWith(contextPath)) {
+      return uri.substring(contextPath.length());
+    }
+    return uri;
   }
 
   private boolean isCoreStaticPath(String uri) {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/StaticCacheInterceptorTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/StaticCacheInterceptorTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.staticresource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Unit tests for {@link StaticCacheInterceptor}, in particular that core static paths are matched
+ * relative to the servlet context path so cache headers are also set on deployments under a
+ * non-root context path (DHIS2-21880).
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@ExtendWith(MockitoExtension.class)
+class StaticCacheInterceptorTest {
+
+  @Mock private StaticCacheControlService staticCacheControlService;
+
+  private StaticCacheInterceptor interceptor;
+
+  private final Object handler = new Object();
+
+  @BeforeEach
+  void setUp() {
+    interceptor = new StaticCacheInterceptor(staticCacheControlService);
+  }
+
+  @ParameterizedTest(
+      name = "Core static URI {1} under context path \"{0}\" gets cache headers for {2}")
+  @CsvSource({
+    "'', /dhis-web-commons/css/style.css, /dhis-web-commons/css/style.css",
+    "/dhis, /dhis/dhis-web-commons/css/style.css, /dhis-web-commons/css/style.css",
+    "/dhis, /dhis/favicon.ico, /favicon.ico",
+    "/dhis, /dhis/icons/star.png, /icons/star.png"
+  })
+  void coreStaticPath_setsHeaders(String contextPath, String requestUri, String expectedPath) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContextPath(contextPath);
+    request.setRequestURI(requestUri);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assertTrue(interceptor.preHandle(request, response, handler));
+
+    verify(staticCacheControlService).setHeaders(response, expectedPath, null, null);
+  }
+
+  @Test
+  @DisplayName("Non-static path does not get cache headers")
+  void nonStaticPath_doesNotSetHeaders() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContextPath("/dhis");
+    request.setRequestURI("/dhis/api/dataElements");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assertTrue(interceptor.preHandle(request, response, handler));
+
+    verify(staticCacheControlService, never())
+        .setHeaders(any(MockHttpServletResponse.class), anyString(), any(), any());
+  }
+}


### PR DESCRIPTION
## Summary

Makes the core static resource cache headers work on deployments under a non-root context path.

## Problem

`StaticCacheInterceptor.isCoreStaticPath()` compared `request.getRequestURI()`, which includes the servlet context path, against absolute prefixes like `/dhis-web-`. Under a context path (e.g. `/dev`) the check never matched, so `/dhis-web-commons/**`, `/icons/**`, `/images/**` and `/favicon.ico` were served with no `Cache-Control` at all, silently disabling the core-static half of DHIS2-21125. Verified live on play.im.dhis2.org/dev (context path `/dev`).

## Fix

The interceptor strips the context path and uses the app-relative path for both the prefix check and the `setHeaders` call, so behavior is identical for root and sub-path deployments.

## Testing

New `StaticCacheInterceptorTest`: the context-path cases failed on unmodified code (confirming the root cause) and pass after the fix; root-path and negative cases covered. Regression: `StaticCacheControlServiceTest` + `HtmlCacheBustingServiceTest` pass.

JIRA: [DHIS2-21880](https://dhis2.atlassian.net/browse/DHIS2-21880) (relates to [DHIS2-21125](https://dhis2.atlassian.net/browse/DHIS2-21125))


[DHIS2-21880]: https://dhis2.atlassian.net/browse/DHIS2-21880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ