### PR TITLE
chore: only include favorite endpoints for objects that support favorites

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -73,9 +73,7 @@ import org.hisp.dhis.security.acl.Access;
 import org.hisp.dhis.setting.UserSettings;
 import org.hisp.dhis.translation.Translatable;
 import org.hisp.dhis.translation.Translation;
-import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.sharing.Sharing;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.user.sharing.UserGroupAccess;
@@ -84,8 +82,7 @@ import org.hisp.dhis.user.sharing.UserGroupAccess;
  * @author Bob Jolliffe
  */
 @JacksonXmlRootElement(localName = "identifiableObject", namespace = DxfNamespaces.DXF_2_0)
-public class BaseIdentifiableObject extends BaseLinkableObject
-    implements IdentifiableObject, FavoritableObject {
+public class BaseIdentifiableObject extends BaseLinkableObject implements IdentifiableObject {
   /** The database internal identifier for this Object. */
   @Setter protected long id;
 
@@ -121,9 +118,6 @@ public class BaseIdentifiableObject extends BaseLinkableObject
 
   /** Access information for this object. Applies to current user. */
   protected transient Access access;
-
-  /** Users who have marked this object as a favorite. */
-  @Setter protected Set<String> favorites = new HashSet<>();
 
   /** Last user updated this object. */
   @Setter protected User lastUpdatedBy;
@@ -380,24 +374,6 @@ public class BaseIdentifiableObject extends BaseLinkableObject
   }
 
   @Override
-  @JsonProperty
-  @JacksonXmlElementWrapper(localName = "favorites", namespace = DxfNamespaces.DXF_2_0)
-  @JacksonXmlProperty(localName = "favorite", namespace = DxfNamespaces.DXF_2_0)
-  public Set<String> getFavorites() {
-    return favorites;
-  }
-
-  @Override
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public boolean isFavorite() {
-    if (favorites == null || !CurrentUserUtil.hasCurrentUser()) {
-      return false;
-    }
-    return favorites.contains(CurrentUserUtil.getCurrentUserDetails().getUid());
-  }
-
-  @Override
   @Sortable(value = false)
   @Gist(included = Include.FALSE)
   @JsonProperty
@@ -408,24 +384,6 @@ public class BaseIdentifiableObject extends BaseLinkableObject
     }
 
     return sharing;
-  }
-
-  @Override
-  public boolean setAsFavorite(UserDetails user) {
-    if (this.favorites == null) {
-      this.favorites = new HashSet<>();
-    }
-
-    return this.favorites.add(user.getUid());
-  }
-
-  @Override
-  public boolean removeAsFavorite(UserDetails user) {
-    if (this.favorites == null) {
-      this.favorites = new HashSet<>();
-    }
-
-    return this.favorites.remove(user.getUid());
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/Dashboard.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/Dashboard.java
@@ -82,7 +82,6 @@ import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.security.acl.Access;
 import org.hisp.dhis.translation.Translatable;
 import org.hisp.dhis.translation.Translation;
-import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.sharing.Sharing;
@@ -280,31 +279,15 @@ public class Dashboard extends BaseMetadataObject implements IdentifiableObject,
   }
 
   @Override
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public boolean isFavorite() {
-    if (favorites == null || !CurrentUserUtil.hasCurrentUser()) {
-      return false;
-    }
-    return favorites.contains(CurrentUserUtil.getCurrentUserDetails().getUid());
-  }
-
-  @Override
   public boolean setAsFavorite(UserDetails user) {
-    if (this.favorites == null) {
-      this.favorites = new HashSet<>();
-    }
-
-    return this.favorites.add(user.getUid());
+    if (favorites == null) favorites = new HashSet<>();
+    return favorites.add(user.getUid());
   }
 
   @Override
   public boolean removeAsFavorite(UserDetails user) {
-    if (this.favorites == null) {
-      this.favorites = new HashSet<>();
-    }
-
-    return this.favorites.remove(user.getUid());
+    if (favorites == null) favorites = new HashSet<>();
+    return favorites.remove(user.getUid());
   }
 
   @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventchart/EventChart.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventchart/EventChart.java
@@ -40,7 +40,11 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.common.AnalyticsType;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
@@ -50,6 +54,7 @@ import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DimensionalObjectUtils;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.EventAnalyticalObject;
+import org.hisp.dhis.common.FavoritableObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.dataelement.DataElement;
@@ -63,6 +68,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.ObjectUtils;
 
 /**
@@ -73,7 +79,12 @@ import org.hisp.dhis.util.ObjectUtils;
  * @author Jan Henrik Overland
  */
 @JacksonXmlRootElement(localName = "eventChart", namespace = DxfNamespaces.DXF_2_0)
-public class EventChart extends BaseChart implements EventAnalyticalObject, MetadataObject {
+public class EventChart extends BaseChart
+    implements EventAnalyticalObject, MetadataObject, FavoritableObject {
+
+  /** Users who have marked this object as a favorite. */
+  @Getter @Setter @JsonProperty private Set<String> favorites = new HashSet<>();
+
   /** Program. Required. */
   private Program program;
 
@@ -420,5 +431,17 @@ public class EventChart extends BaseChart implements EventAnalyticalObject, Meta
 
   public void setLegacy(final boolean legacy) {
     this.legacy = legacy;
+  }
+
+  @Override
+  public boolean setAsFavorite(UserDetails user) {
+    if (favorites == null) favorites = new HashSet<>();
+    return favorites.add(user.getUid());
+  }
+
+  @Override
+  public boolean removeAsFavorite(UserDetails user) {
+    if (favorites == null) favorites = new HashSet<>();
+    return favorites.remove(user.getUid());
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventreport/EventReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventreport/EventReport.java
@@ -43,7 +43,11 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
 import org.hisp.dhis.analytics.EventDataType;
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.common.BaseAnalyticalObject;
@@ -53,6 +57,7 @@ import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DisplayDensity;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.EventAnalyticalObject;
+import org.hisp.dhis.common.FavoritableObject;
 import org.hisp.dhis.common.FontSize;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MetadataObject;
@@ -69,6 +74,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.ObjectUtils;
 
 /**
@@ -80,7 +86,11 @@ import org.hisp.dhis.util.ObjectUtils;
  */
 @JacksonXmlRootElement(localName = "eventReport", namespace = DxfNamespaces.DXF_2_0)
 public class EventReport extends BaseAnalyticalObject
-    implements EventAnalyticalObject, MetadataObject {
+    implements EventAnalyticalObject, MetadataObject, FavoritableObject {
+
+  /** Users who have marked this object as a favorite. */
+  @Getter @Setter @JsonProperty private Set<String> favorites = new HashSet<>();
+
   /** Program. Required. */
   private Program program;
 
@@ -555,5 +565,17 @@ public class EventReport extends BaseAnalyticalObject
 
   public void setLegacy(final boolean legacy) {
     this.legacy = legacy;
+  }
+
+  @Override
+  public boolean setAsFavorite(UserDetails user) {
+    if (favorites == null) favorites = new HashSet<>();
+    return favorites.add(user.getUid());
+  }
+
+  @Override
+  public boolean removeAsFavorite(UserDetails user) {
+    if (favorites == null) favorites = new HashSet<>();
+    return favorites.remove(user.getUid());
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
@@ -53,7 +53,11 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
 import org.hisp.dhis.analytics.EventDataType;
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.analytics.Sorting;
@@ -66,6 +70,7 @@ import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DisplayDensity;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.EventAnalyticalObject;
+import org.hisp.dhis.common.FavoritableObject;
 import org.hisp.dhis.common.FontSize;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -85,12 +90,16 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.translation.Translatable;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 @JacksonXmlRootElement(localName = "eventVisualization", namespace = DXF_2_0)
 public class EventVisualization extends BaseAnalyticalObject
-    implements MetadataObject, EventAnalyticalObject {
+    implements MetadataObject, EventAnalyticalObject, FavoritableObject {
 
   protected EventVisualizationType type;
+
+  /** Users who have marked this object as a favorite. */
+  @Getter @Setter @JsonProperty private Set<String> favorites = new HashSet<>();
 
   // -------------------------------------------------------------------------
   // Dimensional properties
@@ -683,5 +692,17 @@ public class EventVisualization extends BaseAnalyticalObject
 
   public void setLegacy(boolean legacy) {
     this.legacy = legacy;
+  }
+
+  @Override
+  public boolean setAsFavorite(UserDetails user) {
+    if (favorites == null) favorites = new HashSet<>();
+    return favorites.add(user.getUid());
+  }
+
+  @Override
+  public boolean removeAsFavorite(UserDetails user) {
+    if (favorites == null) favorites = new HashSet<>();
+    return favorites.remove(user.getUid());
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/Map.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/Map.java
@@ -40,8 +40,11 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.BaseNameableObject;
+import org.hisp.dhis.common.FavoritableObject;
 import org.hisp.dhis.common.InterpretableObject;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.SubscribableObject;
@@ -56,7 +59,7 @@ import org.hisp.dhis.user.UserDetails;
  */
 @JacksonXmlRootElement(localName = "map", namespace = DXF_2_0)
 public class Map extends BaseNameableObject
-    implements InterpretableObject, SubscribableObject, MetadataObject {
+    implements InterpretableObject, SubscribableObject, FavoritableObject, MetadataObject {
   private Double longitude;
 
   private Double latitude;
@@ -77,7 +80,10 @@ public class Map extends BaseNameableObject
 
   private Set<Interpretation> interpretations = new HashSet<>();
 
-  protected Set<String> subscribers = new HashSet<>();
+  private Set<String> subscribers = new HashSet<>();
+
+  /** Users who have marked this object as a favorite. */
+  @Getter @Setter @JsonProperty private Set<String> favorites = new HashSet<>();
 
   // -------------------------------------------------------------------------
   // Constructors
@@ -220,5 +226,17 @@ public class Map extends BaseNameableObject
     }
 
     return this.subscribers.remove(user.getUid());
+  }
+
+  @Override
+  public boolean setAsFavorite(UserDetails user) {
+    if (favorites == null) favorites = new HashSet<>();
+    return favorites.add(user.getUid());
+  }
+
+  @Override
+  public boolean removeAsFavorite(UserDetails user) {
+    if (favorites == null) favorites = new HashSet<>();
+    return favorites.remove(user.getUid());
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
@@ -65,6 +65,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
 import org.hisp.dhis.analytics.NumberType;
 import org.hisp.dhis.analytics.Sorting;
 import org.hisp.dhis.category.CategoryCombo;
@@ -76,6 +78,7 @@ import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DimensionalObjectUtils;
 import org.hisp.dhis.common.DisplayDensity;
 import org.hisp.dhis.common.DisplayProperty;
+import org.hisp.dhis.common.FavoritableObject;
 import org.hisp.dhis.common.FontSize;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
@@ -93,11 +96,13 @@ import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.translation.Translatable;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.visualization.Icon.IconType;
 import org.springframework.util.Assert;
 
 @JacksonXmlRootElement(localName = "visualization", namespace = DXF_2_0)
-public class Visualization extends BaseAnalyticalObject implements MetadataObject {
+public class Visualization extends BaseAnalyticalObject
+    implements FavoritableObject, MetadataObject {
 
   public static final String REPORTING_MONTH_COLUMN_NAME = "reporting_month_name";
 
@@ -136,6 +141,8 @@ public class Visualization extends BaseAnalyticalObject implements MetadataObjec
   // -------------------------------------------------------------------------
   // Common attributes
   // -------------------------------------------------------------------------
+
+  @Getter @Setter @JsonProperty private Set<String> favorites = new HashSet<>();
 
   /** The type of this visualization object. */
   private VisualizationType type;
@@ -651,6 +658,18 @@ public class Visualization extends BaseAnalyticalObject implements MetadataObjec
     this.axes = axes;
 
     keepAxesReadingCompatibility(this);
+  }
+
+  @Override
+  public boolean setAsFavorite(UserDetails user) {
+    if (favorites == null) favorites = new HashSet<>();
+    return favorites.add(user.getUid());
+  }
+
+  @Override
+  public boolean removeAsFavorite(UserDetails user) {
+    if (favorites == null) favorites = new HashSet<>();
+    return favorites.remove(user.getUid());
   }
 
   /**

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramRuleVariableTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramRuleVariableTest.java
@@ -114,7 +114,7 @@ class ProgramRuleVariableTest {
   @Test
   void testExpectedFieldCount() {
     Field[] allClassFieldsIncludingInherited = getAllFields(ProgramRuleVariable.class);
-    assertEquals(22, allClassFieldsIncludingInherited.length);
+    assertEquals(21, allClassFieldsIncludingInherited.length);
   }
 
   private ProgramRuleVariable getNewProgramRuleVariable(

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramSectionTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramSectionTest.java
@@ -118,7 +118,7 @@ class ProgramSectionTest {
   @Test
   void testExpectedFieldCount() {
     Field[] allClassFieldsIncludingInherited = getAllFields(ProgramSection.class);
-    assertEquals(26, allClassFieldsIncludingInherited.length);
+    assertEquals(25, allClassFieldsIncludingInherited.length);
   }
 
   public static ProgramSection getNewProgramSection(Program original) {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramStageDataElementTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramStageDataElementTest.java
@@ -109,7 +109,7 @@ class ProgramStageDataElementTest {
   @Test
   void testExpectedFieldCount() {
     Field[] allClassFieldsIncludingInherited = getAllFields(ProgramStageDataElement.class);
-    assertEquals(27, allClassFieldsIncludingInherited.length);
+    assertEquals(26, allClassFieldsIncludingInherited.length);
   }
 
   public static ProgramStageDataElement getNewProgramStageDataElement(

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramStageSectionTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramStageSectionTest.java
@@ -133,7 +133,7 @@ class ProgramStageSectionTest {
   @Test
   void testExpectedFieldCount() {
     Field[] allClassFieldsIncludingInherited = getAllFields(ProgramStageSection.class);
-    assertEquals(27, allClassFieldsIncludingInherited.length);
+    assertEquals(26, allClassFieldsIncludingInherited.length);
   }
 
   public static ProgramStageSection getNewProgramStageSection(

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramStageTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramStageTest.java
@@ -131,7 +131,7 @@ class ProgramStageTest {
   @Test
   void testExpectedFieldCount() {
     Field[] allClassFieldsIncludingInherited = getAllFields(ProgramStage.class);
-    assertEquals(49, allClassFieldsIncludingInherited.length);
+    assertEquals(48, allClassFieldsIncludingInherited.length);
   }
 
   private ProgramStage getNewProgramStageWithNoNulls(Program program) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -541,17 +541,17 @@ class AbstractCrudControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testSetAsFavorite_NotFavoritable() {
-    assertWebMessage(
-        "Conflict",
-        409,
-        "ERROR",
-        "Objects of this class cannot be set as favorite",
-        POST("/users/" + getAdminUid() + "/favorite").content(HttpStatus.CONFLICT));
+    assertStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE, POST("/users/" + getAdminUid() + "/favorite"));
   }
 
   @Test
   void testSetAsFavorite_NoSuchObject() {
-    assertStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE, POST("/maps/m1234567890/favorite"));
+    assertWebMessage(
+        "Not Found",
+        404,
+        "ERROR",
+        "Map with id m1234567890 could not be found.",
+        POST("/maps/m1234567890/favorite").content(HttpStatus.NOT_FOUND));
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -551,12 +551,7 @@ class AbstractCrudControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testSetAsFavorite_NoSuchObject() {
-    assertWebMessage(
-        "Not Found",
-        404,
-        "ERROR",
-        "Map with id m1234567890 could not be found.",
-        POST("/maps/m1234567890/favorite").content(HttpStatus.NOT_FOUND));
+    assertStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE, POST("/maps/m1234567890/favorite"));
   }
 
   @Test
@@ -577,12 +572,7 @@ class AbstractCrudControllerTest extends H2ControllerIntegrationTestBase {
 
   @Test
   void testRemoveAsFavorite_NotFavoritable() {
-    assertWebMessage(
-        "Conflict",
-        409,
-        "ERROR",
-        "Objects of this class cannot be set as favorite",
-        DELETE("/users/u1234567890/favorite").content(HttpStatus.CONFLICT));
+    assertStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE, DELETE("/users/u1234567890/favorite"));
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -117,7 +117,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @OpenApi.Document(group = OpenApi.Document.GROUP_MANAGE)
 public abstract class AbstractCrudController<
         T extends IdentifiableObject, P extends GetObjectListParams>
-    extends AbstractFullReadOnlyController<T, P> implements CrudOperationsSupport<T> {
+    extends AbstractFullReadOnlyController<T, P> implements CrudOperationsSupport {
   @Autowired protected SchemaValidator schemaValidator;
 
   @Autowired protected RenderService renderService;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -59,7 +59,6 @@ import org.hisp.dhis.common.SubscribableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.commons.jackson.jsonpatch.JsonPatch;
 import org.hisp.dhis.commons.jackson.jsonpatch.JsonPatchException;
-import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.dxf2.metadata.MetadataExportService;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.metadata.MetadataImportService;
@@ -118,7 +117,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @OpenApi.Document(group = OpenApi.Document.GROUP_MANAGE)
 public abstract class AbstractCrudController<
         T extends IdentifiableObject, P extends GetObjectListParams>
-    extends AbstractFullReadOnlyController<T, P> {
+    extends AbstractFullReadOnlyController<T, P> implements CrudOperationsSupport<T> {
   @Autowired protected SchemaValidator schemaValidator;
 
   @Autowired protected RenderService renderService;
@@ -335,35 +334,6 @@ public abstract class AbstractCrudController<
   }
 
   @OpenApi.Filter(
-      includes = {
-        Dashboard.class,
-        EventVisualization.class,
-        org.hisp.dhis.mapping.Map.class,
-        Visualization.class
-      })
-  @PostMapping(value = "/{uid}/favorite")
-  @ResponseBody
-  public WebMessage setAsFavorite(
-      @PathVariable("uid") UID uid, @CurrentUser UserDetails currentUser)
-      throws ConflictException, NotFoundException {
-
-    if (!getSchema().isFavoritable()) {
-      throw new ConflictException("Objects of this class cannot be set as favorite");
-    }
-
-    T object = getEntity(uid);
-    if (object instanceof FavoritableObject favoritableObject) {
-      favoritableObject.setAsFavorite(currentUser);
-      manager.updateNoAcl(object);
-      return ok(
-          String.format(
-              "Object '%s' set as favorite for user '%s'", uid, currentUser.getUsername()));
-    } else {
-      throw new ConflictException("Objects of this class cannot be set as favorite");
-    }
-  }
-
-  @OpenApi.Filter(
       includes = {EventVisualization.class, org.hisp.dhis.mapping.Map.class, Visualization.class})
   @PostMapping(value = "/{uid}/subscriber")
   @ResponseBody
@@ -497,36 +467,6 @@ public abstract class AbstractCrudController<
     postDeleteEntity(uid);
 
     return objectReport(importReport);
-  }
-
-  @OpenApi.Filter(
-      includes = {
-        Dashboard.class,
-        EventVisualization.class,
-        org.hisp.dhis.mapping.Map.class,
-        Visualization.class
-      })
-  @DeleteMapping(value = "/{uid}/favorite")
-  @ResponseBody
-  public WebMessage removeAsFavorite(
-      @PathVariable("uid") UID uid, @CurrentUser UserDetails currentUser)
-      throws NotFoundException, ConflictException {
-
-    if (!getSchema().isFavoritable()) {
-      throw new ConflictException("Objects of this class cannot be set as favorite");
-    }
-
-    T object = getEntity(uid);
-    if (object instanceof FavoritableObject favoritableObject) {
-      favoritableObject.removeAsFavorite(currentUser);
-      manager.updateNoAcl(object);
-
-      return ok(
-          String.format(
-              "Object '%s' removed as favorite for user '%s'", uid, currentUser.getUsername()));
-    } else {
-      throw new ConflictException("Objects of this class cannot be set as favorite");
-    }
   }
 
   @OpenApi.Filter(
@@ -740,5 +680,31 @@ public abstract class AbstractCrudController<
     if (!aclService.canUpdate(currentUser, persistedObject)) {
       throw new ForbiddenException("You don't have the proper permissions to update this object.");
     }
+  }
+
+  /*
+  Special operations support
+   */
+
+  @Override
+  public boolean setAsFavorite(UID id, UserDetails user) throws NotFoundException {
+    T object = getEntity(id);
+    if (object instanceof FavoritableObject obj) {
+      obj.setAsFavorite(user);
+      manager.updateNoAcl(object);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean removeAsFavorite(UID id, UserDetails user) throws NotFoundException {
+    T object = getEntity(id);
+    if (object instanceof FavoritableObject favoritableObject) {
+      favoritableObject.removeAsFavorite(user);
+      manager.updateNoAcl(object);
+      return true;
+    }
+    return false;
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudOperationsSupport.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudOperationsSupport.java
@@ -29,17 +29,12 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.user.UserDetails;
 
-/**
- * CRUD related operations that only some object types support.
- *
- * @param <T> type of the controller object
- */
-public interface CrudOperationsSupport<T extends IdentifiableObject> {
+/** CRUD related operations that only some object types support. */
+public interface CrudOperationsSupport {
 
   boolean setAsFavorite(UID id, UserDetails user) throws NotFoundException;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudOperationsSupport.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudOperationsSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,30 +27,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.common;
+package org.hisp.dhis.webapi.controller;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Set;
-import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.user.UserDetails;
 
 /**
- * Interface for objects which can be marked as favorite by users. Object implementing this
- * interface must have a property of type {@code Set<String>} with the name 'favorites' where the
- * set contains the UIDs of users having marked the object as favorite.
+ * CRUD related operations that only some object types support.
+ *
+ * @param <T> type of the controller object
  */
-public interface FavoritableObject {
+public interface CrudOperationsSupport<T extends IdentifiableObject> {
 
-  Set<String> getFavorites();
+  boolean setAsFavorite(UID id, UserDetails user) throws NotFoundException;
 
-  @JsonProperty
-  default boolean isFavorite() {
-    Set<String> favorites = getFavorites();
-    if (favorites == null || favorites.isEmpty() || !CurrentUserUtil.hasCurrentUser()) return false;
-    return favorites.contains(CurrentUserUtil.getCurrentUserDetails().getUid());
-  }
-
-  boolean setAsFavorite(UserDetails user);
-
-  boolean removeAsFavorite(UserDetails user);
+  boolean removeAsFavorite(UID id, UserDetails user) throws NotFoundException;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
@@ -66,7 +66,9 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Controller
 @RequestMapping("/api/dashboards")
 @OpenApi.Document(classifiers = {"team:analytics", "purpose:metadata"})
-public class DashboardController extends AbstractCrudController<Dashboard, GetObjectListParams> {
+public class DashboardController extends AbstractCrudController<Dashboard, GetObjectListParams>
+    implements FavoritableOperations<Dashboard> {
+
   @Autowired private DashboardService dashboardService;
 
   @Autowired private CascadeSharingService cascadeSharingService;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FavoritableOperations.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FavoritableOperations.java
@@ -32,7 +32,6 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 
 import org.hisp.dhis.common.FavoritableObject;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.feedback.ConflictException;
@@ -45,8 +44,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /** Endpoints that can be added for types support {@link FavoritableObject} API */
-public interface FavoritableOperations<T extends IdentifiableObject & FavoritableObject>
-    extends CrudOperationsSupport<T> {
+public interface FavoritableOperations<T extends FavoritableObject> extends CrudOperationsSupport {
 
   @PostMapping(value = "/{uid}/favorite")
   @ResponseBody

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FavoritableOperations.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FavoritableOperations.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+
+import org.hisp.dhis.common.FavoritableObject;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.dxf2.webmessage.WebMessage;
+import org.hisp.dhis.feedback.ConflictException;
+import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.user.CurrentUser;
+import org.hisp.dhis.user.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/** Endpoints that can be added for types support {@link FavoritableObject} API */
+public interface FavoritableOperations<T extends IdentifiableObject & FavoritableObject>
+    extends CrudOperationsSupport<T> {
+
+  @PostMapping(value = "/{uid}/favorite")
+  @ResponseBody
+  default WebMessage postSetAsFavorite(
+      @PathVariable("uid") UID uid, @CurrentUser UserDetails currentUser)
+      throws ConflictException, NotFoundException {
+    if (setAsFavorite(uid, currentUser))
+      return ok(
+          String.format(
+              "Object '%s' set as favorite for user '%s'", uid, currentUser.getUsername()));
+    throw new ConflictException("Objects of this class cannot be set as favorite");
+  }
+
+  @DeleteMapping(value = "/{uid}/favorite")
+  @ResponseBody
+  default WebMessage deleteRemoveAsFavorite(
+      @PathVariable("uid") UID uid, @CurrentUser UserDetails currentUser)
+      throws NotFoundException, ConflictException {
+    if (removeAsFavorite(uid, currentUser))
+      return ok(
+          String.format(
+              "Object '%s' removed as favorite for user '%s'", uid, currentUser.getUsername()));
+    throw new ConflictException("Objects of this class cannot be set as favorite");
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
@@ -66,7 +66,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/api/visualizations")
 @OpenApi.Document(classifiers = {"team:analytics", "purpose:metadata"})
 public class VisualizationController
-    extends AbstractCrudController<Visualization, GetObjectListParams> {
+    extends AbstractCrudController<Visualization, GetObjectListParams>
+    implements FavoritableOperations<Visualization> {
+
   private final LegendSetService legendSetService;
 
   private final DimensionService dimensionService;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
@@ -109,7 +109,7 @@ public class DimensionController
 
   @Nonnull
   @Override
-  protected DimensionalObject getEntity(@Nonnull UID uid) throws NotFoundException {
+  public DimensionalObject getEntity(@Nonnull UID uid) throws NotFoundException {
     return dimensionService.getDimensionalObjectCopy(uid.getValue(), true);
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventChartController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventChartController.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.visualization.ChartService;
 import org.hisp.dhis.visualization.PlotData;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.hisp.dhis.webapi.controller.FavoritableOperations;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.jfree.chart.ChartUtilities;
 import org.jfree.chart.JFreeChart;
@@ -82,7 +83,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Deprecated
 @Controller
 @RequestMapping("/api/eventCharts")
-public class EventChartController extends AbstractCrudController<EventChart, GetObjectListParams> {
+public class EventChartController extends AbstractCrudController<EventChart, GetObjectListParams>
+    implements FavoritableOperations<EventChart> {
+
   @Autowired private EventChartService eventChartService;
 
   @Autowired private ChartService chartService;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventReportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventReportController.java
@@ -54,6 +54,7 @@ import org.hisp.dhis.query.GetObjectParams;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.hisp.dhis.webapi.controller.FavoritableOperations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -68,8 +69,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Deprecated
 @Controller
 @RequestMapping("/api/eventReports")
-public class EventReportController
-    extends AbstractCrudController<EventReport, GetObjectListParams> {
+public class EventReportController extends AbstractCrudController<EventReport, GetObjectListParams>
+    implements FavoritableOperations<EventReport> {
+
   @Autowired private DimensionService dimensionService;
 
   @Autowired private I18nManager i18nManager;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventVisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventVisualizationController.java
@@ -81,6 +81,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.visualization.ChartService;
 import org.hisp.dhis.visualization.PlotData;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.hisp.dhis.webapi.controller.FavoritableOperations;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.jfree.chart.ChartUtilities;
 import org.jfree.chart.JFreeChart;
@@ -100,7 +101,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 @AllArgsConstructor
 @OpenApi.Document(classifiers = {"team:tracker", "purpose:metadata"})
 public class EventVisualizationController
-    extends AbstractCrudController<EventVisualization, GetObjectListParams> {
+    extends AbstractCrudController<EventVisualization, GetObjectListParams>
+    implements FavoritableOperations<EventVisualization> {
+
   private final DimensionService dimensionService;
 
   private final LegendSetService legendSetService;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -77,6 +77,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.hisp.dhis.webapi.controller.FavoritableOperations;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -96,7 +97,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @Controller
 @RequestMapping("/api/maps")
 @OpenApi.Document(classifiers = {"team:analytics", "purpose:metadata"})
-public class MapController extends AbstractCrudController<Map, GetObjectListParams> {
+public class MapController extends AbstractCrudController<Map, GetObjectListParams>
+    implements FavoritableOperations<Map> {
   private static final int MAP_MIN_WIDTH = 140;
 
   private static final int MAP_MIN_HEIGHT = 25;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeDto.java
@@ -82,7 +82,6 @@ public class MeDto {
     this.created = user.getCreated();
     this.lastUpdated = user.getLastUpdated();
     this.dataViewOrganisationUnits = user.getDataViewOrganisationUnits();
-    this.favorites = user.getFavorites();
     this.userGroups = filteredUserGroups;
     this.translations = user.getTranslations();
     this.teiSearchOrganisationUnits = user.getTeiSearchOrganisationUnits();
@@ -141,8 +140,6 @@ public class MeDto {
   @OpenApi.Property(BaseIdentifiableObject[].class)
   @JsonProperty
   private Set<OrganisationUnit> dataViewOrganisationUnits;
-
-  @JsonProperty protected Set<String> favorites;
 
   @JsonProperty protected Sharing sharing;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -293,7 +293,7 @@ public class UserController
 
   @Override
   @Nonnull
-  protected User getEntity(@Nonnull UID uid) throws NotFoundException {
+  public User getEntity(@Nonnull UID uid) throws NotFoundException {
     User user = userService.getUser(uid.getValue());
     if (user == null) {
       throw new NotFoundException(User.class, uid);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiExtractor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiExtractor.java
@@ -182,9 +182,12 @@ final class ApiExtractor {
   }
 
   private static Stream<Method> methodsIn(Class<?> source) {
-    return source == null || source == Object.class
-        ? Stream.empty()
-        : Stream.concat(stream(source.getDeclaredMethods()), methodsIn(source.getSuperclass()));
+    if (source == null || source == Object.class) return Stream.empty();
+    Stream<Method> res =
+        Stream.concat(stream(source.getDeclaredMethods()), methodsIn(source.getSuperclass()));
+    return Stream.concat(
+        res,
+        stream(source.getInterfaces()).flatMap(ApiExtractor::methodsIn).filter(Method::isDefault));
   }
 
   private Api.Endpoint extractEndpoint(Api.Controller controller, EndpointMapping mapping) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ConsistentAnnotatedElement.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ConsistentAnnotatedElement.java
@@ -114,7 +114,8 @@ class ConsistentAnnotatedElement implements AnnotatedElement {
   private <T extends Annotation> T[] getMethodAnnotationsByType(Class<T> type, Method method) {
     if (isPrivate(method.getModifiers())
         || isStatic(method.getModifiers())
-        || method.isSynthetic()) {
+        || method.isSynthetic()
+        || method.getDeclaringClass().isInterface()) {
       return target.getAnnotationsByType(type);
     }
     Method m = method;


### PR DESCRIPTION
### Summary
Spring supports defining endpoint mapped method as `default` interface methods. This can be used to cherry-pick the API for controllers that actually support the feature instead of inheriting endpoints for all sub-classes and then throw an error if the object type does not support the operation. In this PR the `favorites` collection is explicitly added to the few types that support it and a `FavoritableOperations` interface is extracted so only the controller for this few object types implement it. 

### API Compatability
The response for `POST/DELETE /api/{type}/{id}/favorite` will give the typical response for an unknown/unmapped URL for those types that do not support favorites (instead of giving a CONFLICT error response). 

### Automatic Testing
The favorite endpoints have controller level coverage. 

### Manual Testing 
I tested OpenAPI manually after adjusting the analysis to include default methods of interfaces, for example http://localhost:8080/api/openapi/openapi.html?scope=entity:Map will have the POST and DELETE endpoints listed for `/favorite`. 