### PR TITLE
fix: Remove obsolete fk from trackedentityaudit table [DHIS2-18694]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_18__drop_trackedentityaudit_foreign_key.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_18__drop_trackedentityaudit_foreign_key.sql
@@ -1,0 +1,20 @@
+-- https://dhis2.atlassian.net/browse/DHIS2-18694
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT c.conname
+        FROM pg_constraint c
+                 JOIN unnest(c.conkey) AS k(attnum) ON true
+                 JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+        WHERE c.contype = 'f'
+          AND c.conrelid = 'trackedentityaudit'::regclass
+          AND a.attname = 'trackedentity'
+        LOOP
+            EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I',
+                           'trackedentityaudit', r.conname);
+        END LOOP;
+END $$;
+
+


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                               
  Removes the obsolete foreign key constraint on `trackedentityaudit.trackedentity`. The audit table is intended to retain history independently of the tracked entities it references, so a live FK to `trackedentity` is no longer appropriate — it blocks deletion of       
  tracked entities and serves no integrity purpose for audit data.                                                                                                                                                                                    
                                                                                                                                                                                                                                                                               
  ## Changes                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                               
  - Adds Flyway migration `2.44/V2_44_18__drop_trackedentityaudit_foreign_key.sql` that drops the foreign key on the `trackedentity` column of the `trackedentityaudit` table.                                                                                                 
  - The migration looks the constraint up by column rather than by name — using a `DO` block over `pg_constraint`/`pg_attribute` — so it works regardless of the auto-generated constraint name and is safe across environments where the name may differ.                     
  - The lookup loops over matching constraints and is a no-op when none exist, making the migration idempotent and safe to re-run.