### PR TITLE
perf: batch-resolve members in UserRoleBundleHook session invalidation (DHIS2-21842)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -611,6 +611,15 @@ public interface UserService {
   void invalidateUserSessions(String username);
 
   /**
+   * Invalidate all sessions for the given users. The users are resolved in a single batch query
+   * rather than one lookup per username, avoiding an N+1 (and, under {@code FlushModeType.AUTO}, an
+   * O(n²) auto-flush) when invalidating a large membership.
+   *
+   * @param usernames the usernames of the user accounts.
+   */
+  void invalidateUserSessions(Collection<String> usernames);
+
+  /**
    * Register a account recovery attempt for the given user account.
    *
    * @param username the username of the user account.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -1064,6 +1064,22 @@ public class DefaultUserService implements UserService {
   }
 
   @Override
+  public void invalidateUserSessions(Collection<String> usernames) {
+    if (usernames == null || usernames.isEmpty()) {
+      return;
+    }
+    // Resolve all users in a single query instead of one getUserByUsername per username. That
+    // per-member lookup is the N+1 behind DHIS2-21842; under FlushModeType.AUTO each call also
+    // auto-flushes the growing persistence context, making a large-membership invalidation O(n²).
+    for (User user : userStore.getUserByUsernames(usernames)) {
+      UserDetails userDetails = createUserDetails(user);
+      if (userDetails != null) {
+        sessionRegistry.getAllSessions(userDetails, false).forEach(SessionInformation::expireNow);
+      }
+    }
+  }
+
+  @Override
   @Transactional(readOnly = true)
   public ErrorCode validateInvite(User user) {
     if (user == null) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHook.java
@@ -69,9 +69,10 @@ public class UserRoleBundleHook extends AbstractObjectBundleHook<UserRole> {
         (Boolean) bundle.getExtras(updatedUserRole, INVALIDATE_SESSION_KEY);
 
     if (Boolean.TRUE.equals(invalidateSessions)) {
-      for (User user : updatedUserRole.getUsers()) {
-        userService.invalidateUserSessions(user.getUsername());
-      }
+      // Batch-resolve members in one query instead of one getUserByUsername per member
+      // (DHIS2-21842).
+      userService.invalidateUserSessions(
+          updatedUserRole.getUsers().stream().map(User::getUsername).toList());
     }
 
     bundle.removeExtras(updatedUserRole, INVALIDATE_SESSION_KEY);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserControllerTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
@@ -223,7 +224,7 @@ class UserControllerTest {
     userController.expireUser(user.getUid(), inTheFuture);
 
     assertUserUpdatedWithAccountExpiry(inTheFuture);
-    verify(userService, never()).invalidateUserSessions(any());
+    verify(userService, never()).invalidateUserSessions(anyString());
   }
 
   @Test


### PR DESCRIPTION
Follow-up to the getUserByUsername flush-mode fix. UserRoleBundleHook.postUpdate invalidated each member's sessions one-by-one via invalidateUserSessions(username), and each call ran getUserByUsername -> a per-member N+1 (and, under FlushModeType.AUTO, an O(n^2) auto-flush) when a role has a large membership.

Add UserService.invalidateUserSessions(Collection<String>) which resolves all users in a single UserStore.getUserByUsernames(...) query, and call it once from the hook with the members' usernames. Collapses the N per-member lookups to one.

Disambiguated the now-overloaded call in UserControllerTest (any() -> anyString()).