### PR TITLE
fix: Use also data values from DB to init rule-engine context [DHIS2-21887] (2.42)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapper.java
@@ -32,8 +32,12 @@ package org.hisp.dhis.tracker.imports.programrule;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentStatus;
@@ -51,6 +55,7 @@ import org.hisp.dhis.rules.models.RuleInstant;
 import org.hisp.dhis.rules.models.RuleLocalDate;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.imports.domain.Attribute;
+import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.util.ObjectUtils;
 
@@ -179,14 +184,40 @@ class RuleEngineMapper {
             : DateUtils.toRuleLocalDate(eventToEvaluate.getCompletedAt()),
         organisationUnit.getUid(),
         organisationUnit.getCode(),
-        eventToEvaluate.getDataValues().stream()
+        getDataValues(
+            eventToEvaluate.getDataValues(),
+            event == null ? Set.of() : event.getEventDataValues(),
+            preheat));
+  }
+
+  private static List<RuleDataValue> getDataValues(
+      Set<DataValue> payloadDataValues, Set<EventDataValue> dbDataValues, TrackerPreheat preheat) {
+    // Data elements present in the payload, whether they carry a value or are explicitly cleared
+    // (null value). A cleared value must not fall back to the persisted one, so these are excluded
+    // from the DB merge below.
+    Set<String> payloadDataElements =
+        payloadDataValues.stream()
+            .filter(Objects::nonNull)
+            .map(dv -> preheat.getDataElement(dv.getDataElement()).getUid())
+            .collect(Collectors.toSet());
+
+    List<RuleDataValue> ruleDataValues =
+        payloadDataValues.stream()
             .filter(Objects::nonNull)
             .filter(dv -> dv.getValue() != null)
             .map(
                 dv ->
                     new RuleDataValue(
                         preheat.getDataElement(dv.getDataElement()).getUid(), dv.getValue()))
-            .toList());
+            .toList();
+
+    Stream<RuleDataValue> dbRuleDataValues =
+        dbDataValues.stream()
+            .filter(dv -> dv.getValue() != null)
+            .filter(dv -> !payloadDataElements.contains(dv.getDataElement()))
+            .map(dv -> new RuleDataValue(dv.getDataElement(), dv.getValue()));
+
+    return Stream.concat(ruleDataValues.stream(), dbRuleDataValues).toList();
   }
 
   private static RuleEvent mapSavedEvent(Event eventToEvaluate) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapperTest.java
@@ -146,6 +146,91 @@ class RuleEngineRuleEngineMapperTest extends TestBase {
   }
 
   @Test
+  void shouldMergeSavedDataValuesNotInPayloadWhenUpdatingExistingTrackerEvent() {
+    // Reproduces the reported bug: an existing event is updated with only some of its data
+    // values, but a program rule references data elements that are not part of the payload.
+    // Those must be sourced from the persisted event so rules evaluate against the full state.
+    DataElement de1 = dataElement; // in payload only
+    DataElement de2 = createDataElement('E'); // in payload and DB -> payload value wins
+    DataElement de3 = createDataElement('F'); // in DB only
+    DataElement de4 = createDataElement('G'); // in DB only
+
+    org.hisp.dhis.tracker.imports.domain.Event payload =
+        payloadEvent(dataValue(de1, "1"), dataValue(de2, "2"));
+
+    Event savedEvent = dbEvent();
+    savedEvent.setUid(payload.getUid().getValue());
+    savedEvent.setEventDataValues(
+        Sets.newHashSet(
+            eventDataValue(de2.getUid(), "20"),
+            eventDataValue(de3.getUid(), "3"),
+            eventDataValue(de4.getUid(), "4")));
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(programStage);
+    preheat.put(TrackerIdSchemeParam.UID, organisationUnit);
+    preheat.put(TrackerIdSchemeParam.UID, List.of(de1, de2, de3, de4));
+    preheat.putEvent(savedEvent);
+
+    List<RuleEvent> ruleEvents = RuleEngineMapper.mapPayloadEvents(preheat, List.of(payload));
+
+    assertContainsOnly(
+        List.of(
+            new RuleDataValue(de1.getUid(), "1"),
+            new RuleDataValue(de2.getUid(), "2"),
+            new RuleDataValue(de3.getUid(), "3"),
+            new RuleDataValue(de4.getUid(), "4")),
+        ruleEvents.get(0).getDataValues());
+  }
+
+  @Test
+  void shouldNotFallBackToSavedDataValueWhenPayloadClearsItForExistingEvent() {
+    DataElement de1 = dataElement; // updated in the payload
+    DataElement de2 = createDataElement('E'); // cleared in the payload (null value)
+
+    org.hisp.dhis.tracker.imports.domain.Event payload =
+        payloadEvent(dataValue(de1, "1"), dataValue(de2, null));
+
+    Event savedEvent = dbEvent();
+    savedEvent.setUid(payload.getUid().getValue());
+    savedEvent.setEventDataValues(
+        Sets.newHashSet(eventDataValue(de1.getUid(), "10"), eventDataValue(de2.getUid(), "20")));
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(programStage);
+    preheat.put(TrackerIdSchemeParam.UID, organisationUnit);
+    preheat.put(TrackerIdSchemeParam.UID, List.of(de1, de2));
+    preheat.putEvent(savedEvent);
+
+    List<RuleEvent> ruleEvents = RuleEngineMapper.mapPayloadEvents(preheat, List.of(payload));
+
+    // de2 was cleared in the payload, so the persisted "20" must not be re-injected
+    assertContainsOnly(
+        List.of(new RuleDataValue(de1.getUid(), "1")), ruleEvents.get(0).getDataValues());
+  }
+
+  @Test
+  void shouldMapOnlyPayloadDataValuesWhenEventDoesNotExistYet() {
+    DataElement de1 = dataElement;
+    DataElement de2 = createDataElement('E');
+
+    org.hisp.dhis.tracker.imports.domain.Event payload =
+        payloadEvent(dataValue(de1, "1"), dataValue(de2, "2"));
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(programStage);
+    preheat.put(TrackerIdSchemeParam.UID, organisationUnit);
+    preheat.put(TrackerIdSchemeParam.UID, List.of(de1, de2));
+    // no saved event in the preheat -> the event is being created
+
+    List<RuleEvent> ruleEvents = RuleEngineMapper.mapPayloadEvents(preheat, List.of(payload));
+
+    assertContainsOnly(
+        List.of(new RuleDataValue(de1.getUid(), "1"), new RuleDataValue(de2.getUid(), "2")),
+        ruleEvents.get(0).getDataValues());
+  }
+
+  @Test
   void shouldMapDBEventsToRuleEvents() {
     Event eventA = dbEvent();
     Event eventB = dbEvent();
@@ -372,7 +457,7 @@ class RuleEngineRuleEngineMapperTest extends TestBase {
     return eventDataValue;
   }
 
-  private org.hisp.dhis.tracker.imports.domain.Event payloadEvent() {
+  private org.hisp.dhis.tracker.imports.domain.Event payloadEvent(DataValue... dataValues) {
     return org.hisp.dhis.tracker.imports.domain.Event.builder()
         .enrollment(UID.generate())
         .event(UID.generate())
@@ -380,12 +465,14 @@ class RuleEngineRuleEngineMapperTest extends TestBase {
         .orgUnit(MetadataIdentifier.ofUid(organisationUnit.getUid()))
         .scheduledAt(YESTERDAY.toInstant())
         .occurredAt(AFTER_TOMORROW.toInstant())
-        .dataValues(
-            Set.of(
-                DataValue.builder()
-                    .dataElement(MetadataIdentifier.ofUid(dataElement.getUid()))
-                    .value(SAMPLE_VALUE_A)
-                    .build()))
+        .dataValues(Set.of(dataValues))
+        .build();
+  }
+
+  private DataValue dataValue(DataElement dataElement, String value) {
+    return DataValue.builder()
+        .dataElement(MetadataIdentifier.ofUid(dataElement.getUid()))
+        .value(value)
         .build();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/RuleEngineMapperTest.java
@@ -119,13 +119,16 @@ class RuleEngineRuleEngineMapperTest extends TestBase {
 
   @Test
   void shouldMapPayloadEventsToRuleEvents() {
-    org.hisp.dhis.tracker.imports.domain.Event eventA = payloadEvent();
-    org.hisp.dhis.tracker.imports.domain.Event eventB = payloadEvent();
+    DataElement de1 = dataElement;
+    DataElement de2 = createDataElement('E');
+    org.hisp.dhis.tracker.imports.domain.Event eventA = payloadEvent(dataValue(de1, "1"));
+    org.hisp.dhis.tracker.imports.domain.Event eventB = payloadEvent(dataValue(de2, "2"));
 
     TrackerPreheat trackerPreheat = new TrackerPreheat();
     trackerPreheat.put(programStage);
     trackerPreheat.put(TrackerIdSchemeParam.UID, organisationUnit);
     trackerPreheat.put(TrackerIdSchemeParam.UID, dataElement);
+    trackerPreheat.put(TrackerIdSchemeParam.UID, List.of(de1, de2));
 
     List<RuleEvent> ruleEvents =
         RuleEngineMapper.mapPayloadEvents(trackerPreheat, List.of(eventA, eventB));


### PR DESCRIPTION
Backport of #24551