### PR TITLE
fix: require email recovery for expired password when email works [DHIS2-21120] (2.43)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserAccountService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserAccountService.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.common.auth.RegistrationParams;
 import org.hisp.dhis.common.auth.UserInviteParams;
 import org.hisp.dhis.common.auth.UserRegistrationParams;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 
 /**
@@ -86,6 +87,19 @@ public interface UserAccountService {
       throws BadRequestException, IOException;
 
   /**
+   * /** Whether this account should recover an expired password via email token rather than the
+   * old-password self-service path. True only when account recovery is enabled and {@link
+   * UserService#validateRestore(User)} succeeds (valid email, not external auth, email sender
+   * configured including SMTP password). When true, login should return {@code
+   * PASSWORD_EXPIRED_EMAIL_RECOVERY} and the expired-password self-service update must reject the
+   * call.
+   *
+   * @param user account under consideration; {@code null} yields {@code false}
+   * @return {@code true} when email recovery is the required path for this user
+   */
+  boolean canUseEmailPasswordRecovery(User user);
+
+  /**
    * Self-service change of an <b>expired</b> password. The caller is not logged in, so the method
    * is self-guarding: it only proceeds for an expired account whose current password is supplied
    * correctly. It deliberately does not establish a session; once the password is changed the
@@ -96,13 +110,18 @@ public interface UserAccountService {
    * repeated attempts against one account are throttled via the shared account-recovery lockout
    * (mirrors the forgot-password flow).
    *
+   * <p>When {@link #canUseEmailPasswordRecovery(User)} is true for the account, this method rejects
+   * after the password and expiry checks so the stronger email-token recovery path cannot be
+   * bypassed by calling the endpoint directly.
+   *
    * @param username username identifying the account
    * @param oldPassword the current (expired) password
    * @param newPassword new password, subject to the password policy
    * @throws BadRequestException when input is missing, credentials are wrong, the account is not
    *     expired, or the new password is not acceptable
+   * @throws ConflictException when the account must use email recovery instead of this path
    * @throws ForbiddenException when the account is temporarily locked due to too many attempts
    */
   void updateExpiredPassword(String username, String oldPassword, String newPassword)
-      throws BadRequestException, ForbiddenException;
+      throws BadRequestException, ConflictException, ForbiddenException;
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserAccountService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserAccountService.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.common.auth.UserInviteParams;
 import org.hisp.dhis.common.auth.UserRegistrationParams;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.security.PasswordManager;
@@ -149,7 +150,7 @@ public class DefaultUserAccountService implements UserAccountService {
   @Override
   @Transactional
   public void updateExpiredPassword(String username, String oldPassword, String newPassword)
-      throws BadRequestException, ForbiddenException {
+      throws BadRequestException, ConflictException, ForbiddenException {
     if (StringUtils.isBlank(username)
         || StringUtils.isBlank(oldPassword)
         || StringUtils.isBlank(newPassword)) {
@@ -180,6 +181,13 @@ public class DefaultUserAccountService implements UserAccountService {
       throw new BadRequestException("Account is not expired");
     }
 
+    // Prefer email-token recovery when it is available for this account (defense in depth for the
+    // FE steering done at login). Checked only after password + expiry so the conflict is not a
+    // username-enumeration oracle and wrong-password attempts still feed the recovery lockout.
+    if (canUseEmailPasswordRecovery(user)) {
+      throw new ConflictException("Password must be reset using email recovery for this account");
+    }
+
     // The old password was verified against the stored hash above, so plain equality is enough.
     if (newPassword.equals(oldPassword)) {
       throw new BadRequestException("New password must be different from the old password");
@@ -191,6 +199,19 @@ public class DefaultUserAccountService implements UserAccountService {
     userService.updateUser(user, new SystemUser());
 
     log.info("Expired password updated for user: {}", user.getUsername());
+  }
+
+  @Override
+  public boolean canUseEmailPasswordRecovery(User user) {
+    if (user == null) {
+      return false;
+    }
+    if (!settingsProvider.getCurrentSettings().getAccountRecoveryEnabled()) {
+      return false;
+    }
+    // validateRestore: valid email, not external auth, and email sender configured
+    // (host/user/password).
+    return userService.validateRestore(user) == null;
   }
 
   /** Rejects a new password that is equal to the username or fails the password policy. */

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserAccountServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserAccountServiceTest.java
@@ -45,6 +45,8 @@ import org.hisp.dhis.common.auth.RegistrationParams;
 import org.hisp.dhis.common.auth.UserRegistrationParams;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ConflictException;
+import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.security.PasswordManager;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationProvider;
@@ -181,6 +183,7 @@ class UserAccountServiceTest {
     when(userService.isRecoveryLocked("mia")).thenReturn(false);
     when(passwordManager.matches("Old_pw1!", "encoded-old")).thenReturn(true);
     when(userService.userNonExpired(user)).thenReturn(false);
+    stubEmailRecoveryUnavailable();
 
     BadRequestException exception =
         assertThrows(
@@ -192,12 +195,14 @@ class UserAccountServiceTest {
 
   @Test
   @DisplayName("updateExpiredPassword sets and persists a valid new password")
-  void updateExpiredPasswordOkTest() throws BadRequestException, ForbiddenException {
+  void updateExpiredPasswordOkTest()
+      throws BadRequestException, ConflictException, ForbiddenException {
     User user = expiredPasswordUser();
     when(userService.getUserByUsername("mia")).thenReturn(user);
     when(userService.isRecoveryLocked("mia")).thenReturn(false);
     when(passwordManager.matches("Old_pw1!", "encoded-old")).thenReturn(true);
     when(userService.userNonExpired(user)).thenReturn(false);
+    stubEmailRecoveryUnavailable();
     when(passwordValidationService.validate(any(CredentialsInfo.class)))
         .thenReturn(PasswordValidationResult.VALID);
 
@@ -212,6 +217,61 @@ class UserAccountServiceTest {
     user.setUsername("mia");
     user.setPassword("encoded-old");
     return user;
+  }
+
+  /** Gate is reached after password+expiry; recovery off keeps the emailless path open. */
+  private void stubEmailRecoveryUnavailable() {
+    when(settingsService.getCurrentSettings())
+        .thenReturn(SystemSettings.of(Map.of("keyAccountRecovery", "false")));
+  }
+
+  private void stubEmailRecoveryAvailable(User user) {
+    when(settingsService.getCurrentSettings())
+        .thenReturn(SystemSettings.of(Map.of("keyAccountRecovery", "true")));
+    when(userService.validateRestore(user)).thenReturn(null);
+  }
+
+  @Test
+  @DisplayName("updateExpiredPassword rejects when email recovery is available for the account")
+  void updateExpiredPasswordEmailRecoveryRequiredTest() {
+    User user = expiredPasswordUser();
+    user.setEmail("mia@dhis2.org");
+    when(userService.getUserByUsername("mia")).thenReturn(user);
+    when(userService.isRecoveryLocked("mia")).thenReturn(false);
+    when(passwordManager.matches("Old_pw1!", "encoded-old")).thenReturn(true);
+    when(userService.userNonExpired(user)).thenReturn(false);
+    stubEmailRecoveryAvailable(user);
+
+    ConflictException exception =
+        assertThrows(
+            ConflictException.class,
+            () -> userAccountService.updateExpiredPassword("mia", "Old_pw1!", "New_pw1!"));
+
+    assertEquals(
+        "Password must be reset using email recovery for this account", exception.getMessage());
+    verify(userService, never()).encodeAndSetPassword(any(User.class), anyString());
+  }
+
+  @Test
+  @DisplayName(
+      "canUseEmailPasswordRecovery is true only when recovery is enabled and restore validates")
+  void canUseEmailPasswordRecoveryTest() {
+    User user = expiredPasswordUser();
+    user.setEmail("mia@dhis2.org");
+
+    when(settingsService.getCurrentSettings())
+        .thenReturn(SystemSettings.of(Map.of("keyAccountRecovery", "false")));
+    assertEquals(false, userAccountService.canUseEmailPasswordRecovery(user));
+
+    when(settingsService.getCurrentSettings())
+        .thenReturn(SystemSettings.of(Map.of("keyAccountRecovery", "true")));
+    when(userService.validateRestore(user)).thenReturn(ErrorCode.E6203);
+    assertEquals(false, userAccountService.canUseEmailPasswordRecovery(user));
+
+    when(userService.validateRestore(user)).thenReturn(null);
+    assertEquals(true, userAccountService.canUseEmailPasswordRecovery(user));
+
+    assertEquals(false, userAccountService.canUseEmailPasswordRecovery(null));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginResponse.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/login/LoginResponse.java
@@ -50,6 +50,7 @@ public class LoginResponse {
     ACCOUNT_LOCKED("accountLocked"),
     ACCOUNT_EXPIRED("accountExpired"),
     PASSWORD_EXPIRED("passwordExpired"),
+    PASSWORD_EXPIRED_EMAIL_RECOVERY("passwordExpiredEmailRecovery"),
     EMAIL_TWO_FACTOR_CODE_SENT("emailTwoFactorCodeSent"),
     INCORRECT_TWO_FACTOR_CODE_TOTP("incorrectTwoFactorCodeTOTP"),
     INCORRECT_TWO_FACTOR_CODE_EMAIL("incorrectTwoFactorCodeEmail"),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
@@ -94,6 +94,11 @@ class UserAccountControllerTest extends H2ControllerIntegrationTestBase {
   @AfterEach
   void afterEach() {
     emailMessageSender.clearMessages();
+    settingsService.put("keyAccountRecovery", false);
+    settingsService.put("credentialsExpires", 0);
+    settingsService.put("keyEmailHostName", "");
+    settingsService.put("keyEmailUsername", "");
+    settingsService.clearCurrentSettings();
   }
 
   @Test
@@ -196,6 +201,9 @@ class UserAccountControllerTest extends H2ControllerIntegrationTestBase {
   void testUpdatePasswordExpiredOk() {
     String oldPassword = "Str0ng_old_1!";
     String newPassword = "Str0ng_new_1!";
+    // Recovery off (default) keeps the emailless path; pin explicitly against suite order.
+    settingsService.put("keyAccountRecovery", false);
+    settingsService.clearCurrentSettings();
     User user = createExpiredUser("expireda", oldPassword);
     clearSecurityContext();
 
@@ -214,6 +222,68 @@ class UserAccountControllerTest extends H2ControllerIntegrationTestBase {
     assertTrue(passwordEncoder.matches(newPassword, updated.getPassword()));
     // The account is no longer expired, so the frontend's follow-up auth/login will succeed.
     assertTrue(userService.userNonExpired(updated));
+  }
+
+  @Test
+  @DisplayName(
+      "Expired user with email recovery available cannot use auth/updatePassword (must use email)")
+  void testUpdatePasswordExpiredEmailRecoveryRequired() {
+    String oldPassword = "Str0ng_old_1!";
+    String newPassword = "Str0ng_new_1!";
+    User user = createExpiredUser("expiredemail", oldPassword);
+    // createUserWithAuth sets email username@dhis2.org; enable recovery + email settings so
+    // validateRestore succeeds (FakeMessageSender is always configured in tests).
+    settingsService.put("keyAccountRecovery", true);
+    settingsService.put("keyEmailHostName", "mail.example.com");
+    settingsService.put("keyEmailUsername", "noreply");
+    settingsService.put("keyEmailPassword", "secret");
+    settingsService.clearCurrentSettings();
+    clearSecurityContext();
+
+    assertWebMessage(
+        "Conflict",
+        409,
+        "ERROR",
+        "Password must be reset using email recovery for this account",
+        POST(
+                "/auth/updatePassword",
+                "{'username':'%s','oldPassword':'%s','newPassword':'%s'}"
+                    .formatted(user.getUsername(), oldPassword, newPassword))
+            .content(HttpStatus.CONFLICT));
+
+    User updated = userService.getUserByUsername(user.getUsername());
+    assertTrue(passwordEncoder.matches(oldPassword, updated.getPassword()));
+    assertFalse(userService.userNonExpired(updated));
+  }
+
+  @Test
+  @DisplayName("Expired user without email can still change password when recovery is enabled")
+  void testUpdatePasswordExpiredNoEmailOk() {
+    String oldPassword = "Str0ng_old_1!";
+    String newPassword = "Str0ng_new_1!";
+    User user = createExpiredUser("expirednoem", oldPassword);
+    user.setEmail(null);
+    userService.updateUser(user);
+    settingsService.put("keyAccountRecovery", true);
+    settingsService.put("keyEmailHostName", "mail.example.com");
+    settingsService.put("keyEmailUsername", "noreply");
+    settingsService.put("keyEmailPassword", "secret");
+    settingsService.clearCurrentSettings();
+    clearSecurityContext();
+
+    assertWebMessage(
+        "OK",
+        200,
+        "OK",
+        "Password updated",
+        POST(
+                "/auth/updatePassword",
+                "{'username':'%s','oldPassword':'%s','newPassword':'%s'}"
+                    .formatted(user.getUsername(), oldPassword, newPassword))
+            .content(HttpStatus.OK));
+
+    User updated = userService.getUserByUsername(user.getUsername());
+    assertTrue(passwordEncoder.matches(newPassword, updated.getPassword()));
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
@@ -73,6 +73,10 @@ class AuthenticationControllerTest extends AuthenticationApiTestBase {
   void tearDown() {
     settingsService.put("keyLockMultipleFailedLogins", false);
     settingsService.put("credentialsExpires", 0);
+    settingsService.put("keyAccountRecovery", false);
+    settingsService.put("keyEmailHostName", "");
+    settingsService.put("keyEmailUsername", "");
+    settingsService.put("keyEmailPassword", "");
     settingsService.clearCurrentSettings();
     userService.invalidateAllSessions();
     clearSecurityContext();
@@ -269,9 +273,71 @@ class AuthenticationControllerTest extends AuthenticationApiTestBase {
   @Test
   void testLoginWithCredentialsExpiredUser() {
     settingsService.put("credentialsExpires", 1);
+    settingsService.put("keyAccountRecovery", false);
+    settingsService.put("keyEmailHostName", "");
+    settingsService.put("keyEmailUsername", "");
+    settingsService.put("keyEmailPassword", "");
     settingsService.clearCurrentSettings();
 
     User admin = userService.getUserByUsername("admin");
+
+    Calendar calendar = Calendar.getInstance();
+    calendar.setTime(admin.getPasswordLastUpdated());
+    calendar.add(Calendar.MONTH, -2);
+
+    admin.setPasswordLastUpdated(calendar.getTime());
+    userService.updateUser(admin);
+
+    JsonLoginResponse loginResponse =
+        POST("/auth/login", "{'username':'admin','password':'district'}")
+            .content(HttpStatus.OK)
+            .as(JsonLoginResponse.class);
+
+    assertEquals("PASSWORD_EXPIRED", loginResponse.getLoginStatus());
+    assertNull(loginResponse.getRedirectUrl());
+  }
+
+  @Test
+  void testLoginWithCredentialsExpiredUserEmailRecovery() {
+    settingsService.put("credentialsExpires", 1);
+    settingsService.put("keyAccountRecovery", true);
+    settingsService.put("keyEmailHostName", "mail.example.com");
+    settingsService.put("keyEmailUsername", "noreply");
+    settingsService.put("keyEmailPassword", "secret");
+    settingsService.clearCurrentSettings();
+
+    User admin = userService.getUserByUsername("admin");
+    // Admin fixtures often carry a non-RFC email (e.g. "emaila"); force a valid one so
+    // validateRestore (real EmailMessageSender) can succeed.
+    admin.setEmail("admin@dhis2.org");
+
+    Calendar calendar = Calendar.getInstance();
+    calendar.setTime(admin.getPasswordLastUpdated());
+    calendar.add(Calendar.MONTH, -2);
+
+    admin.setPasswordLastUpdated(calendar.getTime());
+    userService.updateUser(admin);
+
+    JsonLoginResponse loginResponse =
+        POST("/auth/login", "{'username':'admin','password':'district'}")
+            .content(HttpStatus.OK)
+            .as(JsonLoginResponse.class);
+
+    assertEquals("PASSWORD_EXPIRED_EMAIL_RECOVERY", loginResponse.getLoginStatus());
+    assertNull(loginResponse.getRedirectUrl());
+  }
+
+  @Test
+  void testLoginWithCredentialsExpiredUserNoEmailKeepsOldPasswordPath() {
+    settingsService.put("credentialsExpires", 1);
+    settingsService.put("keyAccountRecovery", true);
+    settingsService.put("keyEmailHostName", "mail.example.com");
+    settingsService.put("keyEmailUsername", "noreply");
+    settingsService.put("keyEmailPassword", "secret");
+    settingsService.clearCurrentSettings();
+
+    User admin = userService.getUserByUsername("admin");
+    admin.setEmail(null);
 
     Calendar calendar = Calendar.getInstance();
     calendar.setTime(admin.getPasswordLastUpdated());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
@@ -77,6 +77,7 @@ import org.hisp.dhis.user.RestoreOptions;
 import org.hisp.dhis.user.RestoreType;
 import org.hisp.dhis.user.SystemUser;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserAccountService;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserLookup;
 import org.hisp.dhis.user.UserRole;
@@ -116,6 +117,7 @@ public class AccountController {
   private static final int MAX_PHONE_NO_LENGTH = 30;
 
   private final UserService userService;
+  private final UserAccountService userAccountService;
 
   private final TwoFactorAuthenticationProvider twoFactorAuthenticationProvider;
 
@@ -473,6 +475,13 @@ public class AccountController {
     if (userService.userNonExpired(user)) {
       result.put("status", "NON_EXPIRED");
       result.put("message", "Account is not expired, redirecting to login.");
+
+      return ResponseEntity.badRequest().cacheControl(noStore()).body(result);
+    }
+
+    if (userAccountService.canUseEmailPasswordRecovery(user)) {
+      result.put("status", "EMAIL_RECOVERY_REQUIRED");
+      result.put("message", "Password must be reset using email recovery for this account");
 
       return ResponseEntity.badRequest().cacheControl(noStore()).body(result);
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetails;
 import org.hisp.dhis.security.twofa.TwoFactorType;
 import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserAccountService;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.controller.security.LoginResponse.STATUS;
@@ -108,6 +109,7 @@ public class AuthenticationController {
   @Autowired private RequestCache requestCache;
   @Autowired private SessionRegistry sessionRegistry;
   @Autowired private UserService userService;
+  @Autowired private UserAccountService userAccountService;
 
   @Autowired protected ApplicationEventPublisher eventPublisher;
   @Autowired private HttpSessionEventPublisher httpSessionEventPublisher;
@@ -178,7 +180,9 @@ public class AuthenticationController {
     } catch (TwoFactorAuthenticationEnrolmentException e) {
       return LoginResponse.builder().loginStatus(STATUS.REQUIRES_TWO_FACTOR_ENROLMENT).build();
     } catch (CredentialsExpiredException e) {
-      return LoginResponse.builder().loginStatus(STATUS.PASSWORD_EXPIRED).build();
+      return LoginResponse.builder()
+          .loginStatus(passwordExpiredStatus(loginRequest.getUsername()))
+          .build();
     } catch (LockedException e) {
       return LoginResponse.builder().loginStatus(STATUS.ACCOUNT_LOCKED).build();
     } catch (DisabledException e) {
@@ -186,6 +190,18 @@ public class AuthenticationController {
     } catch (AccountExpiredException e) {
       return LoginResponse.builder().loginStatus(STATUS.ACCOUNT_EXPIRED).build();
     }
+  }
+
+  /**
+   * Email-capable accounts with working recovery are steered to token reset; others keep the
+   * old-password self-service status.
+   */
+  private STATUS passwordExpiredStatus(String username) {
+    User user = userService.getUserByUsername(username);
+    if (userAccountService.canUseEmailPasswordRecovery(user)) {
+      return STATUS.PASSWORD_EXPIRED_EMAIL_RECOVERY;
+    }
+    return STATUS.PASSWORD_EXPIRED;
   }
 
   private void validateRequest(LoginRequest loginRequest) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginResponse.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginResponse.java
@@ -52,6 +52,7 @@ public class LoginResponse {
     ACCOUNT_LOCKED("accountLocked"),
     ACCOUNT_EXPIRED("accountExpired"),
     PASSWORD_EXPIRED("passwordExpired"),
+    PASSWORD_EXPIRED_EMAIL_RECOVERY("passwordExpiredEmailRecovery"),
     EMAIL_TWO_FACTOR_CODE_SENT("emailTwoFactorCodeSent"),
     INCORRECT_TWO_FACTOR_CODE_TOTP("incorrectTwoFactorCodeTOTP"),
     INCORRECT_TWO_FACTOR_CODE_EMAIL("incorrectTwoFactorCodeEmail"),

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
@@ -207,7 +207,7 @@ public class UserAccountController {
   @PostMapping("/updatePassword")
   @ResponseStatus(HttpStatus.OK)
   public WebMessage updatePassword(@RequestBody UpdatePasswordRequest request)
-      throws BadRequestException, ForbiddenException {
+      throws BadRequestException, ConflictException, ForbiddenException {
     userAccountService.updateExpiredPassword(
         request.getUsername(), request.getOldPassword(), request.getNewPassword());
     return ok("Password updated");


### PR DESCRIPTION
## Summary
Backport of #24552 to `2.43`.
- Login status `PASSWORD_EXPIRED_EMAIL_RECOVERY` when email recovery is available
- Gate on `POST /api/auth/updatePassword` and legacy `POST /api/account/password`

## Test plan
- [x] UserAccountServiceTest
- [x] UserAccountControllerTest
- [x] AuthenticationControllerTest