### PR TITLE
revert: backport DataElement.optionSet Hibernate mapping fix to 2.43

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseMetadataObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseMetadataObject.java
@@ -41,10 +41,8 @@ import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import jakarta.persistence.Transient;
-import java.io.Serializable;
 import java.util.Date;
 import lombok.Setter;
-import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.common.annotation.Description;
 import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.schema.annotation.Gist;
@@ -62,11 +60,10 @@ import org.hisp.dhis.user.User;
  * database columns.
  */
 @MappedSuperclass
-public class BaseMetadataObject implements MetadataObject, Serializable {
+public class BaseMetadataObject implements MetadataObject {
 
   @Column(name = "uid", unique = true, nullable = false, length = 11)
   @Setter
-  @AuditAttribute
   protected String uid;
 
   @Column(name = "created", nullable = false, updatable = false)
@@ -100,7 +97,7 @@ public class BaseMetadataObject implements MetadataObject, Serializable {
   @Transient @Setter protected String href;
 
   /** Access information for this object. Applies to current user. */
-  @Transient @Setter protected transient Access access;
+  @Transient @Setter protected Access access;
 
   // -------------------------------------------------------------------------------------------
   // Getters

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DataDimensionItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DataDimensionItem.java
@@ -337,7 +337,7 @@ public class DataDimensionItem {
   }
 
   @JsonProperty
-  @JsonSerialize(as = NameableObject.class)
+  @JsonSerialize(as = BaseNameableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public DataElement getDataElement() {
     return dataElement;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PrefixedDimensions.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PrefixedDimensions.java
@@ -71,7 +71,7 @@ public class PrefixedDimensions {
   }
 
   public static Collection<PrefixedDimension> ofItemsWithProgram(
-      Program program, Collection<? extends IdentifiableObject> objects) {
+      Program program, Collection<? extends BaseIdentifiableObject> objects) {
     return objects.stream()
         .map(item -> PrefixedDimension.builder().item(item).program(program).build())
         .collect(Collectors.toList());

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -35,36 +35,13 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.hisp.dhis.common.DimensionConstants.TEXTVALUE_COLUMN_NAME;
 import static org.hisp.dhis.common.DimensionConstants.VALUE_COLUMN_NAME;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import jakarta.persistence.Cacheable;
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderColumn;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -72,36 +49,17 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.Setter;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Type;
-import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.DataType;
-import org.hisp.dhis.attribute.AttributeValues;
-import org.hisp.dhis.attribute.AttributeValuesDeserializer;
-import org.hisp.dhis.attribute.AttributeValuesSerializer;
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.BaseIdentifiableObject.AttributeValue;
-import org.hisp.dhis.common.BaseMetadataObject;
 import org.hisp.dhis.common.DimensionItemType;
-import org.hisp.dhis.common.DimensionalItemObject;
-import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.IdentifiableProperty;
 import org.hisp.dhis.common.MetadataObject;
-import org.hisp.dhis.common.NameableObject;
 import org.hisp.dhis.common.ObjectStyle;
-import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.QueryModifiers;
-import org.hisp.dhis.common.Sortable;
-import org.hisp.dhis.common.TotalAggregationType;
-import org.hisp.dhis.common.TranslationProperty;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.common.ValueTypeOptions;
 import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
@@ -109,170 +67,66 @@ import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetElement;
 import org.hisp.dhis.dataset.comparator.DataSetApprovalFrequencyComparator;
 import org.hisp.dhis.dataset.comparator.DataSetFrequencyComparator;
-import org.hisp.dhis.hibernate.HibernateProxyUtils;
-import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.schema.PropertyType;
-import org.hisp.dhis.schema.annotation.Gist;
-import org.hisp.dhis.schema.annotation.Gist.Include;
 import org.hisp.dhis.schema.annotation.Property;
 import org.hisp.dhis.schema.annotation.PropertyRange;
-import org.hisp.dhis.translation.Translatable;
-import org.hisp.dhis.translation.Translation;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.sharing.Sharing;
-import org.hisp.dhis.user.sharing.UserAccess;
-import org.hisp.dhis.user.sharing.UserGroupAccess;
 
 /**
  * @author Kristian Nordal
  */
-@Setter
-@Entity
-@Table(name = "dataelement")
-@Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @JacksonXmlRootElement(localName = "dataElement", namespace = DxfNamespaces.DXF_2_0)
-public class DataElement extends BaseMetadataObject
-    implements DimensionalItemObject,
-        NameableObject,
-        MetadataObject,
-        ValueTypedDimensionalItemObject {
-
-  @Id
-  @GeneratedValue(strategy = GenerationType.SEQUENCE)
-  @Column(name = "dataelementid")
-  private long id;
-
-  @Column(name = "code", unique = true, length = 50)
-  @AuditAttribute
-  private String code;
-
-  @Column(name = "name", nullable = false, unique = true, length = 230)
-  private String name;
-
-  @Column(name = "shortname", nullable = false, unique = true, length = 50)
-  private String shortName;
-
-  @Column(name = "description", columnDefinition = "text")
-  private String description;
-
-  @Column(name = "formname", length = 230)
-  private String formName;
-
-  @Embedded private TranslationProperty translations = new TranslationProperty();
-
-  /** The style defines how the DataElement should be represented on clients */
-  @Type(type = "jbObjectStyle")
-  private ObjectStyle style;
-
-  /**
-   * Field mask represent how the value should be formatted during input. This string will be
-   * validated as a TextPatternSegment of type TEXT.
-   */
-  @Column(name = "fieldmask")
-  private String fieldMask;
-
+public class DataElement extends BaseDimensionalItemObject
+    implements MetadataObject, ValueTypedDimensionalItemObject {
   /** Data element value type (int, boolean, etc) */
-  @Enumerated(EnumType.STRING)
-  @Column(name = "valueType", length = 50, nullable = false)
   private ValueType valueType;
 
   /** Abstract class representing options for value types. */
-  @Type(type = "jbValueTypeOptions")
   private ValueTypeOptions valueTypeOptions;
 
   /**
    * The domain of this DataElement; e.g. DataElementDomainType.AGGREGATE or
    * DataElementDomainType.TRACKER.
    */
-  @Enumerated(EnumType.STRING)
-  @Column(name = "domainType", nullable = false)
   private DataElementDomain domainType;
-
-  @Enumerated(EnumType.STRING)
-  @Column(name = "aggregationtype", length = 50, nullable = false)
-  private AggregationType aggregationType;
 
   /**
    * A combination of categories to capture data for this data element. Note that this category
    * combination could be overridden by data set elements which this data element is part of, see
    * {@link DataSetElement}.
    */
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(
-      name = "categorycomboid",
-      nullable = false,
-      foreignKey = @ForeignKey(name = "fk_dataelement_categorycomboid"))
   private CategoryCombo categoryCombo;
 
   /** URL for lookup of additional information on the web. */
-  @Column(name = "url")
   private String url;
 
   /** The data element groups which this data element is a member of. */
-  @ManyToMany(mappedBy = "members")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
   private Set<DataElementGroup> groups = new HashSet<>();
 
   /** The data sets which this data element is a member of. */
-  @OneToMany(mappedBy = "dataElement")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
   private Set<DataSetElement> dataSetElements = new HashSet<>();
 
   /** The lower organisation unit levels for aggregation. */
-  @ElementCollection
-  @CollectionTable(
-      name = "dataelementaggregationlevels",
-      joinColumns = @JoinColumn(name = "dataelementid"),
-      foreignKey = @ForeignKey(name = "fk_dataelementaggregationlevels_dataelementid"))
-  @Column(name = "aggregationlevel")
-  @OrderColumn(name = "sort_order")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
   private List<Integer> aggregationLevels = new ArrayList<>();
 
   /** Indicates whether to store zero data values. */
-  @Column(name = "zeroissignificant", nullable = false)
   private boolean zeroIsSignificant;
 
   /** The option set for data values linked to this data element, can be null. */
-  @AuditAttribute
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "optionsetid", foreignKey = @ForeignKey(name = "fk_dataelement_optionsetid"))
-  private OptionSet optionSet;
+  @AuditAttribute private OptionSet optionSet;
 
   /** The option set for comments linked to this data element, can be null. */
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(
-      name = "commentoptionsetid",
-      foreignKey = @ForeignKey(name = "fk_dataelement_commentoptionsetid"))
   private OptionSet commentOptionSet;
 
-  @ManyToMany
-  @JoinTable(
-      name = "dataelementlegendsets",
-      joinColumns = @JoinColumn(name = "dataelementid"),
-      inverseJoinColumns =
-          @JoinColumn(
-              name = "legendsetid",
-              foreignKey = @ForeignKey(name = "fk_dataelement_legendsetid")))
-  @OrderColumn(name = "sort_order")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
-  private List<LegendSet> legendSets = new ArrayList<>();
+  /** The style defines how the DataElement should be represented on clients */
+  private ObjectStyle style;
 
-  @AuditAttribute
-  @Type(type = "jsbAttributeValues")
-  private AttributeValues attributeValues = AttributeValues.empty();
-
-  @Type(type = "jsbObjectSharing")
-  private Sharing sharing = new Sharing();
-
-  // -------------------------------------------------------------------------
-  // Transient fields
-  // -------------------------------------------------------------------------
-
-  @Transient private transient QueryModifiers queryMods;
+  /**
+   * Field mask represent how the value should be formatted during input. This string will be
+   * validated as a TextPatternSegment of type TEXT.
+   */
+  private String fieldMask;
 
   // -------------------------------------------------------------------------
   // Constructors
@@ -283,34 +137,6 @@ public class DataElement extends BaseMetadataObject
   public DataElement(String name) {
     this();
     this.name = name;
-  }
-
-  // -------------------------------------------------------------------------
-  // hashCode and equals
-  // -------------------------------------------------------------------------
-
-  @Override
-  public boolean equals(Object obj) {
-    return this == obj
-        || obj instanceof DataElement other
-            && HibernateProxyUtils.getRealClass(this) == HibernateProxyUtils.getRealClass(obj)
-            && Objects.equals(getUid(), other.getUid())
-            && Objects.equals(getCode(), other.getCode())
-            && Objects.equals(getName(), other.getName())
-            && Objects.equals(getShortName(), other.getShortName())
-            && Objects.equals(getDescription(), other.getDescription())
-            && Objects.equals(queryMods, other.queryMods);
-  }
-
-  @Override
-  public int hashCode() {
-    int result = getUid() != null ? getUid().hashCode() : 0;
-    result = 31 * result + (getShortName() != null ? getShortName().hashCode() : 0);
-    result = 31 * result + (getDescription() != null ? getDescription().hashCode() : 0);
-    result = 31 * result + (getCode() != null ? getCode().hashCode() : 0);
-    result = 31 * result + (getName() != null ? getName().hashCode() : 0);
-    result = 31 * result + (queryMods != null ? queryMods.hashCode() : 0);
-    return result;
   }
 
   // -------------------------------------------------------------------------
@@ -513,7 +339,7 @@ public class DataElement extends BaseMetadataObject
   }
 
   // -------------------------------------------------------------------------
-  // DimensionalItemObject implementation
+  // DimensionalItemObject
   // -------------------------------------------------------------------------
 
   // TODO can also be dimension
@@ -521,246 +347,6 @@ public class DataElement extends BaseMetadataObject
   @Override
   public DimensionItemType getDimensionItemType() {
     return DimensionItemType.DATA_ELEMENT;
-  }
-
-  @Override
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public String getDimensionItem() {
-    return getUid();
-  }
-
-  @Override
-  public String getDimensionItem(IdScheme idScheme) {
-    return getPropertyValue(idScheme);
-  }
-
-  @Override
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public AggregationType getAggregationType() {
-    return (queryMods != null && queryMods.getAggregationType() != null)
-        ? queryMods.getAggregationType()
-        : aggregationType;
-  }
-
-  @Override
-  public boolean hasAggregationType() {
-    return aggregationType != null;
-  }
-
-  @Override
-  public TotalAggregationType getTotalAggregationType() {
-    return getAggregationType() == AggregationType.NONE
-        ? TotalAggregationType.NONE
-        : TotalAggregationType.SUM;
-  }
-
-  @Override
-  @JsonProperty
-  @JacksonXmlElementWrapper(localName = "legendSets", namespace = DxfNamespaces.DXF_2_0)
-  @JacksonXmlProperty(localName = "legendSets", namespace = DxfNamespaces.DXF_2_0)
-  public List<LegendSet> getLegendSets() {
-    return legendSets;
-  }
-
-  @Override
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public LegendSet getLegendSet() {
-    return legendSets.isEmpty() ? null : legendSets.get(0);
-  }
-
-  @Override
-  public boolean hasLegendSet() {
-    return !legendSets.isEmpty();
-  }
-
-  @Override
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public QueryModifiers getQueryMods() {
-    return queryMods;
-  }
-
-  // -------------------------------------------------------------------------
-  // IdentifiableObject implementation
-  // -------------------------------------------------------------------------
-
-  @Override
-  @JsonIgnore
-  public long getId() {
-    return id;
-  }
-
-  @Override
-  @JsonProperty
-  @JacksonXmlProperty(isAttribute = true)
-  @Property(PropertyType.IDENTIFIER)
-  public String getCode() {
-    return code;
-  }
-
-  @Override
-  @JsonProperty
-  @JacksonXmlProperty(isAttribute = true)
-  @PropertyRange(min = 1)
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  @Sortable(whenPersisted = false)
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  @Translatable(propertyName = "name", key = "NAME")
-  public String getDisplayName() {
-    return translations.getTranslation("NAME", name);
-  }
-
-  @JsonProperty
-  @Sortable(whenPersisted = false)
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  @Translatable(propertyName = "formName", key = "FORM_NAME")
-  public String getDisplayFormName() {
-    return translations.getTranslation(
-        "FORM_NAME", getFormName() != null ? getFormName() : getDisplayName());
-  }
-
-  @Override
-  @JsonProperty
-  @JacksonXmlElementWrapper(localName = "translations", namespace = DxfNamespaces.DXF_2_0)
-  @JacksonXmlProperty(localName = "translation", namespace = DxfNamespaces.DXF_2_0)
-  public Set<Translation> getTranslations() {
-    return translations.getTranslations();
-  }
-
-  @Override
-  public void setTranslations(Set<Translation> translations) {
-    this.translations.setTranslations(translations);
-  }
-
-  @Override
-  public void setUser(User user) {
-    setCreatedBy(createdBy == null ? user : createdBy);
-    setOwner(user != null ? user.getUid() : null);
-  }
-
-  @Override
-  @Sortable(value = false)
-  @Gist(included = Include.FALSE)
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public Sharing getSharing() {
-    return sharing;
-  }
-
-  @Override
-  @JsonIgnore
-  public String getPropertyValue(IdScheme idScheme) {
-    if (idScheme.isNull() || idScheme.is(IdentifiableProperty.UID)) {
-      return uid;
-    } else if (idScheme.is(IdentifiableProperty.CODE)) {
-      return code;
-    } else if (idScheme.is(IdentifiableProperty.ID)) {
-      return id > 0 ? String.valueOf(id) : null;
-    } else if (idScheme.is(IdentifiableProperty.NAME)) {
-      return name;
-    } else if (idScheme.is(IdentifiableProperty.ATTRIBUTE)) {
-      return attributeValues.get(idScheme.getAttribute());
-    }
-    return null;
-  }
-
-  @Override
-  @JsonIgnore
-  public String getDisplayPropertyValue(IdScheme idScheme) {
-    if (idScheme.is(IdentifiableProperty.NAME)) {
-      return getDisplayName();
-    } else {
-      return getPropertyValue(idScheme);
-    }
-  }
-
-  @Override
-  public void setOwner(String owner) {
-    getSharing().setOwner(owner);
-  }
-
-  // -------------------------------------------------------------------------
-  // AttributeValues
-  // -------------------------------------------------------------------------
-
-  @Override
-  @OpenApi.Property(AttributeValue[].class)
-  @JsonProperty("attributeValues")
-  @JsonDeserialize(using = AttributeValuesDeserializer.class)
-  @JsonSerialize(using = AttributeValuesSerializer.class)
-  public AttributeValues getAttributeValues() {
-    return attributeValues;
-  }
-
-  @Override
-  public void setAttributeValues(AttributeValues attributeValues) {
-    this.attributeValues = attributeValues == null ? AttributeValues.empty() : attributeValues;
-  }
-
-  @Override
-  public void addAttributeValue(String attributeId, String value) {
-    this.attributeValues = attributeValues.added(attributeId, value);
-  }
-
-  @Override
-  public void removeAttributeValue(String attributeId) {
-    this.attributeValues = attributeValues.removed(attributeId);
-  }
-
-  // -------------------------------------------------------------------------
-  // NameableObject implementation
-  // -------------------------------------------------------------------------
-
-  @Override
-  @Sortable
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public String getShortName() {
-    return shortName;
-  }
-
-  @Override
-  @Sortable(whenPersisted = false)
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  @Translatable(propertyName = "shortName", key = "SHORT_NAME")
-  public String getDisplayShortName() {
-    return translations.getTranslation("SHORT_NAME", shortName);
-  }
-
-  @Override
-  @Sortable
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public String getDescription() {
-    return description;
-  }
-
-  @Override
-  @Sortable(value = false)
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  @Translatable(propertyName = "description", key = "DESCRIPTION")
-  public String getDisplayDescription() {
-    return translations.getTranslation("DESCRIPTION", description);
-  }
-
-  @Override
-  @JsonIgnore
-  public String getDisplayProperty(DisplayProperty property) {
-    if (DisplayProperty.SHORTNAME == property && getDisplayShortName() != null) {
-      return getDisplayShortName();
-    } else {
-      return getDisplayName();
-    }
   }
 
   // -------------------------------------------------------------------------
@@ -787,13 +373,21 @@ public class DataElement extends BaseMetadataObject
         : valueType;
   }
 
+  public void setValueType(ValueType valueType) {
+    this.valueType = valueType;
+  }
+
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public ValueTypeOptions getValueTypeOptions() {
     return valueTypeOptions;
   }
 
-  @Sortable
+  public void setValueTypeOptions(ValueTypeOptions valueTypeOptions) {
+    this.valueTypeOptions = valueTypeOptions;
+  }
+
+  @Override
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   @PropertyRange(min = 2)
@@ -801,15 +395,19 @@ public class DataElement extends BaseMetadataObject
     return formName;
   }
 
-  /** Returns the form name, or the display name if it does not exist. */
-  public String getFormNameFallback() {
-    return formName != null && !formName.isEmpty() ? getFormName() : getDisplayName();
+  @Override
+  public void setFormName(String formName) {
+    this.formName = formName;
   }
 
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public DataElementDomain getDomainType() {
     return domainType;
+  }
+
+  public void setDomainType(DataElementDomain domainType) {
+    this.domainType = domainType;
   }
 
   @JsonProperty(value = "categoryCombo")
@@ -819,11 +417,19 @@ public class DataElement extends BaseMetadataObject
     return categoryCombo;
   }
 
+  public void setCategoryCombo(CategoryCombo categoryCombo) {
+    this.categoryCombo = categoryCombo;
+  }
+
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   @Property(PropertyType.URL)
   public String getUrl() {
     return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
   }
 
   @JsonProperty("dataElementGroups")
@@ -834,11 +440,19 @@ public class DataElement extends BaseMetadataObject
     return groups;
   }
 
+  public void setGroups(Set<DataElementGroup> groups) {
+    this.groups = groups;
+  }
+
   @JsonProperty
   @JacksonXmlElementWrapper(localName = "dataSetElements", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "dataSetElements", namespace = DxfNamespaces.DXF_2_0)
   public Set<DataSetElement> getDataSetElements() {
     return dataSetElements;
+  }
+
+  public void setDataSetElements(Set<DataSetElement> dataSetElements) {
+    this.dataSetElements = dataSetElements;
   }
 
   @JsonProperty
@@ -847,10 +461,18 @@ public class DataElement extends BaseMetadataObject
     return aggregationLevels;
   }
 
+  public void setAggregationLevels(List<Integer> aggregationLevels) {
+    this.aggregationLevels = aggregationLevels;
+  }
+
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isZeroIsSignificant() {
     return zeroIsSignificant;
+  }
+
+  public void setZeroIsSignificant(boolean zeroIsSignificant) {
+    this.zeroIsSignificant = zeroIsSignificant;
   }
 
   @Override
@@ -860,10 +482,18 @@ public class DataElement extends BaseMetadataObject
     return optionSet;
   }
 
+  public void setOptionSet(OptionSet optionSet) {
+    this.optionSet = optionSet;
+  }
+
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public OptionSet getCommentOptionSet() {
     return commentOptionSet;
+  }
+
+  public void setCommentOptionSet(OptionSet commentOptionSet) {
+    this.commentOptionSet = commentOptionSet;
   }
 
   @JsonProperty
@@ -872,34 +502,17 @@ public class DataElement extends BaseMetadataObject
     return style;
   }
 
+  public void setStyle(ObjectStyle style) {
+    this.style = style;
+  }
+
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getFieldMask() {
     return fieldMask;
   }
 
-  // -------------------------------------------------------------------------
-  // Sharing helpers
-  // -------------------------------------------------------------------------
-
-  public void setPublicAccess(String access) {
-    getSharing().setPublicAccess(access);
-  }
-
-  public String getPublicAccess() {
-    return getSharing().getPublicAccess();
-  }
-
-  public Collection<UserAccess> getUserAccesses() {
-    return getSharing().getUsers().values();
-  }
-
-  public Collection<UserGroupAccess> getUserGroupAccesses() {
-    return getSharing().getUserGroups().values();
-  }
-
-  @JsonIgnore
-  public String getAttributeValue(String attributeUid) {
-    return attributeValues.get(attributeUid);
+  public void setFieldMask(String fieldMask) {
+    this.fieldMask = fieldMask;
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementGroup.java
@@ -41,7 +41,6 @@ import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.period.PeriodType;
@@ -148,7 +147,7 @@ public class DataElementGroup extends BaseDimensionalItemObject implements Metad
   // -------------------------------------------------------------------------
 
   @JsonProperty("dataElements")
-  @JsonSerialize(contentAs = IdentifiableObject.class)
+  @JsonSerialize(contentAs = BaseIdentifiableObject.class)
   @JacksonXmlElementWrapper(localName = "dataElements", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "dataElement", namespace = DxfNamespaces.DXF_2_0)
   public Set<DataElement> getMembers() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementOperand.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementOperand.java
@@ -45,7 +45,6 @@ import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdScheme;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
 import org.hisp.dhis.option.OptionSet;
@@ -304,7 +303,7 @@ public class DataElementOperand extends BaseDimensionalItemObject
   // -------------------------------------------------------------------------
 
   @JsonProperty
-  @JsonSerialize(as = IdentifiableObject.class)
+  @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public DataElement getDataElement() {
     return dataElement;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementStore.java
@@ -29,12 +29,9 @@
  */
 package org.hisp.dhis.dataelement;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.GenericDimensionalObjectStore;
-import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.user.User;
 
 /**
@@ -98,14 +95,4 @@ public interface DataElementStore extends GenericDimensionalObjectStore<DataElem
 
   /** Get all DataElements that have any of the CategoryCombos */
   List<DataElement> getByCategoryCombo(List<CategoryCombo> categoryCombos);
-
-  /**
-   * Returns the {@link PeriodType} for each given DataElement UID, derived from the associated
-   * DataSet with the highest collection frequency (see {@code DataSetFrequencyComparator}).
-   * DataElements with no associated DataSet are omitted from the result.
-   *
-   * <p>Resolves all UIDs in a single query so callers can build a session-independent lookup map
-   * and avoid per-element lazy loads on {@code DataElement.dataSetElements}.
-   */
-  Map<String, PeriodType> getPeriodTypesByUid(Collection<String> uids);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSetElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSetElement.java
@@ -186,7 +186,7 @@ public class DataSetElement implements EmbeddedObject, Serializable {
   }
 
   @JsonProperty
-  @JsonSerialize(as = IdentifiableObject.class)
+  @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public DataElement getDataElement() {
     return dataElement;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/Section.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/Section.java
@@ -277,7 +277,7 @@ public class Section extends BaseLinkableObject implements IdentifiableObject, M
   }
 
   @JsonProperty
-  @JsonSerialize(contentAs = IdentifiableObject.class)
+  @JsonSerialize(contentAs = BaseIdentifiableObject.class)
   @JacksonXmlElementWrapper(localName = "dataElements", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "dataElement", namespace = DxfNamespaces.DXF_2_0)
   public List<DataElement> getDataElements() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValue.java
@@ -46,7 +46,6 @@ import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.UsageTestOnly;
 import org.hisp.dhis.common.adapter.JacksonPeriodDeserializer;
@@ -312,7 +311,7 @@ public class DataValue implements Serializable {
   // -------------------------------------------------------------------------
 
   @JsonProperty
-  @JsonSerialize(contentAs = IdentifiableObject.class)
+  @JsonSerialize(contentAs = BaseIdentifiableObject.class)
   public DataElement getDataElement() {
     return dataElement;
   }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventchart/EventChart.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventchart/EventChart.java
@@ -259,7 +259,7 @@ public class EventChart extends BaseChart implements EventAnalyticalObject, Meta
   }
 
   @JsonProperty
-  @JsonSerialize(as = IdentifiableObject.class)
+  @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public DataElement getDataElementValueDimension() {
     return dataElementValueDimension;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventreport/EventReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventreport/EventReport.java
@@ -258,7 +258,7 @@ public class EventReport extends BaseAnalyticalObject
   }
 
   @JsonProperty
-  @JsonSerialize(as = IdentifiableObject.class)
+  @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public DataElement getDataElementValueDimension() {
     return dataElementValueDimension;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
@@ -472,7 +472,7 @@ public class EventVisualization extends BaseAnalyticalObject
   }
 
   @JsonProperty
-  @JsonSerialize(as = IdentifiableObject.class)
+  @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DXF_2_0)
   public DataElement getDataElementValueDimension() {
     return dataElementValueDimension;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramDataElementDimensionItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramDataElementDimensionItem.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.List;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
+import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.EmbeddedObject;
@@ -178,7 +179,7 @@ public class ProgramDataElementDimensionItem extends BaseDimensionalItemObject
   }
 
   @JsonProperty
-  @JsonSerialize(as = IdentifiableObject.class)
+  @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   @Property(value = PropertyType.REFERENCE, required = Property.Value.TRUE)
   public DataElement getDataElement() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramDataElementOptionDimensionItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramDataElementOptionDimensionItem.java
@@ -193,7 +193,7 @@ public class ProgramDataElementOptionDimensionItem extends BaseDimensionalItemOb
   }
 
   @JsonProperty
-  @JsonSerialize(as = IdentifiableObject.class)
+  @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DXF_2_0)
   @Property(value = REFERENCE, required = TRUE)
   public DataElement getDataElement() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageDataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageDataElement.java
@@ -38,7 +38,6 @@ import java.util.function.BiFunction;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.EmbeddedObject;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.adapter.DeviceRenderTypeMapSerializer;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.render.DeviceRenderTypeMap;
@@ -119,7 +118,7 @@ public class ProgramStageDataElement extends BaseIdentifiableObject implements E
   }
 
   @JsonProperty
-  @JsonSerialize(as = IdentifiableObject.class)
+  @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public DataElement getDataElement() {
     return dataElement;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageSection.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageSection.java
@@ -40,7 +40,6 @@ import java.util.function.BiFunction;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.BaseNameableObject;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.ObjectStyle;
 import org.hisp.dhis.common.adapter.DeviceRenderTypeMapSerializer;
@@ -122,7 +121,7 @@ public class ProgramStageSection extends BaseNameableObject implements MetadataO
   }
 
   @JsonProperty
-  @JsonSerialize(contentAs = IdentifiableObject.class)
+  @JsonSerialize(contentAs = BaseIdentifiableObject.class)
   @JacksonXmlElementWrapper(localName = "dataElements", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "dataElement", namespace = DxfNamespaces.DXF_2_0)
   public List<DataElement> getDataElements() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/template/NotificationTemplateMapper.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/template/NotificationTemplateMapper.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectSnapshot;
 import org.hisp.dhis.dataelement.DataElement;
@@ -185,7 +186,7 @@ public class NotificationTemplateMapper {
     return optionalInstance.orElse(null);
   }
 
-  private static <T extends IdentifiableObject> T toBaseIdentifiableObject(
+  private static <T extends BaseIdentifiableObject> T toBaseIdentifiableObject(
       IdentifiableObjectSnapshot from,
       Supplier<T> instanceSupplier,
       Collection<Consumer<T>> instanceTransformers) {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleAction.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleAction.java
@@ -37,7 +37,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.Set;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.legend.LegendSet;
@@ -327,7 +326,7 @@ public class ProgramRuleAction extends BaseIdentifiableObject implements Metadat
   }
 
   @JsonProperty
-  @JsonSerialize(as = IdentifiableObject.class)
+  @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public DataElement getDataElement() {
     return dataElement;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleVariable.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleVariable.java
@@ -172,7 +172,7 @@ public class ProgramRuleVariable extends BaseIdentifiableObject implements Metad
   }
 
   @JsonProperty
-  @JsonSerialize(as = IdentifiableObject.class)
+  @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public DataElement getDataElement() {
     return dataElement;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/command/code/SMSCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/command/code/SMSCode.java
@@ -38,7 +38,6 @@ import java.io.Serializable;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 
@@ -98,7 +97,7 @@ public class SMSCode implements Serializable {
   }
 
   @JsonProperty
-  @JsonSerialize(as = IdentifiableObject.class)
+  @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(localName = "dataElement")
   public DataElement getDataElement() {
     return dataElement;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityDataElementDimension.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityDataElementDimension.java
@@ -87,7 +87,7 @@ public class TrackedEntityDataElementDimension {
   }
 
   @JsonProperty
-  @JsonSerialize(as = IdentifiableObject.class)
+  @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public DataElement getDataElement() {
     return dataElement;

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/CommonMergeHandler.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/CommonMergeHandler.java
@@ -32,7 +32,6 @@ package org.hisp.dhis.merge;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.collection.CollectionUtils;
 import org.hisp.dhis.dataentryform.DataEntryForm;
@@ -62,7 +61,7 @@ public class CommonMergeHandler {
    * @param sources to be replaced
    * @param target to replace each source
    */
-  public <T extends IdentifiableObject> void handleRefsInIndicatorExpression(
+  public <T extends BaseIdentifiableObject> void handleRefsInIndicatorExpression(
       List<T> sources, T target) {
     for (T source : sources) {
       // numerators
@@ -93,7 +92,8 @@ public class CommonMergeHandler {
    * @param sources to be replaced
    * @param target to replace each source
    */
-  public <T extends IdentifiableObject> void handleRefsInCustomForms(List<T> sources, T target) {
+  public <T extends BaseIdentifiableObject> void handleRefsInCustomForms(
+      List<T> sources, T target) {
     for (T source : sources) {
       List<DataEntryForm> forms =
           dataEntryFormService.getDataEntryFormsWithHtmlContaining(source.getUid());

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/MergeHandler.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/MergeHandler.java
@@ -31,7 +31,6 @@ package org.hisp.dhis.merge;
 
 import java.util.List;
 import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObject;
 
 /**
  * Functional interface representing a common {@link BaseIdentifiableObject} merge operation.
@@ -40,5 +39,5 @@ import org.hisp.dhis.common.IdentifiableObject;
  */
 @FunctionalInterface
 public interface MergeHandler {
-  <T extends IdentifiableObject> void merge(List<T> sources, T target);
+  <T extends BaseIdentifiableObject> void merge(List<T> sources, T target);
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -440,14 +440,6 @@ public class DataQueryParams {
   /** Mapping of organisation unit sub-hierarchy roots and lowest available data approval levels. */
   protected transient Map<OrganisationUnit, Integer> dataApprovalLevels = new HashMap<>();
 
-  /**
-   * Resolved period type per data element UID, populated by the query planner via a single batch
-   * query. Used by {@link org.hisp.dhis.analytics.data.QueryPlannerUtils} so downstream grouping
-   * does not depend on lazy-loading {@code DataElement.dataSetElements} on entities that may be
-   * detached.
-   */
-  protected Map<String, PeriodType> dataElementPeriodTypes = new HashMap<>();
-
   /** Hints for the aggregation process. */
   protected transient Set<ProcessingHint> processingHints = new HashSet<>();
 
@@ -556,7 +548,6 @@ public class DataQueryParams {
     params.startDateRestriction = this.startDateRestriction;
     params.endDateRestriction = this.endDateRestriction;
     params.dataApprovalLevels = new HashMap<>(this.dataApprovalLevels);
-    params.dataElementPeriodTypes = new HashMap<>(this.dataElementPeriodTypes);
     params.skipDataDimensionValidation = this.skipDataDimensionValidation;
     params.userOrgUnitType = this.userOrgUnitType;
     params.explainOrderId = this.explainOrderId;
@@ -2223,10 +2214,6 @@ public class DataQueryParams {
     this.dataApprovalLevels = dataApprovalLevels;
   }
 
-  public Map<String, PeriodType> getDataElementPeriodTypes() {
-    return dataElementPeriodTypes;
-  }
-
   // -------------------------------------------------------------------------
   // Get helpers for dimensions and filters
   // -------------------------------------------------------------------------
@@ -3015,11 +3002,6 @@ public class DataQueryParams {
 
     public Builder withDataApprovalLevels(Map<OrganisationUnit, Integer> dataApprovalLevels) {
       this.params.dataApprovalLevels = dataApprovalLevels;
-      return this;
-    }
-
-    public Builder withDataElementPeriodTypes(Map<String, PeriodType> dataElementPeriodTypes) {
-      this.params.dataElementPeriodTypes = dataElementPeriodTypes;
       return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
@@ -42,10 +42,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.analytics.AggregationType;
@@ -70,7 +67,6 @@ import org.hisp.dhis.common.QueryModifiers;
 import org.hisp.dhis.commons.collection.PaginatedList;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
-import org.hisp.dhis.dataelement.DataElementStore;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.period.PeriodDimension;
 import org.hisp.dhis.period.PeriodType;
@@ -87,16 +83,12 @@ import org.springframework.stereotype.Component;
 public class DefaultQueryPlanner implements QueryPlanner {
   private final PartitionManager partitionManager;
 
-  private final DataElementStore dataElementStore;
-
   // -------------------------------------------------------------------------
   // QueryPlanner implementation
   // -------------------------------------------------------------------------
 
   @Override
   public DataQueryGroups planQuery(DataQueryParams params, QueryPlannerParams plannerParams) {
-    params = withResolvedDataElementPeriodTypes(params);
-
     params = PeriodOffsetUtils.addShiftedPeriods(params);
 
     // Group queries which can be executed together
@@ -174,28 +166,6 @@ public class DefaultQueryPlanner implements QueryPlanner {
     }
 
     return DataQueryParams.newBuilder(params).withPartitions(partitions).build();
-  }
-
-  /**
-   * Returns a copy of the given {@link DataQueryParams} with {@code dataElementPeriodTypes}
-   * populated via a single batch query. Resolving period types here — inside the planner, while a
-   * Hibernate session is guaranteed open — avoids per-element lazy loads on {@code
-   * DataElement.dataSetElements} that fail when the entities arrive detached (e.g. from a cached
-   * params builder or test path that bypasses OSIV).
-   */
-  private DataQueryParams withResolvedDataElementPeriodTypes(DataQueryParams params) {
-    Set<String> uids =
-        params.getAllDataElements().stream()
-            .map(item -> ((DataElement) item).getUid())
-            .collect(Collectors.toSet());
-
-    if (uids.isEmpty()) {
-      return params;
-    }
-
-    Map<String, PeriodType> periodTypes = dataElementStore.getPeriodTypesByUid(uids);
-
-    return DataQueryParams.newBuilder(params).withDataElementPeriodTypes(periodTypes).build();
   }
 
   // -------------------------------------------------------------------------
@@ -511,10 +481,7 @@ public class DefaultQueryPlanner implements QueryPlanner {
     if (isNotEmpty(params.getDataElements())) {
       ListMap<AnalyticsAggregationType, DimensionalItemObject> aggregationTypeDataElementMap =
           QueryPlannerUtils.getAggregationTypeDataElementMap(
-              params.getDataElements(),
-              params.getAggregationType(),
-              params.getPeriodType(),
-              params.getDataElementPeriodTypes());
+              params.getDataElements(), params.getAggregationType(), params.getPeriodType());
 
       for (AnalyticsAggregationType aggregationType : aggregationTypeDataElementMap.keySet()) {
         DataQueryParams query =
@@ -553,8 +520,7 @@ public class DefaultQueryPlanner implements QueryPlanner {
           QueryPlannerUtils.getAggregationTypeDataElementMap(
               params.getFilterOptions(DATA_X_DIM_ID, DataDimensionItemType.DATA_ELEMENT),
               params.getAggregationType(),
-              params.getPeriodType(),
-              params.getDataElementPeriodTypes());
+              params.getPeriodType());
 
       for (AnalyticsAggregationType aggregationType : aggregationTypeDataElementMap.keySet()) {
         DataQueryParams query =
@@ -672,8 +638,7 @@ public class DefaultQueryPlanner implements QueryPlanner {
 
     if (params.isDisaggregation() && isNotEmpty(params.getDataElements())) {
       ListMap<PeriodType, DimensionalItemObject> periodTypeDataElementMap =
-          QueryPlannerUtils.getPeriodTypeDataElementMap(
-              params.getDataElements(), params.getDataElementPeriodTypes());
+          QueryPlannerUtils.getPeriodTypeDataElementMap(params.getDataElements());
 
       for (PeriodType periodType : periodTypeDataElementMap.keySet()) {
         DataQueryParams query =

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/QueryPlannerUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/QueryPlannerUtils.java
@@ -32,7 +32,6 @@ package org.hisp.dhis.analytics.data;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
 import org.hisp.dhis.analytics.DataQueryParams;
@@ -147,8 +146,7 @@ public class QueryPlannerUtils {
       getAggregationTypeDataElementMap(
           List<DimensionalItemObject> dataElements,
           AnalyticsAggregationType aggregationType,
-          String periodType,
-          Map<String, PeriodType> dataElementPeriodTypes) {
+          String periodType) {
     PeriodType aggregationPeriodType = PeriodType.getPeriodTypeByName(periodType);
 
     ListMap<AnalyticsAggregationType, DimensionalItemObject> map = new ListMap<>();
@@ -161,10 +159,8 @@ public class QueryPlannerUtils {
               aggregationType,
               AnalyticsAggregationType.fromAggregationType(de.getAggregationType()));
 
-      PeriodType dePeriodType = dataElementPeriodTypes.get(de.getUid());
-
       AnalyticsAggregationType analyticsAggregationType =
-          getAggregationType(aggType, de.getValueType(), aggregationPeriodType, dePeriodType);
+          getAggregationType(aggType, de.getValueType(), aggregationPeriodType, de.getPeriodType());
 
       map.putValue(analyticsAggregationType, de);
     }
@@ -260,14 +256,9 @@ public class QueryPlannerUtils {
    * @return a {@link ListMap} of period type and data elements.
    */
   public static ListMap<PeriodType, DimensionalItemObject> getPeriodTypeDataElementMap(
-      Collection<DimensionalItemObject> dataElements,
-      Map<String, PeriodType> dataElementPeriodTypes) {
+      Collection<DimensionalItemObject> dataElements) {
     ListMap<PeriodType, DimensionalItemObject> map = new ListMap<>();
-    dataElements.forEach(
-        item -> {
-          DataElement de = (DataElement) item;
-          map.putValue(dataElementPeriodTypes.get(de.getUid()), de);
-        });
+    dataElements.forEach(de -> map.putValue(((DataElement) de).getPeriodType(), de));
     return map;
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DefaultQueryPlannerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DefaultQueryPlannerTest.java
@@ -66,7 +66,6 @@ import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.dataelement.DataElementStore;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.PeriodDimension;
@@ -86,8 +85,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class DefaultQueryPlannerTest extends TestBase {
 
   @Mock private PartitionManager partitionManager;
-
-  @Mock private DataElementStore dataElementStore;
 
   @InjectMocks private DefaultQueryPlanner queryPlanner;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerGroupByAggregationTypeTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerGroupByAggregationTypeTest.java
@@ -60,7 +60,6 @@ import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElementDomain;
-import org.hisp.dhis.dataelement.DataElementStore;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.PeriodDimension;
@@ -77,8 +76,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class QueryPlannerGroupByAggregationTypeTest {
   @Mock private PartitionManager partitionManager;
-
-  @Mock private DataElementStore dataElementStore;
 
   @InjectMocks private DefaultQueryPlanner subject;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsUtilsTest.java
@@ -723,6 +723,7 @@ class AnalyticsUtilsTest extends TestBase {
     pi.setDecimals(0);
     DataElement de = new DataElement();
     de.setUid(CodeGenerator.generateUid());
+    de.setDimensionItemType(DimensionItemType.DATA_ELEMENT);
     de.setValueType(ValueType.TEXT);
     assertEquals(5, AnalyticsUtils.getIntegerOrValue(5d, pi));
     assertEquals("Male", AnalyticsUtils.getIntegerOrValue("Male", de));

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/hibernate/HibernateDataElementStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/hibernate/HibernateDataElementStore.java
@@ -35,10 +35,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import org.hibernate.LockOptions;
 import org.hisp.dhis.category.CategoryCombo;
@@ -47,7 +44,6 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
 import org.hisp.dhis.dataelement.DataElementStore;
 import org.hisp.dhis.hibernate.JpaQueryParameters;
-import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.CurrentUserGroupInfo;
 import org.hisp.dhis.user.User;
@@ -152,31 +148,5 @@ public class HibernateDataElementStore extends HibernateIdentifiableObjectStore<
         .setParameter("categoryCombos", categoryCombos)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
         .list();
-  }
-
-  @Override
-  public Map<String, PeriodType> getPeriodTypesByUid(Collection<String> uids) {
-    if (uids == null || uids.isEmpty()) return Map.of();
-
-    @Language("hql")
-    String hql =
-        """
-        select distinct de
-        from DataElement de
-        join fetch de.dataSetElements dse
-        join fetch dse.dataSet
-        where de.uid in (:uids)
-        """;
-
-    List<DataElement> dataElements = getQuery(hql).setParameter("uids", uids).list();
-
-    Map<String, PeriodType> result = new HashMap<>();
-    for (DataElement de : dataElements) {
-      PeriodType pt = de.getPeriodType();
-      if (pt != null) {
-        result.put(de.getUid(), pt);
-      }
-    }
-    return result;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionExtractor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionExtractor.java
@@ -38,7 +38,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.SerializationUtils;
+import org.apache.commons.beanutils.BeanUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
@@ -445,7 +445,7 @@ public class DataDimensionExtractor {
     }
 
     try {
-      DimensionalItemObject clone = SerializationUtils.clone(item);
+      DimensionalItemObject clone = (DimensionalItemObject) BeanUtils.cloneBean(item);
       clone.setQueryMods(id.getQueryMods());
       return clone;
     } catch (Exception e) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElement.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElement.hbm.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+  "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+  "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd"
+  [<!ENTITY identifiableProperties SYSTEM "classpath://org/hisp/dhis/common/identifiableProperties.hbm">]
+  >
+<hibernate-mapping>
+  <class name="org.hisp.dhis.dataelement.DataElement" table="dataelement">
+
+    <cache usage="read-write" />
+
+    <id name="id" column="dataelementid">
+      <generator class="native" />
+    </id>
+    &identifiableProperties;
+
+    <property name="name" column="name" not-null="true" unique="true" length="230" />
+
+    <property name="shortName" column="shortname" not-null="true" unique="true" length="50" />
+
+    <property name="description" type="text" />
+
+    <property name="formName" length="230" />
+
+    <property name="style" type="jbObjectStyle" column="style" />
+
+    <property name="fieldMask" />
+
+    <property name="translations" type="jblTranslations"/>
+
+    <property name="valueType" length="50" not-null="true">
+      <type name="org.hibernate.type.EnumType">
+        <param name="enumClass">org.hisp.dhis.common.ValueType</param>
+        <param name="useNamed">true</param>
+        <param name="type">12</param>
+      </type>
+    </property>
+
+    <property name="valueTypeOptions" type="jbValueTypeOptions"/>
+
+    <property name="domainType" column="domainType" type="org.hisp.dhis.dataelement.DataElementDomainUserType" not-null="true" />
+
+    <property name="aggregationType" length="50" column="aggregationtype" not-null="true">
+      <type name="org.hibernate.type.EnumType">
+        <param name="enumClass">org.hisp.dhis.analytics.AggregationType</param>
+        <param name="useNamed">true</param>
+        <param name="type">12</param>
+      </type>
+    </property>
+
+    <many-to-one name="categoryCombo" class="org.hisp.dhis.category.CategoryCombo"
+      column="categorycomboid" not-null="true" foreign-key="fk_dataelement_categorycomboid" />
+
+    <property name="url" />
+
+    <set name="groups" table="dataelementgroupmembers" inverse="true">
+      <cache usage="read-write" />
+      <key column="dataelementid" />
+      <many-to-many class="org.hisp.dhis.dataelement.DataElementGroup" column="dataelementgroupid" />
+    </set>
+
+    <set name="dataSetElements" table="datasetelement" inverse="true">
+      <cache usage="read-write" />
+      <key column="dataelementid" foreign-key="fk_datasetmembers_dataelementid" not-null="true" />
+      <one-to-many class="org.hisp.dhis.dataset.DataSetElement" />
+    </set>
+
+    <list name="aggregationLevels" table="dataelementaggregationlevels">
+      <cache usage="read-write" />
+      <key column="dataelementid" foreign-key="fk_dataelementaggregationlevels_dataelementid" />
+      <list-index column="sort_order" base="0" />
+      <element column="aggregationlevel" type="integer" />
+    </list>
+
+    <property name="zeroIsSignificant" not-null="true" />
+
+    <many-to-one name="optionSet" class="org.hisp.dhis.option.OptionSet" column="optionsetid"
+      foreign-key="fk_dataelement_optionsetid" />
+
+    <many-to-one name="commentOptionSet" class="org.hisp.dhis.option.OptionSet" column="commentoptionsetid"
+      foreign-key="fk_dataelement_commentoptionsetid" />
+
+    <list name="legendSets" table="dataelementlegendsets">
+      <cache usage="read-write" />
+      <key column="dataelementid" />
+      <list-index column="sort_order" base="0" />
+      <many-to-many class="org.hisp.dhis.legend.LegendSet" column="legendsetid" foreign-key="fk_dataelement_legendsetid" />
+    </list>
+
+    <!-- Dynamic attribute values -->
+    <property name="attributeValues" type="jsbAttributeValues"/>
+
+    <many-to-one name="createdBy" class="org.hisp.dhis.user.User" column="userid" foreign-key="fk_dataelement_userid" />
+
+    <!-- Sharing -->
+    <property name="sharing" type="jsbObjectSharing"/>
+
+  </class>
+
+</hibernate-mapping>

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/aggregate/EventsAggregate5AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/aggregate/EventsAggregate5AutoTest.java
@@ -91,8 +91,7 @@ public class EventsAggregate5AutoTest extends AnalyticsApiTest {
         "TEXT",
         "java.lang.String",
         false,
-        true,
-        "iDFPKpFTiVw");
+        true);
     validateHeader(response, 1, "ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
     validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, true);
     validateHeader(
@@ -264,8 +263,7 @@ public class EventsAggregate5AutoTest extends AnalyticsApiTest {
         "TEXT",
         "java.lang.String",
         false,
-        true,
-        "iDFPKpFTiVw");
+        true);
     validateHeader(response, 1, "pe", "Period", "TEXT", "java.lang.String", false, true);
     validateHeader(response, 2, "value", "Value", "NUMBER", "java.lang.Double", false, false);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -1026,6 +1026,7 @@ class AnalyticsServiceTest extends PostgresIntegrationTestBase {
         inA, "( #{" + deE.getUid() + "}.yearToDate() + [periodInYear] ).periodOffset(-1)");
     withIndicator(
         inB, "( #{" + deE.getUid() + "}.yearToDate() + [periodInYear] ).periodOffset(-2)");
+
     assertDataValues(
         Map.of(
             "indicatorAA-ouabcdefghA-201706",

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/analytics/dimension/DimensionMapperTestSupport.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/analytics/dimension/DimensionMapperTestSupport.java
@@ -40,7 +40,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.PrefixedDimension;
 import org.hisp.dhis.webapi.dimension.DimensionMapper;
 import org.hisp.dhis.webapi.dimension.DimensionResponse;
@@ -54,7 +53,7 @@ public class DimensionMapperTestSupport {
     asserter(dimensionMapper, instanceSupplier, instanceSetters, assertingPairs, null);
   }
 
-  public static <T extends IdentifiableObject> void asserter(
+  public static <T extends BaseIdentifiableObject> void asserter(
       DimensionMapper dimensionMapper,
       Supplier<T> instanceSupplier,
       List<Consumer<T>> instanceSetters,
@@ -78,7 +77,7 @@ public class DimensionMapperTestSupport {
             .collect(Collectors.toList()));
   }
 
-  private static <T extends IdentifiableObject> T getBaseIdentifiableObject(
+  private static <T extends BaseIdentifiableObject> T getBaseIdentifiableObject(
       Supplier<T> instanceSupplier, List<Consumer<T>> setters) {
     T baseIdentifiableObject = instanceSupplier.get();
     setters.forEach(setter -> setter.accept(baseIdentifiableObject));

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/analytics/dimension/mappers/DataElementMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/analytics/dimension/mappers/DataElementMapperTest.java
@@ -50,6 +50,7 @@ class DataElementMapperTest {
         new DataElementMapper(),
         DataElement::new,
         List.of(
+            b -> b.setDimensionItemType(DIMENSION_ITEM_TYPE),
             b -> b.setValueType(ValueType.TEXT),
             b -> b.setAggregationType(AggregationType.AVERAGE),
             b -> b.setUid("DE_ID")),


### PR DESCRIPTION

This reverts commit PR https://github.com/dhis2/dhis2-core/pull/24394

Restores the XML-based DataElement Hibernate mapping (DataElement.hbm.xml) and reverts the annotation-based mapping migration along with the associated analytics query-planner and store changes.