### PR TITLE
fix: restore bare item id in aggregate metaData.items for stage-scoped dimensions [DHIS2-19750]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tracker/MetadataItemsHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tracker/MetadataItemsHandler.java
@@ -398,15 +398,20 @@ public class MetadataItemsHandler {
         .filter(Objects::nonNull)
         .forEach(
             item -> {
-              String key = getItemIdWithProgramStageIdPrefix(item);
               if (item.hasCustomHeader()) {
                 // For custom headers, only include the label (name), not the underlying item
                 // details
-                metadataItemMap.put(key, new MetadataItem(item.getCustomHeader().label()));
+                metadataItemMap.put(
+                    getItemIdWithProgramStageIdPrefix(item),
+                    new MetadataItem(item.getCustomHeader().label()));
               } else {
                 String name = item.getItem().getDisplayName();
-                metadataItemMap.put(
-                    key, new MetadataItem(name, includeDetails ? item.getItem() : null));
+                MetadataItem metadataItem =
+                    new MetadataItem(name, includeDetails ? item.getItem() : null);
+
+                metadataItemMap.put(getItemIdWithProgramStageIdPrefix(item), metadataItem);
+                // Done for backwards compatibility.
+                metadataItemMap.put(item.getItemId(), metadataItem);
               }
 
               addResolvedOrgUnitMetadata(metadataItemMap, params, includeDetails, item);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tracker/MetadataItemsHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tracker/MetadataItemsHandlerTest.java
@@ -838,6 +838,55 @@ class MetadataItemsHandlerTest {
     }
 
     @Test
+    @DisplayName(
+        "should include both the bare item id and the stage-prefixed id for a program-stage item, for backwards compatibility")
+    void shouldIncludeBareItemIdAlongsideStagePrefixedIdForNonQueryRequest() {
+      // Given
+      Grid grid = new ListGrid();
+
+      ProgramStage programStage = createProgramStage('S', programA);
+
+      QueryItem queryItem =
+          new QueryItem(
+              dataElementA,
+              null,
+              dataElementA.getValueType(),
+              dataElementA.getAggregationType(),
+              null);
+      queryItem.setProgramStage(programStage);
+
+      EventQueryParams params =
+          new EventQueryParams.Builder()
+              .withProgram(programA)
+              .withSkipMeta(false)
+              .withEndpointAction(AGGREGATE)
+              .withOrganisationUnits(List.of(orgUnitA))
+              .withPeriods(createPeriodDimensions("2023Q1"), "quarterly")
+              .addItem(queryItem)
+              .build();
+
+      when(userService.getUserByUsername(anyString())).thenReturn(null);
+
+      // When
+      metadataItemsHandler.addMetadata(grid, params, List.of());
+
+      // Then
+      @SuppressWarnings("unchecked")
+      Map<String, Object> items = (Map<String, Object>) grid.getMetaData().get(ITEMS.getKey());
+      assertNotNull(items);
+
+      String prefixedKey = programStage.getUid() + "." + dataElementA.getUid();
+      assertTrue(
+          items.containsKey(prefixedKey),
+          "Items should contain the stage-prefixed key '" + prefixedKey + "'");
+      assertTrue(
+          items.containsKey(dataElementA.getUid()),
+          "Items should also contain the bare item id '"
+              + dataElementA.getUid()
+              + "' for backwards compatibility");
+    }
+
+    @Test
     @DisplayName("should include legend metadata for non-query request")
     void shouldIncludeLegendMetadataForNonQueryRequest() {
       // Given


### PR DESCRIPTION
## Summary

Related: DHIS2-19750

Same fix as #24549, cherry-picked to master (where the bug originates).

`PR #21479` ("feat: support cross-stage data elements in metadata response",
DHIS2-19750) added a program-stage prefix to `metaData.items` keys for
**aggregate** (non-query) event/enrollment analytics responses whenever a
`QueryItem` has a program stage — but it replaced the bare item id entirely
instead of adding the prefixed form alongside it. This is a backwards
compatibility break for any integration doing a `metaData.items` lookup by
the plain data element/attribute uid, even for an ordinary single-stage query
with no cross-stage ambiguity at all (e.g. a single-data-element,
single-stage `dimension=fWIAEtYVEGk` query now only exposes
`Zj7UnCAulEk.fWIAEtYVEGk` in `metaData.items`, not `fWIAEtYVEGk`).

The sibling `/query` (row-level) endpoint never had this problem —
`MetadataItemsHandler.addItemToMetadata` already writes **both** the
stage-prefixed and bare keys to the same `MetadataItem`, tagged "Done for
backwards compatibility". This PR applies the identical dual-write pattern to
the aggregate endpoint's `addItemsAndFiltersMetadataForNonQuery`, so both
lookup forms resolve there too — bringing it in line with the query
endpoint's existing, already-correct behavior.

`metaData.dimensions` and the `headers` array are intentionally **not**
touched by this change — `metaData.items` is a plain lookup dictionary, so
adding a second key pointing at the same value is harmless; `dimensions` and
`headers` are positional/structural and are out of scope here.

## Test plan
- [x] New unit test `shouldIncludeBareItemIdAlongsideStagePrefixedIdForNonQueryRequest` in `MetadataItemsHandlerTest$NonQueryEndpointTests`, confirmed red before the fix and green after.
- [x] Full `MetadataItemsHandlerTest` suite passes (50 tests, 0 failures) on master.
- [x] Existing `dhis-test-e2e` aggregate `AutoTest` fixtures use `JSONAssert.assertEquals(expected, actual, false)` (lenient mode), which tolerates the additional key — no fixture changes needed/expected to break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)