### PR TITLE
chore: use UserDetails for me authorities/password and 2FA endpoints

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/twofa/TwoFactorAuthService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/twofa/TwoFactorAuthService.java
@@ -306,7 +306,7 @@ public class TwoFactorAuthService {
   }
 
   @NonTransactional
-  public @Nonnull byte[] generateQRCode(@Nonnull User currentUser) throws ConflictException {
+  public @Nonnull byte[] generateQRCode(@Nonnull UserDetails currentUser) throws ConflictException {
     if (!configurationProvider.isEnabled(ConfigurationKey.TOTP_2FA_ENABLED)) {
       throw new ConflictException(ErrorCode.E3046);
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/twofa/TwoFactorAuthService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/twofa/TwoFactorAuthService.java
@@ -305,8 +305,16 @@ public class TwoFactorAuthService {
     }
   }
 
+  /**
+   * Generates the TOTP enrollment QR code.
+   *
+   * <p>Takes the {@link User} entity, not {@link UserDetails}: enrollment writes a new secret and
+   * {@code ENROLLING_TOTP} type to the database without refreshing the authenticated principal, so
+   * a {@code UserDetails} snapshot from login time still reports the pre-enrollment secret and
+   * type, and this method would reject with {@link ErrorCode#E3047}.
+   */
   @NonTransactional
-  public @Nonnull byte[] generateQRCode(@Nonnull UserDetails currentUser) throws ConflictException {
+  public @Nonnull byte[] generateQRCode(@Nonnull User currentUser) throws ConflictException {
     if (!configurationProvider.isEnabled(ConfigurationKey.TOTP_2FA_ENABLED)) {
       throw new ConflictException(ErrorCode.E3046);
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
@@ -74,7 +74,7 @@ public class TwoFactorController {
 
   @PostMapping(value = "/enrollTOTP2FA")
   @ResponseStatus(HttpStatus.OK)
-  public WebMessage enrollTOTP2FA(@CurrentUser User currentUser) throws ConflictException {
+  public WebMessage enrollTOTP2FA(@CurrentUser UserDetails currentUser) throws ConflictException {
     twoFactorAuthService.enrollTOTP2FA(currentUser.getUsername());
     return ok(
         "The user has enrolled in TOTP 2FA, call the QR code endpoint to continue the process");
@@ -82,7 +82,7 @@ public class TwoFactorController {
 
   @PostMapping(value = "/enrollEmail2FA")
   @ResponseStatus(HttpStatus.OK)
-  public WebMessage enrollEmail2FA(@CurrentUser User currentUser) throws ConflictException {
+  public WebMessage enrollEmail2FA(@CurrentUser UserDetails currentUser) throws ConflictException {
     twoFactorAuthService.enrollEmail2FA(currentUser.getUsername());
     return ok(
         "The user has enrolled in email-based 2FA, a code was generated and sent successfully to the user's email");
@@ -99,7 +99,7 @@ public class TwoFactorController {
       value = {"/qrCodePng"},
       produces = APPLICATION_OCTET_STREAM_VALUE)
   @ResponseStatus(HttpStatus.ACCEPTED)
-  public void qrCodePng(@CurrentUser User currentUser, HttpServletResponse response)
+  public void qrCodePng(@CurrentUser UserDetails currentUser, HttpServletResponse response)
       throws IOException, ConflictException {
     byte[] qrCode = twoFactorAuthService.generateQRCode(currentUser);
     response.getOutputStream().write(qrCode);
@@ -115,7 +115,7 @@ public class TwoFactorController {
       value = {"/qrCodeJson"},
       produces = APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.OK)
-  public QRCode qrCodeJson(@CurrentUser User currentUser) throws ConflictException {
+  public QRCode qrCodeJson(@CurrentUser UserDetails currentUser) throws ConflictException {
     byte[] qrCode = twoFactorAuthService.generateQRCode(currentUser);
     return new QRCode(currentUser.getSecret(), Base64.getEncoder().encodeToString(qrCode));
   }
@@ -134,7 +134,7 @@ public class TwoFactorController {
       produces = APPLICATION_OCTET_STREAM_VALUE)
   @ResponseStatus(HttpStatus.ACCEPTED)
   @Deprecated(forRemoval = true, since = "2.42")
-  public void generateQRCode(@CurrentUser User currentUser, HttpServletResponse response)
+  public void generateQRCode(@CurrentUser UserDetails currentUser, HttpServletResponse response)
       throws IOException, ConflictException {
     twoFactorAuthService.enrollTOTP2FA(currentUser.getUsername());
     byte[] qrCode = twoFactorAuthService.generateQRCode(currentUser);
@@ -145,7 +145,7 @@ public class TwoFactorController {
       value = "/enabled",
       consumes = {"text/*", "application/*"})
   @ResponseStatus(HttpStatus.OK)
-  public boolean isEnabled(@CurrentUser(required = true) User currentUser) {
+  public boolean isEnabled(@CurrentUser(required = true) UserDetails currentUser) {
     return currentUser.isTwoFactorEnabled();
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
@@ -99,7 +99,7 @@ public class TwoFactorController {
       value = {"/qrCodePng"},
       produces = APPLICATION_OCTET_STREAM_VALUE)
   @ResponseStatus(HttpStatus.ACCEPTED)
-  public void qrCodePng(@CurrentUser UserDetails currentUser, HttpServletResponse response)
+  public void qrCodePng(@CurrentUser User currentUser, HttpServletResponse response)
       throws IOException, ConflictException {
     byte[] qrCode = twoFactorAuthService.generateQRCode(currentUser);
     response.getOutputStream().write(qrCode);
@@ -115,7 +115,7 @@ public class TwoFactorController {
       value = {"/qrCodeJson"},
       produces = APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.OK)
-  public QRCode qrCodeJson(@CurrentUser UserDetails currentUser) throws ConflictException {
+  public QRCode qrCodeJson(@CurrentUser User currentUser) throws ConflictException {
     byte[] qrCode = twoFactorAuthService.generateQRCode(currentUser);
     return new QRCode(currentUser.getSecret(), Base64.getEncoder().encodeToString(qrCode));
   }
@@ -134,7 +134,7 @@ public class TwoFactorController {
       produces = APPLICATION_OCTET_STREAM_VALUE)
   @ResponseStatus(HttpStatus.ACCEPTED)
   @Deprecated(forRemoval = true, since = "2.42")
-  public void generateQRCode(@CurrentUser UserDetails currentUser, HttpServletResponse response)
+  public void generateQRCode(@CurrentUser User currentUser, HttpServletResponse response)
       throws IOException, ConflictException {
     twoFactorAuthService.enrollTOTP2FA(currentUser.getUsername());
     byte[] qrCode = twoFactorAuthService.generateQRCode(currentUser);
@@ -145,7 +145,7 @@ public class TwoFactorController {
       value = "/enabled",
       consumes = {"text/*", "application/*"})
   @ResponseStatus(HttpStatus.OK)
-  public boolean isEnabled(@CurrentUser(required = true) UserDetails currentUser) {
+  public boolean isEnabled(@CurrentUser(required = true) User currentUser) {
     return currentUser.isTwoFactorEnabled();
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
@@ -300,7 +300,7 @@ public class MeController {
       value = {"/authorization", "/authorities"},
       produces = APPLICATION_JSON_VALUE)
   public ResponseEntity<Set<String>> getAuthorities(
-      @CurrentUser(required = true) User currentUser) {
+      @CurrentUser(required = true) UserDetails currentUser) {
     return ResponseEntity.ok().cacheControl(noStore()).body(currentUser.getAllAuthorities());
   }
 
@@ -308,7 +308,7 @@ public class MeController {
       value = {"/authorization/{authority}", "/authorities/{authority}"},
       produces = APPLICATION_JSON_VALUE)
   public ResponseEntity<Boolean> hasAuthority(
-      @PathVariable String authority, @CurrentUser(required = true) User currentUser) {
+      @PathVariable String authority, @CurrentUser(required = true) UserDetails currentUser) {
     return ResponseEntity.ok().cacheControl(noStore()).body(currentUser.isAuthorized(authority));
   }
 
@@ -357,7 +357,7 @@ public class MeController {
   @OpenApi.Document(group = OpenApi.Document.GROUP_MANAGE)
   @PostMapping(value = "/verifyPassword", consumes = "text/*")
   public @ResponseBody RootNode verifyPasswordText(
-      @RequestBody String password, @CurrentUser(required = true) User currentUser)
+      @RequestBody String password, @CurrentUser(required = true) UserDetails currentUser)
       throws ConflictException {
     return verifyPasswordInternal(password, currentUser);
   }
@@ -365,7 +365,7 @@ public class MeController {
   @OpenApi.Document(group = OpenApi.Document.GROUP_MANAGE)
   @PostMapping(value = "/validatePassword", consumes = "text/*")
   public @ResponseBody RootNode validatePasswordText(
-      @RequestBody String password, @CurrentUser(required = true) User currentUser)
+      @RequestBody String password, @CurrentUser(required = true) UserDetails currentUser)
       throws ConflictException {
     return validatePasswordInternal(password, currentUser);
   }
@@ -373,7 +373,7 @@ public class MeController {
   @OpenApi.Document(group = OpenApi.Document.GROUP_MANAGE)
   @PostMapping(value = "/verifyPassword", consumes = APPLICATION_JSON_VALUE)
   public @ResponseBody RootNode verifyPasswordJson(
-      @RequestBody Map<String, String> body, @CurrentUser(required = true) User currentUser)
+      @RequestBody Map<String, String> body, @CurrentUser(required = true) UserDetails currentUser)
       throws ConflictException {
     return verifyPasswordInternal(body.get("password"), currentUser);
   }
@@ -408,7 +408,7 @@ public class MeController {
   // Supportive methods
   // ------------------------------------------------------------------------------------------------
 
-  private RootNode verifyPasswordInternal(String password, User currentUser)
+  private RootNode verifyPasswordInternal(String password, UserDetails currentUser)
       throws ConflictException {
     if (password == null) {
       throw new ConflictException("Required attribute 'password' missing or null.");
@@ -422,7 +422,7 @@ public class MeController {
     return rootNode;
   }
 
-  private RootNode validatePasswordInternal(String password, User currentUser)
+  private RootNode validatePasswordInternal(String password, UserDetails currentUser)
       throws ConflictException {
     if (password == null) {
       throw new ConflictException("Required attribute 'password' missing or null.");


### PR DESCRIPTION
## Summary
Stop loading full Hibernate `User` via `@CurrentUser User` on endpoints that only need data already on the security principal.

## Why
`CurrentUserHandlerMethodArgumentResolver`:
- `UserDetails` → free (`SecurityContext`)
- `User` → `userService.getUserByUsername` every time

## Changes
- `MeController`: `getAuthorities`, `hasAuthority`, verify/validate password
- `TwoFactorController`: `enrollTOTP2FA`, `enrollEmail2FA` (username only)

## Still on `User` (needs entity)
- `GET /api/me`, avatar, change password, data approval levels, etc.
- `/api/2fa/qrCode`, `/qrCodePng`, `/qrCodeJson`, `/enabled` and `TwoFactorAuthService.generateQRCode`: enrollment writes a new secret and `ENROLLING_TOTP` type to the DB without refreshing the authenticated principal, so a login-time `UserDetails` snapshot is stale (E3047 / null `base32Secret`). Reverted in e994fb9.

## Notes
Supersedes the UserDetails half of #23470. Independent of the OU UID cache PR.

## Test plan
- [x] `mvn -pl dhis-services/dhis-service-core,dhis-web-api -am compile -DskipTests`
- [x] `TwoFactorControllerTest` (18) + `AuthenticationControllerTest` (14) green locally


AI Assisted