### PR TITLE
fix: apply no-store to directory URL HTML entry points [DHIS2-21881]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlService.java
@@ -111,6 +111,11 @@ public class StaticCacheControlService {
 
   private CacheControl computeCacheControl(
       String uri, @CheckForNull String queryString, AppCacheConfig config) {
+    // Directory URLs serve the index.html entry point, normalize so the same cache rules
+    // apply to both forms of the URL (DHIS2-21881)
+    if (uri.endsWith("/")) {
+      uri = uri + "index.html";
+    }
     if (matchesAnyNoCachePattern(uri) || matchesNoCacheRule(uri, config)) {
       return CacheControl.noStore();
     }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/staticresource/StaticCacheControlServiceTest.java
@@ -114,6 +114,43 @@ class StaticCacheControlServiceTest {
   }
 
   @Test
+  @DisplayName("Directory URL serving index.html returns no-store")
+  void directoryUrl_returnsNoStore() {
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    service.setHeaders(response, "/login/", null, null);
+
+    assertThat(response.getHeader("Cache-Control"), containsString("no-store"));
+  }
+
+  @Test
+  @DisplayName("App directory URL returns no-store")
+  void appDirectoryUrl_returnsNoStore() {
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    service.setHeaders(response, "/apps/login/", null, null);
+
+    assertThat(response.getHeader("Cache-Control"), containsString("no-store"));
+  }
+
+  @Test
+  @DisplayName("App no-cache rule matches directory URL via index.html normalization")
+  void appNoCacheRule_matchesDirectoryUrl() {
+    when(config.getProperty(ConfigurationKey.STATIC_CACHE_ALWAYS_NO_CACHE_PATTERNS)).thenReturn("");
+
+    App app = new App();
+    app.setName("my-app");
+    app.setShortName("my-app");
+    CacheRule rule = new CacheRule("**/index.html", 0, null, null);
+    app.setCacheConfig(new AppCacheConfig(List.of(rule), null, null));
+
+    when(appManager.getApp("my-app")).thenReturn(app);
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    service.setHeaders(response, "/apps/my-app/", null, "my-app");
+
+    assertThat(response.getHeader("Cache-Control"), containsString("no-store"));
+  }
+
+  @Test
   @DisplayName("Regular JS file gets default max-age with public caching")
   void regularJsFile_getsDefaultMaxAge() {
     MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
## Summary

Directory URLs serving HTML entry points now get the same `no-store` policy as their `index.html` form.

## Problem

`/login/` returned `max-age=300, must-revalidate, public` while `/login/index.html` returned `no-store`: a URI ending in `/` matches none of the `always_no_cache_patterns` (`**/*.html`, `**/index.*`, ...). After an upgrade, users hitting the directory URL could see a stale login shell for up to 5 minutes. Verified live on play.im.dhis2.org/dev.

## Fix

`computeCacheControl` normalizes URIs ending in `/` to their `index.html` form before any rule matching (mirrors what the controller actually serves), so global patterns and per-app rules apply to both URL forms.

## Testing

New unit tests: `/login/` and `/apps/login/` return `no-store`; app-level no-cache rules also match directory URLs. All failed before the fix, green after. Regression: `StaticCacheControlServiceTest` + `HtmlCacheBustingServiceTest` pass.

JIRA: [DHIS2-21881](https://dhis2.atlassian.net/browse/DHIS2-21881) (relates to [DHIS2-21125](https://dhis2.atlassian.net/browse/DHIS2-21125))


[DHIS2-21881]: https://dhis2.atlassian.net/browse/DHIS2-21881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-21125]: https://dhis2.atlassian.net/browse/DHIS2-21125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ