### PR TITLE
fix: require email recovery for expired password when email works [DHIS2-21120] (2.41)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserAccountService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserAccountService.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.common.auth.RegistrationParams;
 import org.hisp.dhis.common.auth.UserInviteParams;
 import org.hisp.dhis.common.auth.UserRegistrationParams;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 
 /**
@@ -84,6 +85,19 @@ public interface UserAccountService {
       throws BadRequestException, IOException;
 
   /**
+   * Whether this account should recover an expired password via email token rather than the
+   * old-password self-service path. True only when account recovery is enabled and {@link
+   * UserService#validateRestore(User)} succeeds (valid email, not external auth, email sender
+   * configured including SMTP password). When true, login should return {@code
+   * PASSWORD_EXPIRED_EMAIL_RECOVERY} and the expired-password self-service update must reject the
+   * call.
+   *
+   * @param user account under consideration; {@code null} yields {@code false}
+   * @return {@code true} when email recovery is the required path for this user
+   */
+  boolean canUseEmailPasswordRecovery(User user);
+
+  /**
    * Self-service change of an <b>expired</b> password. The caller is not logged in, so the method
    * is self-guarding: it only proceeds for an expired account whose current password is supplied
    * correctly. It deliberately does not establish a session; once the password is changed the
@@ -94,13 +108,18 @@ public interface UserAccountService {
    * repeated attempts against one account are throttled via the shared account-recovery lockout
    * (mirrors the forgot-password flow).
    *
+   * <p>When {@link #canUseEmailPasswordRecovery(User)} is true for the account, this method rejects
+   * after the password and expiry checks so the stronger email-token recovery path cannot be
+   * bypassed by calling the endpoint directly.
+   *
    * @param username username identifying the account
    * @param oldPassword the current (expired) password
    * @param newPassword new password, subject to the password policy
    * @throws BadRequestException when input is missing, credentials are wrong, the account is not
    *     expired, or the new password is not acceptable
+   * @throws ConflictException when the account must use email recovery instead of this path
    * @throws ForbiddenException when the account is temporarily locked due to too many attempts
    */
   void updateExpiredPassword(String username, String oldPassword, String newPassword)
-      throws BadRequestException, ForbiddenException;
+      throws BadRequestException, ConflictException, ForbiddenException;
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserAccountService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserAccountService.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.common.auth.UserInviteParams;
 import org.hisp.dhis.common.auth.UserRegistrationParams;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.security.PasswordManager;
@@ -142,7 +143,7 @@ public class DefaultUserAccountService implements UserAccountService {
   @Override
   @Transactional
   public void updateExpiredPassword(String username, String oldPassword, String newPassword)
-      throws BadRequestException, ForbiddenException {
+      throws BadRequestException, ConflictException, ForbiddenException {
     if (StringUtils.isBlank(username)
         || StringUtils.isBlank(oldPassword)
         || StringUtils.isBlank(newPassword)) {
@@ -173,6 +174,13 @@ public class DefaultUserAccountService implements UserAccountService {
       throw new BadRequestException("Account is not expired");
     }
 
+    // Prefer email-token recovery when it is available for this account (defense in depth for the
+    // FE steering done at login). Checked only after password + expiry so the conflict is not a
+    // username-enumeration oracle and wrong-password attempts still feed the recovery lockout.
+    if (canUseEmailPasswordRecovery(user)) {
+      throw new ConflictException("Password must be reset using email recovery for this account");
+    }
+
     // The old password was verified against the stored hash above, so plain equality is enough.
     if (newPassword.equals(oldPassword)) {
       throw new BadRequestException("New password must be different from the old password");
@@ -184,6 +192,19 @@ public class DefaultUserAccountService implements UserAccountService {
     userService.updateUser(user, new SystemUser());
 
     log.info("Expired password updated for user: {}", user.getUsername());
+  }
+
+  @Override
+  public boolean canUseEmailPasswordRecovery(User user) {
+    if (user == null) {
+      return false;
+    }
+    if (!systemSettingManager.accountRecoveryEnabled()) {
+      return false;
+    }
+    // validateRestore: valid email, not external auth, and email sender configured
+    // (host/user/password).
+    return userService.validateRestore(user) == null;
   }
 
   /** Rejects a new password that is equal to the username or fails the password policy. */

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
@@ -187,6 +187,7 @@ class UserAccountControllerTest extends DhisControllerConvenienceTest {
   void testUpdatePasswordExpiredOk() {
     String oldPassword = "Str0ng_old_1!";
     String newPassword = "Str0ng_new_1!";
+    systemSettingManager.saveSystemSetting(SettingKey.ACCOUNT_RECOVERY, false);
     User user = createExpiredUser("expireda", oldPassword);
     clearSecurityContext();
 
@@ -205,6 +206,64 @@ class UserAccountControllerTest extends DhisControllerConvenienceTest {
     assertTrue(passwordEncoder.matches(newPassword, updated.getPassword()));
     // The account is no longer expired, so the frontend's follow-up auth/login will succeed.
     assertTrue(userService.userNonExpired(updated));
+  }
+
+  @Test
+  @DisplayName(
+      "Expired user with email recovery available cannot use auth/updatePassword (must use email)")
+  void testUpdatePasswordExpiredEmailRecoveryRequired() {
+    String oldPassword = "Str0ng_old_1!";
+    String newPassword = "Str0ng_new_1!";
+    User user = createExpiredUser("expiredemail", oldPassword);
+    systemSettingManager.saveSystemSetting(SettingKey.ACCOUNT_RECOVERY, true);
+    systemSettingManager.saveSystemSetting(SettingKey.EMAIL_HOST_NAME, "mail.example.com");
+    systemSettingManager.saveSystemSetting(SettingKey.EMAIL_USERNAME, "noreply");
+    systemSettingManager.saveSystemSetting(SettingKey.EMAIL_PASSWORD, "secret");
+    clearSecurityContext();
+
+    assertWebMessage(
+        "Conflict",
+        409,
+        "ERROR",
+        "Password must be reset using email recovery for this account",
+        POST(
+                "/auth/updatePassword",
+                "{'username':'%s','oldPassword':'%s','newPassword':'%s'}"
+                    .formatted(user.getUsername(), oldPassword, newPassword))
+            .content(HttpStatus.CONFLICT));
+
+    User updated = userService.getUserByUsername(user.getUsername());
+    assertTrue(passwordEncoder.matches(oldPassword, updated.getPassword()));
+    assertFalse(userService.userNonExpired(updated));
+  }
+
+  @Test
+  @DisplayName("Expired user without email can still change password when recovery is enabled")
+  void testUpdatePasswordExpiredNoEmailOk() {
+    String oldPassword = "Str0ng_old_1!";
+    String newPassword = "Str0ng_new_1!";
+    User user = createExpiredUser("expirednoem", oldPassword);
+    user.setEmail(null);
+    userService.updateUser(user);
+    systemSettingManager.saveSystemSetting(SettingKey.ACCOUNT_RECOVERY, true);
+    systemSettingManager.saveSystemSetting(SettingKey.EMAIL_HOST_NAME, "mail.example.com");
+    systemSettingManager.saveSystemSetting(SettingKey.EMAIL_USERNAME, "noreply");
+    systemSettingManager.saveSystemSetting(SettingKey.EMAIL_PASSWORD, "secret");
+    clearSecurityContext();
+
+    assertWebMessage(
+        "OK",
+        200,
+        "OK",
+        "Password updated",
+        POST(
+                "/auth/updatePassword",
+                "{'username':'%s','oldPassword':'%s','newPassword':'%s'}"
+                    .formatted(user.getUsername(), oldPassword, newPassword))
+            .content(HttpStatus.OK));
+
+    User updated = userService.getUserByUsername(user.getUsername());
+    assertTrue(passwordEncoder.matches(newPassword, updated.getPassword()));
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
@@ -182,8 +182,63 @@ class AuthenticationControllerTest extends DhisAuthenticationApiTest {
   @Test
   void testLoginWithCredentialsExpiredUser() {
     systemSettingManager.saveSystemSetting(SettingKey.CREDENTIALS_EXPIRES, 1);
+    systemSettingManager.saveSystemSetting(SettingKey.ACCOUNT_RECOVERY, false);
 
     User admin = userService.getUserByUsername("admin");
+
+    Calendar calendar = Calendar.getInstance();
+    calendar.setTime(admin.getPasswordLastUpdated());
+    calendar.add(Calendar.MONTH, -2);
+
+    admin.setPasswordLastUpdated(calendar.getTime());
+    userService.updateUser(admin);
+
+    JsonLoginResponse loginResponse =
+        POST("/auth/login", "{'username':'admin','password':'district'}")
+            .content(HttpStatus.OK)
+            .as(JsonLoginResponse.class);
+
+    assertEquals("PASSWORD_EXPIRED", loginResponse.getLoginStatus());
+    assertNull(loginResponse.getRedirectUrl());
+  }
+
+  @Test
+  void testLoginWithCredentialsExpiredUserEmailRecovery() {
+    systemSettingManager.saveSystemSetting(SettingKey.CREDENTIALS_EXPIRES, 1);
+    systemSettingManager.saveSystemSetting(SettingKey.ACCOUNT_RECOVERY, true);
+    systemSettingManager.saveSystemSetting(SettingKey.EMAIL_HOST_NAME, "mail.example.com");
+    systemSettingManager.saveSystemSetting(SettingKey.EMAIL_USERNAME, "noreply");
+    systemSettingManager.saveSystemSetting(SettingKey.EMAIL_PASSWORD, "secret");
+
+    User admin = userService.getUserByUsername("admin");
+    admin.setEmail("admin@dhis2.org");
+
+    Calendar calendar = Calendar.getInstance();
+    calendar.setTime(admin.getPasswordLastUpdated());
+    calendar.add(Calendar.MONTH, -2);
+
+    admin.setPasswordLastUpdated(calendar.getTime());
+    userService.updateUser(admin);
+
+    JsonLoginResponse loginResponse =
+        POST("/auth/login", "{'username':'admin','password':'district'}")
+            .content(HttpStatus.OK)
+            .as(JsonLoginResponse.class);
+
+    assertEquals("PASSWORD_EXPIRED_EMAIL_RECOVERY", loginResponse.getLoginStatus());
+    assertNull(loginResponse.getRedirectUrl());
+  }
+
+  @Test
+  void testLoginWithCredentialsExpiredUserNoEmailKeepsOldPasswordPath() {
+    systemSettingManager.saveSystemSetting(SettingKey.CREDENTIALS_EXPIRES, 1);
+    systemSettingManager.saveSystemSetting(SettingKey.ACCOUNT_RECOVERY, true);
+    systemSettingManager.saveSystemSetting(SettingKey.EMAIL_HOST_NAME, "mail.example.com");
+    systemSettingManager.saveSystemSetting(SettingKey.EMAIL_USERNAME, "noreply");
+    systemSettingManager.saveSystemSetting(SettingKey.EMAIL_PASSWORD, "secret");
+
+    User admin = userService.getUserByUsername("admin");
+    admin.setEmail(null);
 
     Calendar calendar = Calendar.getInstance();
     calendar.setTime(admin.getPasswordLastUpdated());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
@@ -72,6 +72,7 @@ import org.hisp.dhis.user.RestoreOptions;
 import org.hisp.dhis.user.RestoreType;
 import org.hisp.dhis.user.SystemUser;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserAccountService;
 import org.hisp.dhis.user.UserLookup;
 import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.user.UserService;
@@ -106,6 +107,7 @@ public class AccountController {
   private static final int MAX_PHONE_NO_LENGTH = 30;
 
   private final UserService userService;
+  private final UserAccountService userAccountService;
 
   private final TwoFactorAuthenticationProvider twoFactorAuthenticationProvider;
 
@@ -456,6 +458,13 @@ public class AccountController {
     if (userService.userNonExpired(user)) {
       result.put("status", "NON_EXPIRED");
       result.put("message", "Account is not expired, redirecting to login.");
+
+      return ResponseEntity.badRequest().cacheControl(noStore()).body(result);
+    }
+
+    if (userAccountService.canUseEmailPasswordRecovery(user)) {
+      result.put("status", "EMAIL_RECOVERY_REQUIRED");
+      result.put("message", "Password must be reset using email recovery for this account");
 
       return ResponseEntity.badRequest().cacheControl(noStore()).body(result);
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetails;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserAccountService;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.controller.security.LoginResponse.STATUS;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -100,6 +101,7 @@ public class AuthenticationController {
   @Autowired private RequestCache requestCache;
   @Autowired private SessionRegistry sessionRegistry;
   @Autowired private UserService userService;
+  @Autowired private UserAccountService userAccountService;
 
   private SessionAuthenticationStrategy sessionStrategy = new NullAuthenticatedSessionStrategy();
 
@@ -151,7 +153,9 @@ public class AuthenticationController {
       return LoginResponse.builder().loginStatus(STATUS.REQUIRES_TWO_FACTOR_ENROLMENT).build();
 
     } catch (CredentialsExpiredException e) {
-      return LoginResponse.builder().loginStatus(STATUS.PASSWORD_EXPIRED).build();
+      return LoginResponse.builder()
+          .loginStatus(passwordExpiredStatus(loginRequest.getUsername()))
+          .build();
     } catch (LockedException e) {
       return LoginResponse.builder().loginStatus(STATUS.ACCOUNT_LOCKED).build();
     } catch (DisabledException e) {
@@ -159,6 +163,18 @@ public class AuthenticationController {
     } catch (AccountExpiredException e) {
       return LoginResponse.builder().loginStatus(STATUS.ACCOUNT_EXPIRED).build();
     }
+  }
+
+  /**
+   * Email-capable accounts with working recovery are steered to token reset; others keep the
+   * old-password self-service status.
+   */
+  private STATUS passwordExpiredStatus(String username) {
+    User user = userService.getUserByUsername(username);
+    if (userAccountService.canUseEmailPasswordRecovery(user)) {
+      return STATUS.PASSWORD_EXPIRED_EMAIL_RECOVERY;
+    }
+    return STATUS.PASSWORD_EXPIRED;
   }
 
   private void validateRequest(LoginRequest loginRequest) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginResponse.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginResponse.java
@@ -48,6 +48,7 @@ public class LoginResponse {
     ACCOUNT_LOCKED("accountLocked"),
     ACCOUNT_EXPIRED("accountExpired"),
     PASSWORD_EXPIRED("passwordExpired"),
+    PASSWORD_EXPIRED_EMAIL_RECOVERY("passwordExpiredEmailRecovery"),
     INCORRECT_TWO_FACTOR_CODE("incorrectTwoFactorCode"),
     REQUIRES_TWO_FACTOR_ENROLMENT("requiresTwoFactorEnrolment");
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
@@ -207,7 +207,7 @@ public class UserAccountController {
   @PostMapping("/updatePassword")
   @ResponseStatus(HttpStatus.OK)
   public WebMessageResponse updatePassword(@RequestBody UpdatePasswordRequest request)
-      throws BadRequestException, ForbiddenException {
+      throws BadRequestException, ConflictException, ForbiddenException {
     userAccountService.updateExpiredPassword(
         request.getUsername(), request.getOldPassword(), request.getNewPassword());
     return ok("Password updated");


### PR DESCRIPTION
## Summary
Backport of #24552 to `2.41`.
- Login status `PASSWORD_EXPIRED_EMAIL_RECOVERY` when email recovery is available
- Gate on `POST /api/auth/updatePassword` and legacy `POST /api/account/password`

## Test plan
- [x] UserAccountControllerTest
- [x] AuthenticationControllerTest (Postgres/Testcontainers)