### PR TITLE
fix: Use also data values from DB to init rule-engine context [DHIS2-21887]

### DIFF
--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapper.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapper.java
@@ -32,8 +32,12 @@ package org.hisp.dhis.tracker.imports.programrule;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Program;
@@ -49,6 +53,7 @@ import org.hisp.dhis.rules.models.RuleInstant;
 import org.hisp.dhis.rules.models.RuleLocalDate;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.imports.domain.Attribute;
+import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.model.Enrollment;
 import org.hisp.dhis.tracker.model.SingleEvent;
@@ -182,14 +187,40 @@ class RuleEngineMapper {
         eventToEvaluate.getCompletedAt() == null ? null : getDate(eventToEvaluate.getCompletedAt()),
         organisationUnit.getUid(),
         organisationUnit.getCode(),
-        eventToEvaluate.getDataValues().stream()
+        getDataValues(
+            eventToEvaluate.getDataValues(),
+            event == null ? Set.of() : event.getEventDataValues(),
+            preheat));
+  }
+
+  private static List<RuleDataValue> getDataValues(
+      Set<DataValue> payloadDataValues, Set<EventDataValue> dbDataValues, TrackerPreheat preheat) {
+    // Data elements present in the payload, whether they carry a value or are explicitly cleared
+    // (null value). A cleared value must not fall back to the persisted one, so these are excluded
+    // from the DB merge below.
+    Set<String> payloadDataElements =
+        payloadDataValues.stream()
+            .filter(Objects::nonNull)
+            .map(dv -> preheat.getDataElement(dv.getDataElement()).getUid())
+            .collect(Collectors.toSet());
+
+    List<RuleDataValue> ruleDataValues =
+        payloadDataValues.stream()
             .filter(Objects::nonNull)
             .filter(dv -> dv.getValue() != null)
             .map(
                 dv ->
                     new RuleDataValue(
                         preheat.getDataElement(dv.getDataElement()).getUid(), dv.getValue()))
-            .toList());
+            .toList();
+
+    Stream<RuleDataValue> dbRuleDataValues =
+        dbDataValues.stream()
+            .filter(dv -> dv.getValue() != null)
+            .filter(dv -> !payloadDataElements.contains(dv.getDataElement()))
+            .map(dv -> new RuleDataValue(dv.getDataElement(), dv.getValue()));
+
+    return Stream.concat(ruleDataValues.stream(), dbRuleDataValues).toList();
   }
 
   private static RuleEvent mapPayloadSingleEvent(
@@ -214,14 +245,10 @@ class RuleEngineMapper {
         eventToEvaluate.getCompletedAt() == null ? null : getDate(eventToEvaluate.getCompletedAt()),
         organisationUnit.getUid(),
         organisationUnit.getCode(),
-        eventToEvaluate.getDataValues().stream()
-            .filter(Objects::nonNull)
-            .filter(dv -> dv.getValue() != null)
-            .map(
-                dv ->
-                    new RuleDataValue(
-                        preheat.getDataElement(dv.getDataElement()).getUid(), dv.getValue()))
-            .toList());
+        getDataValues(
+            eventToEvaluate.getDataValues(),
+            event == null ? Set.of() : event.getEventDataValues(),
+            preheat));
   }
 
   private static RuleEvent mapSavedEvent(TrackerEvent eventToEvaluate) {

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapperTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapperTest.java
@@ -146,6 +146,94 @@ class RuleEngineMapperTest extends TrackerTestBase {
   }
 
   @Test
+  void shouldMergeSavedDataValuesNotInPayloadWhenUpdatingExistingTrackerEvent() {
+    // Reproduces the reported bug: an existing event is updated with only some of its data
+    // values, but a program rule references data elements that are not part of the payload.
+    // Those must be sourced from the persisted event so rules evaluate against the full state.
+    DataElement de1 = dataElement; // in payload only
+    DataElement de2 = createDataElement('E'); // in payload and DB -> payload value wins
+    DataElement de3 = createDataElement('F'); // in DB only
+    DataElement de4 = createDataElement('G'); // in DB only
+
+    org.hisp.dhis.tracker.imports.domain.TrackerEvent payload =
+        payloadEvent(dataValue(de1, "1"), dataValue(de2, "2"));
+
+    TrackerEvent savedEvent = dbEvent();
+    savedEvent.setUid(payload.getUID().getValue());
+    savedEvent.setEventDataValues(
+        Sets.newHashSet(
+            eventDataValue(de2.getUid(), "20"),
+            eventDataValue(de3.getUid(), "3"),
+            eventDataValue(de4.getUid(), "4")));
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(programStage);
+    preheat.put(TrackerIdSchemeParam.UID, organisationUnit);
+    preheat.put(TrackerIdSchemeParam.UID, List.of(de1, de2, de3, de4));
+    preheat.putTrackerEvent(savedEvent);
+
+    List<RuleEvent> ruleEvents =
+        RuleEngineMapper.mapPayloadTrackerEvents(preheat, List.of(payload));
+
+    assertContainsOnly(
+        List.of(
+            new RuleDataValue(de1.getUid(), "1"),
+            new RuleDataValue(de2.getUid(), "2"),
+            new RuleDataValue(de3.getUid(), "3"),
+            new RuleDataValue(de4.getUid(), "4")),
+        ruleEvents.get(0).getDataValues());
+  }
+
+  @Test
+  void shouldNotFallBackToSavedDataValueWhenPayloadClearsItForExistingTrackerEvent() {
+    DataElement de1 = dataElement; // updated in the payload
+    DataElement de2 = createDataElement('E'); // cleared in the payload (null value)
+
+    org.hisp.dhis.tracker.imports.domain.TrackerEvent payload =
+        payloadEvent(dataValue(de1, "1"), dataValue(de2, null));
+
+    TrackerEvent savedEvent = dbEvent();
+    savedEvent.setUid(payload.getUID().getValue());
+    savedEvent.setEventDataValues(
+        Sets.newHashSet(eventDataValue(de1.getUid(), "10"), eventDataValue(de2.getUid(), "20")));
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(programStage);
+    preheat.put(TrackerIdSchemeParam.UID, organisationUnit);
+    preheat.put(TrackerIdSchemeParam.UID, List.of(de1, de2));
+    preheat.putTrackerEvent(savedEvent);
+
+    List<RuleEvent> ruleEvents =
+        RuleEngineMapper.mapPayloadTrackerEvents(preheat, List.of(payload));
+
+    // de2 was cleared in the payload, so the persisted "20" must not be re-injected
+    assertContainsOnly(
+        List.of(new RuleDataValue(de1.getUid(), "1")), ruleEvents.get(0).getDataValues());
+  }
+
+  @Test
+  void shouldMapOnlyPayloadDataValuesWhenTrackerEventDoesNotExistYet() {
+    DataElement de1 = dataElement;
+    DataElement de2 = createDataElement('E');
+
+    org.hisp.dhis.tracker.imports.domain.TrackerEvent payload =
+        payloadEvent(dataValue(de1, "1"), dataValue(de2, "2"));
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(programStage);
+    preheat.put(TrackerIdSchemeParam.UID, organisationUnit);
+    preheat.put(TrackerIdSchemeParam.UID, List.of(de1, de2));
+    // no saved event in the preheat -> the event is being created
+
+    List<RuleEvent> ruleEvents =
+        RuleEngineMapper.mapPayloadTrackerEvents(preheat, List.of(payload));
+
+    assertContainsOnly(
+        List.of(new RuleDataValue(de1.getUid(), "1"), new RuleDataValue(de2.getUid(), "2")),
+        ruleEvents.get(0).getDataValues());
+  }
+
+  @Test
   void shouldMapDBEventsToRuleEvents() {
     TrackerEvent eventA = dbEvent();
     TrackerEvent eventB = dbEvent();
@@ -375,6 +463,10 @@ class RuleEngineMapperTest extends TrackerTestBase {
   }
 
   private org.hisp.dhis.tracker.imports.domain.TrackerEvent payloadEvent() {
+    return payloadEvent(dataValue(dataElement, SAMPLE_VALUE_A));
+  }
+
+  private org.hisp.dhis.tracker.imports.domain.TrackerEvent payloadEvent(DataValue... dataValues) {
     return org.hisp.dhis.tracker.imports.domain.TrackerEvent.builder()
         .enrollment(UID.generate())
         .event(UID.generate())
@@ -382,12 +474,14 @@ class RuleEngineMapperTest extends TrackerTestBase {
         .orgUnit(MetadataIdentifier.ofUid(organisationUnit.getUid()))
         .scheduledAt(YESTERDAY.toInstant())
         .occurredAt(AFTER_TOMORROW.toInstant())
-        .dataValues(
-            Set.of(
-                DataValue.builder()
-                    .dataElement(MetadataIdentifier.ofUid(dataElement.getUid()))
-                    .value(SAMPLE_VALUE_A)
-                    .build()))
+        .dataValues(Set.of(dataValues))
+        .build();
+  }
+
+  private DataValue dataValue(DataElement dataElement, String value) {
+    return DataValue.builder()
+        .dataElement(MetadataIdentifier.ofUid(dataElement.getUid()))
+        .value(value)
         .build();
   }
 }


### PR DESCRIPTION
## Summary

Fixes program rule evaluation for existing events that are updated with a partial set of data values. Previously the rule engine only saw the data values contained in the import payload, so a rule that references data elements not included in the request (e.g. an `assign` action summing several fields) evaluated against incomplete state and could fail the import. The rule engine context is now initialised from both the payload and the persisted event, with the payload taking precedence. Fixes [DHIS2-21887].

## Changes

- `RuleEngineMapper.java`: Introduces a shared `getDataValues(payloadDataValues, dbDataValues, preheat)` helper that merges the payload's data values with those already stored on the event. Payload values win on overlap; persisted values are pulled in only for data elements the payload does not mention, so rules evaluate against the event's full state.
- `RuleEngineMapper.java`: Honours deletions — a data element sent in the payload with a `null` value is treated as explicitly cleared and is **not** re-populated from the persisted value (tracked via the `payloadDataElements` set).
- `RuleEngineMapper.java`: Filters out persisted data values with a `null` value before mapping, avoiding an NPE when constructing the (non-null) `RuleDataValue`.
- `RuleEngineMapper.java`: Applies the same merge to both the tracker-event path (`mapPayloadTrackerEvent`) and the single-event path (`mapPayloadSingleEvent`). Newly created events (not present in the preheat) continue to use payload data values only.
- `RuleEngineMapperTest.java`: Adds unit tests covering the merge of persisted data values not in the payload, payload-wins-on-overlap with no duplicates, cleared values not falling back to the persisted value, and the new-event (payload-only) case.


[DHIS2-21887]: https://dhis2.atlassian.net/browse/DHIS2-21887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ