### PR TITLE
fix: avoid loading UserRole members during JSON Patch apply [DHIS2-21852] (2.41)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchExcludedPropertyFilter.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchExcludedPropertyFilter.java
@@ -4,16 +4,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
+ * Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors 
- * may be used to endorse or promote products derived from this software without
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchExcludedPropertyFilter.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchExcludedPropertyFilter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsonpatch;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.PropertyWriter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import java.util.Set;
+
+/**
+ * PropertyFilter that omits properties named in {@code excluded} without invoking their getter, via
+ * {@link PropertyWriter#serializeAsOmittedField}. Mirrors {@code
+ * org.hisp.dhis.fieldfiltering.FieldFilterSimpleBeanPropertyFilter}'s shape, simplified to a flat
+ * excluded-name set (no path-context tracking needed here).
+ *
+ * @author Jason Pickering
+ */
+class JsonPatchExcludedPropertyFilter extends SimpleBeanPropertyFilter {
+
+  /**
+   * Single source of truth for the filter id -- referenced by both {@link JsonPatchFilterMixin}'s
+   * {@code @JsonFilter} annotation and {@link JsonPatchManager}'s {@code addFilter} call. Declared
+   * here, on a concrete class, rather than on the mixin interface itself: an interface holding only
+   * a constant is exactly the "constant interface" anti-pattern (SonarQube java:S1214) --
+   * implementing classes would inherit the constant into their own namespace for no reason. {@code
+   * JsonPatchFilterMixin} stays a truly empty marker interface, matching its precedent, {@code
+   * org.hisp.dhis.fieldfiltering.FieldFilterMixin}.
+   */
+  static final String ID = "json-patch-collection-filter";
+
+  private final Set<String> excluded;
+
+  JsonPatchExcludedPropertyFilter(Set<String> excluded) {
+    this.excluded = excluded;
+  }
+
+  @Override
+  protected boolean include(final BeanPropertyWriter writer) {
+    return true;
+  }
+
+  @Override
+  protected boolean include(final PropertyWriter writer) {
+    return true;
+  }
+
+  @Override
+  public void serializeAsField(
+      Object pojo, JsonGenerator jgen, SerializerProvider provider, PropertyWriter writer)
+      throws Exception {
+    if (excluded.contains(writer.getName())) {
+      if (!jgen.canOmitFields()) {
+        writer.serializeAsOmittedField(pojo, jgen, provider);
+      }
+    } else {
+      writer.serializeAsField(pojo, jgen, provider);
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchFilterMixin.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchFilterMixin.java
@@ -4,16 +4,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
+ * Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors 
- * may be used to endorse or promote products derived from this software without
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchFilterMixin.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchFilterMixin.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsonpatch;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+
+/**
+ * Bound per patched entity type ({@code realClass}), not {@code Object.class} -- see {@link
+ * JsonPatchManager}'s {@code patchMapperCache} field for why a global binding is wrong: {@code
+ * JsonPatchExcludedPropertyFilter} matches by property name only, so binding this mixin to {@code
+ * Object.class} would apply the exclusion filter to every nested object in the graph too (e.g.
+ * {@code org.hisp.dhis.user.sharing.Sharing.users}, which collides by name with {@code
+ * UserRole.users}) and silently strip unrelated data. {@code JsonPatchManager} builds one
+ * mixin-bound {@code ObjectMapper} copy per distinct {@code realClass}, lazily, and caches it.
+ *
+ * <p>Solves the same underlying problem as {@code org.hisp.dhis.fieldfiltering.FieldFilterMixin}
+ * (skip a getter during Jackson serialization based on per-call criteria, without invoking it) for
+ * the {@code ?fields=} GET path -- but that mixin's filter is path-aware, which is what makes its
+ * own {@code Object.class}-wide binding safe; this one is not, so it must stay scoped per-class.
+ *
+ * @author Jason Pickering
+ */
+@JsonFilter(JsonPatchExcludedPropertyFilter.ID)
+interface JsonPatchFilterMixin {}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchManager.java
@@ -33,6 +33,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import java.util.Collection;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.EmbeddedObject;
@@ -58,6 +64,29 @@ import org.springframework.transaction.annotation.Transactional;
 public class JsonPatchManager {
   private final ObjectMapper jsonMapper;
 
+  /**
+   * Cache of per-entity-type {@code ObjectMapper} copies with {@link JsonPatchFilterMixin} bound to
+   * that type only -- NOT {@code Object.class}. Binding the mixin globally would apply the
+   * exclusion filter to every nested object in the serialized graph too: {@code Sharing} (present
+   * on every {@code IdentifiableObject} via {@code BaseIdentifiableObject.getSharing()}) has its
+   * own {@code @JsonProperty} field literally named {@code users}, so a global binding would
+   * silently strip {@code sharing.users}/{@code sharing.userGroups} whenever a same-named top-level
+   * collection (e.g. {@code UserRole.users}) is excluded -- confirmed as a real bug during review,
+   * not a hypothetical. Scoping to {@code realClass} makes that specific cross-type collision
+   * impossible: only {@code realClass} carries {@code @JsonFilter}, so a differently-typed nested
+   * object (e.g. {@code Sharing}) is never affected by another type's exclusions. (A
+   * self-referential {@code realClass}, e.g. a nested {@code OrganisationUnit} under another {@code
+   * OrganisationUnit}, does re-carry the filter -- but the excluded set only ever names {@code
+   * realClass}'s own non-owner collections, so re-applying it at any depth is safe by the same
+   * owner/non-owner invariant that makes dropping them at the root safe.) Built lazily, once per
+   * distinct {@code realClass} ever patched, then reused -- mirrors {@code
+   * org.hisp.dhis.fieldfiltering.FieldFilterSimpleBeanPropertyFilter}'s own {@code
+   * ALWAYS_EXPAND_CACHE} pattern for the same "compute once per Class" idiom. Per-call code (see
+   * {@link #toJsonNode}) only attaches a fresh {@link SimpleFilterProvider}; it does not rebuild
+   * the cached entry on every patch.
+   */
+  private final Map<Class<?>, ObjectMapper> patchMapperCache = new ConcurrentHashMap<>();
+
   private final SchemaService schemaService;
 
   public JsonPatchManager(ObjectMapper jsonMapper, SchemaService schemaService) {
@@ -69,6 +98,16 @@ public class JsonPatchManager {
    * Applies a JSON patch to any valid jackson java object. It uses valueToTree to convert from the
    * object into a tree like node structure, and this is where the patch will be applied. This means
    * that any property renaming etc will be followed.
+   *
+   * <p>Non-owner collection properties that are not referenced by any patch path are omitted from
+   * serialization. Non-owner collections are ignored by metadata import UPDATE, so omitting them is
+   * free; omitting owner collections would clear them on import. Non-persisted derived properties
+   * (for example {@code OrganisationUnit.leaf}) are also omitted when unreferenced, because their
+   * getters can force-initialize inverse lazy collections. Skipping avoids initializing lazy
+   * Hibernate collections such as {@code UserRole.members} during scalar PATCH /userRoles (slow
+   * PATCH /userRoles). A patch path that explicitly targets an otherwise-excludable property (e.g.
+   * {@code /users}) removes it from the excluded set, so that property still falls back to full
+   * (slower, but correct) hydration -- it is never silently dropped.
    *
    * @param patch JsonPatch object with the operations it should apply.
    * @param object Jackson Object to apply the patch to.
@@ -83,12 +122,19 @@ public class JsonPatchManager {
 
     Class realClass = HibernateProxyUtils.getRealClass(object);
     Schema schema = schemaService.getSchema(realClass);
-    JsonNode node = jsonMapper.valueToTree(object);
+
+    Set<String> patchedPaths =
+        patch.getOperations().stream()
+            .map(op -> op.getPath().getMatchingProperty())
+            .collect(Collectors.toSet());
+    Set<String> excluded = findExcludableProperties(schema, patchedPaths);
+
+    JsonNode node = toJsonNode(object, realClass, excluded);
 
     // since valueToTree does not properly handle our deeply nested classes,
     // we need to make another trip to make sure all collections are
     // correctly made into json nodes.
-    handleCollectionUpdates(object, schema, (ObjectNode) node);
+    handleCollectionUpdates(object, schema, (ObjectNode) node, excluded);
 
     validatePatchPath(patch, schema);
 
@@ -97,10 +143,82 @@ public class JsonPatchManager {
         jsonToObject(node, realClass, jsonMapper, ex -> new JsonPatchException(ex.getMessage()));
   }
 
-  private <T> void handleCollectionUpdates(T object, Schema schema, ObjectNode node) {
+
+  /**
+   * Collect JSON field names that are safe to omit during patch serialization.
+   *
+   * <p>Include when no patch path references {@link Property#getName()} or {@link
+   * Property#getCollectionName()}, and either:
+   *
+   * <ul>
+   *   <li>{@code isCollection() && !isOwner()} - non-owner collections are ignored by metadata
+   *       import UPDATE
+   *   <li>{@code !isPersisted()} - derived getters must not run (e.g. {@code leaf} calling {@code
+   *       children.isEmpty()})
+   * </ul>
+   *
+   * <p>Owner collections must always remain serialized (metadata import UPDATE would wipe them if
+   * omitted). Properties referenced by a patch path keep today's behavior.
+   */
+  private static Set<String> findExcludableProperties(Schema schema, Set<String> patchedPaths) {
+    Set<String> excluded = new HashSet<>();
+    for (Property property : schema.getProperties()) {
+      if (isReferencedByPatch(property, patchedPaths)) {
+        continue;
+      }
+      if (property.isCollection() && !property.isOwner()) {
+        // collectionName is the JSON name Jackson serializes (e.g. "users")
+        excluded.add(property.getCollectionName());
+      } else if (!property.isPersisted()) {
+        String jsonName =
+            property.isCollection() ? property.getCollectionName() : property.getName();
+        if (jsonName != null) {
+          excluded.add(jsonName);
+        }
+      }
+    }
+    return excluded;
+  }
+
+  private static boolean isReferencedByPatch(Property property, Set<String> patchedPaths) {
+    return patchedPaths.contains(property.getName())
+        || (property.getCollectionName() != null
+            && patchedPaths.contains(property.getCollectionName()));
+  }
+
+  /**
+   * Builds the JSON tree for {@code object}, skipping getters for properties in {@code excluded}.
+   * Looks up (or lazily builds) {@code realClass}'s cached mapper from {@link #patchMapperCache};
+   * only attaches a fresh, per-call {@link SimpleFilterProvider} -- the expensive
+   * mixin-binding/{@code copy()} happens at most once per distinct {@code realClass}, not on every
+   * patch.
+   */
+  private JsonNode toJsonNode(Object object, Class realClass, Set<String> excluded) {
+    if (excluded.isEmpty()) {
+      return jsonMapper.valueToTree(object);
+    }
+
+    ObjectMapper patchMapper =
+        patchMapperCache.computeIfAbsent(
+            realClass, cls -> jsonMapper.copy().addMixIn(cls, JsonPatchFilterMixin.class));
+
+    SimpleFilterProvider filterProvider =
+        new SimpleFilterProvider()
+            .addFilter(
+                JsonPatchExcludedPropertyFilter.ID, new JsonPatchExcludedPropertyFilter(excluded));
+    return patchMapper.copy().setFilterProvider(filterProvider).valueToTree(object);
+  }
+
+  private <T> void handleCollectionUpdates(
+      T object, Schema schema, ObjectNode node, Set<String> excluded) {
     for (Property property : schema.getProperties()) {
 
       if (property.isCollection()) {
+        // Skip before invoke so excluded lazy collections stay uninitialized.
+        if (excluded.contains(property.getCollectionName())) {
+          continue;
+        }
+
         Object data = ReflectionUtils.invokeMethod(object, property.getGetterMethod());
 
         Collection<?> collection = (Collection<?>) data;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchManager.java
@@ -120,7 +120,7 @@ public class JsonPatchManager {
       return null;
     }
 
-    Class realClass = HibernateProxyUtils.getRealClass(object);
+    Class<?> realClass = HibernateProxyUtils.getRealClass(object);
     Schema schema = schemaService.getSchema(realClass);
 
     Set<String> patchedPaths =
@@ -192,7 +192,7 @@ public class JsonPatchManager {
    * mixin-binding/{@code copy()} happens at most once per distinct {@code realClass}, not on every
    * patch.
    */
-  private JsonNode toJsonNode(Object object, Class realClass, Set<String> excluded) {
+  private JsonNode toJsonNode(Object object, Class<?> realClass, Set<String> excluded) {
     if (excluded.isEmpty()) {
       return jsonMapper.valueToTree(object);
     }
@@ -211,21 +211,16 @@ public class JsonPatchManager {
   private <T> void handleCollectionUpdates(
       T object, Schema schema, ObjectNode node, Set<String> excluded) {
     for (Property property : schema.getProperties()) {
+      // Skip non-collections and excluded lazy collections before invoke so they stay
+      // uninitialized.
+      if (!property.isCollection() || excluded.contains(property.getCollectionName())) {
+        continue;
+      }
 
-      if (property.isCollection()) {
-        // Skip before invoke so excluded lazy collections stay uninitialized.
-        if (excluded.contains(property.getCollectionName())) {
-          continue;
-        }
+      Object data = ReflectionUtils.invokeMethod(object, property.getGetterMethod());
+      Collection<?> collection = (Collection<?>) data;
 
-        Object data = ReflectionUtils.invokeMethod(object, property.getGetterMethod());
-
-        Collection<?> collection = (Collection<?>) data;
-
-        if (CollectionUtils.isEmpty(collection)) {
-          continue;
-        }
-
+      if (!CollectionUtils.isEmpty(collection)) {
         if (BaseIdentifiableObject.class.isAssignableFrom(property.getItemKlass())
             && !EmbeddedObject.class.isAssignableFrom(property.getItemKlass())) {
           ArrayNode arrayNode = jsonMapper.createArrayNode();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchManager.java
@@ -34,12 +34,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import java.util.Collection;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.commons.collection.CollectionUtils;
@@ -142,7 +142,6 @@ public class JsonPatchManager {
     return (T)
         jsonToObject(node, realClass, jsonMapper, ex -> new JsonPatchException(ex.getMessage()));
   }
-
 
   /**
    * Collect JSON field names that are safe to omit during patch serialization.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -43,6 +43,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Hibernate;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.category.CategoryDimension;
@@ -726,7 +727,7 @@ public class DefaultPreheatService implements PreheatService {
                 Collection<IdentifiableObject> references =
                     ReflectionUtils.invokeMethod(object, p.getGetterMethod());
 
-                if (references != null) {
+                if (references != null && Hibernate.isInitialized(references)) {
                   for (IdentifiableObject reference : references) {
                     if (reference == null) {
                       continue;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/jsonpatch/JsonPatchExcludedPropertyFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/jsonpatch/JsonPatchExcludedPropertyFilterTest.java
@@ -4,16 +4,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
+ * Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors 
- * may be used to endorse or promote products derived from this software without
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/jsonpatch/JsonPatchExcludedPropertyFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/jsonpatch/JsonPatchExcludedPropertyFilterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.jsonpatch;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jason Pickering
+ */
+class JsonPatchExcludedPropertyFilterTest {
+
+  /** Getter throws if invoked, so the test fails loudly if the filter ever calls it. */
+  static class SampleBean {
+    public String getId() {
+      return "abc";
+    }
+
+    public List<String> getUsers() {
+      throw new UnsupportedOperationException("users getter must not be invoked when excluded");
+    }
+  }
+
+  @Test
+  void excludedPropertyGetterIsNeverInvokedAndOmittedFromOutput() {
+    ObjectMapper mapper = new ObjectMapper();
+    SimpleModule module = new SimpleModule();
+    module.setMixInAnnotation(Object.class, JsonPatchFilterMixin.class);
+    mapper.registerModule(module);
+
+    SimpleFilterProvider filterProvider =
+        new SimpleFilterProvider()
+            .addFilter(
+                JsonPatchExcludedPropertyFilter.ID,
+                new JsonPatchExcludedPropertyFilter(Set.of("users")));
+
+    JsonNode node = mapper.copy().setFilterProvider(filterProvider).valueToTree(new SampleBean());
+
+    assertTrue(node.has("id"), "non-excluded property must still be serialized");
+    assertFalse(node.has("users"), "excluded property must not appear in output");
+  }
+
+  @Test
+  void nonExcludedPropertiesAreUnaffected() {
+    ObjectMapper mapper = new ObjectMapper();
+    SimpleModule module = new SimpleModule();
+    module.setMixInAnnotation(Object.class, JsonPatchFilterMixin.class);
+    mapper.registerModule(module);
+
+    SimpleFilterProvider filterProvider =
+        new SimpleFilterProvider()
+            .addFilter(
+                JsonPatchExcludedPropertyFilter.ID, new JsonPatchExcludedPropertyFilter(Set.of()));
+
+    JsonNode node = mapper.copy().setFilterProvider(filterProvider).valueToTree(new NoUsersBean());
+
+    assertTrue(node.has("id"));
+  }
+
+  static class NoUsersBean {
+    public String getId() {
+      return "abc";
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMetadataMergeService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMetadataMergeService.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Hibernate;
 import org.hisp.dhis.common.MergeMode;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.system.util.ReflectionUtils;
@@ -71,14 +72,25 @@ public class DefaultMetadataMergeService implements MetadataMergeService {
       }
 
       if (property.isCollection()) {
-        Collection<T> sourceObject =
-            ReflectionUtils.invokeMethod(source, property.getGetterMethod());
-        Collection<T> targetObject =
-            ReflectionUtils.invokeMethod(target, property.getGetterMethod());
-
-        if (sourceObject == null) {
+        // Skip read-only computed collections: calling the getter may trigger Hibernate lazy-init
+        // of huge membership sets (e.g. UserRole.getUsers() iterates all members immediately).
+        // If there is no setter, the merge result would be discarded anyway.
+        if (property.getSetterMethod() == null) {
           continue;
         }
+
+        Collection<T> sourceObject =
+            ReflectionUtils.invokeMethod(source, property.getGetterMethod());
+
+        // Skip null or uninitialized Hibernate PersistentCollections to avoid triggering massive
+        // lazy loads when merging Hibernate-managed entities during preheat reference collection.
+        // Plain Java collections are always "initialized".
+        if (sourceObject == null || !Hibernate.isInitialized(sourceObject)) {
+          continue;
+        }
+
+        Collection<T> targetObject =
+            ReflectionUtils.invokeMethod(target, property.getGetterMethod());
 
         if (targetObject == null) {
           targetObject = ReflectionUtils.newCollectionInstance(property.getKlass());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/jsonpatch/JsonPatchManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/jsonpatch/JsonPatchManagerTest.java
@@ -28,19 +28,15 @@
 package org.hisp.dhis.jsonpatch;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import java.util.Set;
-import org.hibernate.Hibernate;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.user.UserGroup;
-import org.hisp.dhis.user.sharing.UserAccess;
-import org.junit.jupiter.api.DisplayName;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Set;
+import org.hibernate.Hibernate;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
@@ -49,16 +45,20 @@ import org.hisp.dhis.commons.jackson.jsonpatch.JsonPatchException;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
-import org.hisp.dhis.test.integration.IntegrationTestBase;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserRole;
+import org.hisp.dhis.user.sharing.UserAccess;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Morten Olav Hansen
  */
-class JsonPatchManagerTest extends IntegrationTestBase {
+class JsonPatchManagerTest extends TransactionalIntegrationTest {
 
   private final ObjectMapper jsonMapper = JacksonObjectMapperConfig.staticJsonMapper();
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/jsonpatch/JsonPatchManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/jsonpatch/JsonPatchManagerTest.java
@@ -30,6 +30,14 @@ package org.hisp.dhis.jsonpatch;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Set;
+import org.hibernate.Hibernate;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.user.UserGroup;
+import org.hisp.dhis.user.sharing.UserAccess;
+import org.junit.jupiter.api.DisplayName;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -265,5 +273,284 @@ class JsonPatchManagerTest extends IntegrationTestBase {
             JsonPatch.class);
     assertNotNull(patch);
     assertThrows(JsonPatchException.class, () -> jsonPatchManager.apply(patch, userRole));
+  }
+
+  private void clearSession() {
+    dbmsManager.clearSession();
+  }
+
+  @Test
+  @DisplayName(
+      "Scalar UserRole patch must not initialize lazy members (slow PATCH /userRoles invariant)")
+  void testUserRoleScalarPatchDoesNotInitializeMembers() throws Exception {
+    UserRole userRole = createUserRole("roleMembersLazy", "AUTH_A");
+    manager.save(userRole);
+
+    for (int i = 0; i < 4; i++) {
+      User user = makeUser(String.valueOf((char) ('A' + i)));
+      manager.save(user);
+      userRole.addUser(user);
+      manager.update(user);
+    }
+    manager.update(userRole);
+
+    clearSession();
+
+    UserRole reloaded = manager.get(UserRole.class, userRole.getUid());
+    assertNotNull(reloaded);
+    assertFalse(
+        Hibernate.isInitialized(reloaded.getMembers()),
+        "members should be lazy before patch apply");
+
+    JsonPatch patch =
+        jsonMapper.readValue(
+            "[{\"op\": \"replace\", \"path\": \"/description\", \"value\": \"updated\"}]",
+            JsonPatch.class);
+
+    UserRole patched = jsonPatchManager.apply(patch, reloaded);
+
+    assertEquals("updated", patched.getDescription());
+    assertFalse(
+        Hibernate.isInitialized(reloaded.getMembers()),
+        "scalar patch must not initialize UserRole.members");
+  }
+
+  @Test
+  @DisplayName("Owner collection authorities survive a name-only UserRole patch")
+  void testUserRoleOwnerAuthoritiesPreservedOnNamePatch() throws Exception {
+    UserRole userRole = createUserRole("roleOwnerAuths", "AUTH_A", "AUTH_B");
+    manager.save(userRole);
+
+    JsonPatch patch =
+        jsonMapper.readValue(
+            "[{\"op\": \"replace\", \"path\": \"/name\", \"value\": \"roleOwnerAuthsRenamed\"}]",
+            JsonPatch.class);
+
+    UserRole patched = jsonPatchManager.apply(patch, userRole);
+
+    assertEquals("roleOwnerAuthsRenamed", patched.getName());
+    assertEquals(Set.of("AUTH_A", "AUTH_B"), patched.getAuthorities());
+  }
+
+  @Test
+  @DisplayName(
+      "Patch referencing non-owner /users path falls back to full hydration, not silently"
+          + " excluded")
+  void testUserRoleUsersPathPatchFallsBackToFullHydration() throws Exception {
+    UserRole userRole = createUserRole("roleUsersPath", "AUTH_A");
+    manager.save(userRole);
+
+    User user = makeUser("Z");
+    manager.save(user);
+    userRole.addUser(user);
+    manager.update(user);
+    manager.update(userRole);
+
+    clearSession();
+
+    UserRole reloaded = manager.get(UserRole.class, userRole.getUid());
+    assertNotNull(reloaded);
+    assertFalse(
+        Hibernate.isInitialized(reloaded.getMembers()),
+        "members should be lazy before patch apply");
+
+    JsonPatch patch =
+        jsonMapper.readValue(
+            "[{\"op\": \"replace\", \"path\": \"/users\", \"value\": []}]", JsonPatch.class);
+
+    UserRole patched = jsonPatchManager.apply(patch, reloaded);
+
+    assertNotNull(patched);
+    assertTrue(
+        Hibernate.isInitialized(reloaded.getMembers()),
+        "explicit /users patch must fall back to full hydration, not be silently excluded");
+  }
+
+  @Test
+  @DisplayName(
+      "sharing.users survives a UserRole scalar patch (regression: exclusion filter must not"
+          + " collide with same-named properties on unrelated nested objects)")
+  void testUserRoleSharingUsersSurviveScalarPatch() throws Exception {
+    UserRole userRole = createUserRole("roleSharingCheck", "AUTH_A");
+    User userA = makeUser("Q");
+    userRole.getSharing().addUserAccess(new UserAccess(userA, "rw------"));
+
+    assertEquals(
+        1, userRole.getSharing().getUsers().size(), "precondition: sharing.users populated");
+
+    JsonPatch patch =
+        jsonMapper.readValue(
+            "[{\"op\": \"replace\", \"path\": \"/name\", \"value\": \"roleSharingCheckRenamed\"}]",
+            JsonPatch.class);
+
+    UserRole patched = jsonPatchManager.apply(patch, userRole);
+
+    assertEquals("roleSharingCheckRenamed", patched.getName());
+    assertEquals(
+        1,
+        patched.getSharing().getUsers().size(),
+        "sharing.users must survive an unrelated scalar patch");
+  }
+
+  @Test
+  @DisplayName(
+      "Scalar OrganisationUnit patch must not initialize inverse children/users collections")
+  void testOrganisationUnitScalarPatchDoesNotInitializeInverseCollections() throws Exception {
+    OrganisationUnit parent = createOrganisationUnit('P');
+    manager.save(parent);
+
+    OrganisationUnit childA = createOrganisationUnit('A', parent);
+    OrganisationUnit childB = createOrganisationUnit('B', parent);
+    manager.save(childA);
+    manager.save(childB);
+    manager.update(parent);
+
+    User user = makeUser("Z");
+    user.addOrganisationUnit(parent);
+    manager.save(user);
+    manager.update(parent);
+
+    clearSession();
+
+    OrganisationUnit reloaded = manager.get(OrganisationUnit.class, parent.getUid());
+    assertNotNull(reloaded);
+    assertFalse(
+        Hibernate.isInitialized(reloaded.getChildren()),
+        "children should be lazy before patch apply");
+    assertFalse(
+        Hibernate.isInitialized(reloaded.getUsers()), "users should be lazy before patch apply");
+
+    JsonPatch patch =
+        jsonMapper.readValue(
+            "[{\"op\": \"replace\", \"path\": \"/name\", \"value\": \"ParentRenamed\"}]",
+            JsonPatch.class);
+
+    OrganisationUnit patched = jsonPatchManager.apply(patch, reloaded);
+
+    assertEquals("ParentRenamed", patched.getName());
+    assertFalse(
+        Hibernate.isInitialized(reloaded.getChildren()),
+        "scalar patch must not initialize OrganisationUnit.children");
+    assertFalse(
+        Hibernate.isInitialized(reloaded.getUsers()),
+        "scalar patch must not initialize OrganisationUnit.users");
+  }
+
+  @Test
+  @DisplayName(
+      "Scalar User patch must not initialize inverse userGroups; owner userRoles stay on patched object")
+  void testUserScalarPatchDoesNotInitializeUserGroups() throws Exception {
+    UserRole role = createUserRole("roleUserPatch", "AUTH_X");
+    manager.save(role);
+
+    User user = makeUser("G");
+    user.getUserRoles().add(role);
+    manager.save(user);
+
+    UserGroup group = createUserGroup('G', Set.of(user));
+    manager.save(group);
+    // Keep both sides consistent for Hibernate inverse User.groups
+    user.getGroups().add(group);
+    manager.update(user);
+
+    clearSession();
+
+    User reloaded = manager.get(User.class, user.getUid());
+    assertNotNull(reloaded);
+    assertFalse(
+        Hibernate.isInitialized(reloaded.getGroups()),
+        "userGroups/groups should be lazy before patch apply");
+
+    JsonPatch patch =
+        jsonMapper.readValue(
+            "[{\"op\": \"replace\", \"path\": \"/firstName\", \"value\": \"PatchedFirst\"}]",
+            JsonPatch.class);
+
+    User patched = jsonPatchManager.apply(patch, reloaded);
+
+    assertEquals("PatchedFirst", patched.getFirstName());
+    assertFalse(
+        Hibernate.isInitialized(reloaded.getGroups()),
+        "scalar patch must not initialize User.groups");
+    assertNotNull(patched.getUserRoles());
+    assertEquals(1, patched.getUserRoles().size(), "owner userRoles must survive scalar patch");
+  }
+
+  @Test
+  @DisplayName(
+      "Scalar UserGroup patch keeps owner users and does not initialize inverse managedByGroups")
+  void testUserGroupScalarPatchKeepsOwnerUsersAndSkipsManagedBy() throws Exception {
+    User userA = makeUser("A");
+    User userB = makeUser("B");
+    manager.save(userA);
+    manager.save(userB);
+
+    UserGroup managed = createUserGroup('M', Set.of());
+    manager.save(managed);
+
+    UserGroup group = createUserGroup('U', Set.of(userA, userB));
+    manager.save(group);
+    // managedByGroups on `managed` is inverse of managedGroups on `group`
+    group.addManagedGroup(managed);
+    manager.update(group);
+    manager.update(managed);
+
+    clearSession();
+
+    UserGroup reloaded = manager.get(UserGroup.class, group.getUid());
+    assertNotNull(reloaded);
+    // Owner collection may or may not be initialized depending on load plan;
+    // after apply, patched object MUST still carry both users.
+    UserGroup managedReloaded = manager.get(UserGroup.class, managed.getUid());
+    assertNotNull(managedReloaded);
+    assertFalse(
+        Hibernate.isInitialized(managedReloaded.getManagedByGroups()),
+        "managedByGroups should be lazy before patch apply on managed group");
+
+    JsonPatch patchOnOwnerGroup =
+        jsonMapper.readValue(
+            "[{\"op\": \"replace\", \"path\": \"/name\", \"value\": \"UserGroupURenamed\"}]",
+            JsonPatch.class);
+
+    UserGroup patched = jsonPatchManager.apply(patchOnOwnerGroup, reloaded);
+
+    assertEquals("UserGroupURenamed", patched.getName());
+    assertNotNull(patched.getMembers());
+    assertEquals(2, patched.getMembers().size(), "owner users must not be omitted on scalar patch");
+
+    // Apply scalar patch on the managed group: inverse managedByGroups must stay lazy
+    JsonPatch patchOnManaged =
+        jsonMapper.readValue(
+            "[{\"op\": \"replace\", \"path\": \"/name\", \"value\": \"UserGroupMRenamed\"}]",
+            JsonPatch.class);
+
+    UserGroup patchedManaged = jsonPatchManager.apply(patchOnManaged, managedReloaded);
+
+    assertEquals("UserGroupMRenamed", patchedManaged.getName());
+    assertFalse(
+        Hibernate.isInitialized(managedReloaded.getManagedByGroups()),
+        "scalar patch must not initialize UserGroup.managedByGroups");
+  }
+
+  @Test
+  @DisplayName("Name-only DataElementGroup patch preserves owner dataElements members")
+  void testDataElementGroupNamePatchPreservesOwnerMembers() throws Exception {
+    DataElement deA = createDataElement('A');
+    DataElement deB = createDataElement('B');
+    manager.save(deA);
+    manager.save(deB);
+
+    DataElementGroup group = createDataElementGroup('G', deA, deB);
+    manager.save(group);
+
+    JsonPatch patch =
+        jsonMapper.readValue(
+            "[{\"op\": \"replace\", \"path\": \"/name\", \"value\": \"DataElementGroupGRenamed\"}]",
+            JsonPatch.class);
+
+    DataElementGroup patched = jsonPatchManager.apply(patch, group);
+
+    assertEquals("DataElementGroupGRenamed", patched.getName());
+    assertEquals(2, patched.getMembers().size(), "owner members must survive name-only patch");
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JsonPatchSideEffectControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JsonPatchSideEffectControllerTest.java
@@ -4,16 +4,14 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
+ * Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors 
- * may be used to endorse or promote products derived from this software without
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
@@ -32,12 +30,12 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserRole;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JsonPatchSideEffectControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JsonPatchSideEffectControllerTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * HTTP-level regressions for system-wide JsonPatchManager non-owner collection skipping
+ * (DHIS2-21852 / PR #24489). Complements {@link org.hisp.dhis.jsonpatch.JsonPatchManagerTest}.
+ *
+ * @author Morten (netroms)
+ */
+@Transactional
+class JsonPatchSideEffectControllerTest extends DhisControllerConvenienceTest {
+
+  @Test
+  @DisplayName("PATCH organisationUnit name keeps children")
+  void testPatchOrganisationUnitNameKeepsChildren() {
+    OrganisationUnit parent = createOrganisationUnit('P');
+    manager.save(parent);
+    OrganisationUnit child = createOrganisationUnit('C', parent);
+    manager.save(child);
+    manager.update(parent);
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/organisationUnits/" + parent.getUid(),
+            "[{'op':'replace','path':'/name','value':'ParentPatched'}]"));
+
+    JsonObject body =
+        GET("/organisationUnits/{id}?fields=name,children[id]", parent.getUid())
+            .content(HttpStatus.OK);
+
+    assertEquals("ParentPatched", body.getString("name").string());
+    assertEquals(1, body.getArray("children").size());
+    assertEquals(child.getUid(), body.getArray("children").getObject(0).getString("id").string());
+  }
+
+  @Test
+  @DisplayName("PATCH userGroup name keeps owner users")
+  void testPatchUserGroupNameKeepsUsers() {
+    User user = makeUser("G");
+    userService.addUser(user);
+
+    String groupId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST("/userGroups/", "{'name':'GroupSide','users':[{'id':'" + user.getUid() + "'}]}"));
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/userGroups/" + groupId,
+            "[{'op':'replace','path':'/name','value':'GroupSideRenamed'}]"));
+
+    JsonObject body = GET("/userGroups/{id}?fields=name,users[id]", groupId).content(HttpStatus.OK);
+
+    assertEquals("GroupSideRenamed", body.getString("name").string());
+    assertEquals(1, body.getArray("users").size());
+    assertEquals(user.getUid(), body.getArray("users").getObject(0).getString("id").string());
+  }
+
+  @Test
+  @DisplayName("PATCH user firstName keeps userGroups")
+  void testPatchUserFirstNameKeepsUserGroups() {
+    UserRole role = createUserRole('F');
+    manager.save(role);
+
+    User user = makeUser("F");
+    user.setEmail("first@example.org");
+    user.getUserRoles().add(role);
+    userService.addUser(user);
+
+    String groupId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/userGroups/",
+                "{'name':'UserFirstGroup','users':[{'id':'" + user.getUid() + "'}]}"));
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/" + user.getUid() + "?importReportMode=ERRORS",
+            "[{'op':'replace','path':'/firstName','value':'FirstPatched'}]"));
+
+    JsonObject body =
+        GET("/users/{id}?fields=firstName,userGroups[id]", user.getUid()).content(HttpStatus.OK);
+
+    assertEquals("FirstPatched", body.getString("firstName").string());
+    assertEquals(1, body.getArray("userGroups").size());
+    assertEquals(groupId, body.getArray("userGroups").getObject(0).getString("id").string());
+  }
+
+  @Test
+  @DisplayName("PATCH userRole replace /users does not change membership")
+  void testPatchUserRoleUsersPathDoesNotChangeMembership() {
+    UserRole role = createUserRole('S');
+    User user = makeUser("R");
+    userService.addUser(user);
+    role.addUser(user);
+    manager.save(role);
+
+    // Non-owner path: may return OK with ERRORS_NOT_OWNER notes; membership must not drop.
+    PATCH("/userRoles/" + role.getUid(), "[{'op':'replace','path':'/users','value':[]}]");
+
+    JsonObject body = GET("/userRoles/{id}?fields=users[id]", role.getUid()).content(HttpStatus.OK);
+
+    assertEquals(1, body.getArray("users").size());
+    assertEquals(user.getUid(), body.getArray("users").getObject(0).getString("id").string());
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -1288,4 +1288,29 @@ class UserControllerTest extends DhisControllerConvenienceTest {
     assertFalse(userInRole.has("email"), "email should not be exposed");
     assertEquals(user.getUid(), userInRole.getString("id").string());
   }
+
+  @Test
+  @DisplayName("PATCH /userRoles/{uid} scalar description keeps assigned users")
+  void testPatchUserRoleDescriptionKeepsUsers() {
+    UserRole role = createUserRole('P');
+    User user = makeUser("R");
+    userService.addUser(user);
+    role.addUser(user);
+    manager.save(role);
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/userRoles/" + role.getUid(),
+            "[{'op':'replace','path':'/description','value':'patched'}]"));
+
+    JsonObject patchedRole =
+        GET("/userRoles/{id}?fields=id,description,users[id]", role.getUid())
+            .content(HttpStatus.OK);
+
+    assertEquals("patched", patchedRole.getString("description").string());
+    assertEquals(1, patchedRole.getArray("users").size());
+    assertEquals(
+        user.getUid(), patchedRole.getArray("users").getObject(0).getString("id").string());
+  }
 }


### PR DESCRIPTION
## Summary
Backport of #24489 (`5f6a524513f`) to `2.41`.

`PATCH /api/userRoles/{uid}` (and other scalar JSON patches) no longer hydrate inverse lazy collections such as `UserRole.members` during `JsonPatchManager.apply`.

## Source
- Master PR: https://github.com/dhis2/dhis2-core/pull/24489
- Jira: [DHIS2-21852](https://dhis2.atlassian.net/browse/DHIS2-21852)

## Notes
Manual backport (cherry-pick conflicted on `JsonPatchManager` / `JsonPatchManagerTest` / `UserControllerTest`).
- Kept branch-local `ReflectionUtils.invokeMethod` and `org.hisp.dhis.commons.collection.CollectionUtils`
- Web tests use `DhisControllerConvenienceTest` / `org.hisp.dhis.web.*` packages
- Integration tests use `dbmsManager.clearSession()`
- Gatling module not shipped on this line (ran from 2.42 minimal module layout locally)

## Fold-in: merge/preheat lazy guards (#23123)

HTTP PATCH still runs `importMetadata(UPDATE)` after `JsonPatchManager.apply`. On 2.41, `DefaultMetadataMergeService` called read-only `UserRole.getUsers()` and hydrated `members`.

Backported the #23123 guards (commit `130e286683`):
- skip collection properties with no setter
- skip uninitialized Hibernate `PersistentCollection`s in merge + preheat

### Local Gatling `UserRolesPerformanceTest` (20k-member role) - PASS

| Request | p95 | max | assert |
|---------|----:|----:|--------|
| PATCH empty role | 38ms | 61ms | PASS |
| PATCH large role (20k) | 33ms | 36ms | PASS |
| GET large role narrow fields | 14ms | 15ms | PASS |

Image revision `130e286`, base URL `http://127.0.0.1:18081`. Empty and large scalar PATCH stay in the same noise band.

Report: local `USERROLES-PERF-2.41-REPORT.md`.

## Test plan
- [x] `JsonPatchExcludedPropertyFilterTest` (unit)
- [ ] `JsonPatchManagerTest` (integration)
- [ ] `JsonPatchSideEffectControllerTest` / `UserControllerTest#testPatchUserRoleDescriptionKeepsUsers` (web-api)
- [x] local `UserRolesPerformanceTest` (20k members) after fold-in

[DHIS2-21852]: https://dhis2.atlassian.net/browse/DHIS2-21852