### PR TITLE
fix: i18n for Org. Unit hierarchy in DV [DHIS2-19860]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
@@ -666,10 +666,12 @@ public class OrganisationUnit extends BaseDimensionalItemObject
     List<OrganisationUnit> ancestors = getAncestors(roots);
 
     builder.append(
-        ancestors.stream().map(IdentifiableObject::getName).collect(Collectors.joining(delimiter)));
+        ancestors.stream()
+            .map(IdentifiableObject::getDisplayName)
+            .collect(Collectors.joining(delimiter)));
 
     if (includeThis) {
-      builder.append(delimiter).append(name);
+      builder.append(delimiter).append(getDisplayName());
     }
 
     if (withLeadingDelimiter) {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitTest.java
@@ -33,6 +33,8 @@ import static org.hisp.dhis.organisationunit.FeatureType.MULTI_POLYGON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -44,6 +46,7 @@ import org.hisp.dhis.common.coordinate.CoordinateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
+import org.mockito.Mockito;
 
 /**
  * @author Lars Helge Overland
@@ -118,21 +121,24 @@ class OrganisationUnitTest {
 
   @Test
   void testGetAncestorNames() {
-    unitD.setParent(unitC);
+    OrganisationUnit unitDSpy = Mockito.spy(unitD);
+    unitDSpy.setParent(unitC);
     unitC.setParent(unitB);
     unitB.setParent(unitA);
     List<String> expected =
         new ArrayList<>(
             Arrays.asList(unitA.getDisplayName(), unitB.getDisplayName(), unitC.getDisplayName()));
-    assertEquals(expected, unitD.getAncestorNames(null, false));
+    assertEquals(expected, unitDSpy.getAncestorNames(null, false));
     expected =
         new ArrayList<>(
             Arrays.asList(
                 unitA.getDisplayName(),
                 unitB.getDisplayName(),
                 unitC.getDisplayName(),
-                unitD.getDisplayName()));
-    assertEquals(expected, unitD.getAncestorNames(null, true));
+                unitDSpy.getDisplayName()));
+    assertEquals(expected, unitDSpy.getAncestorNames(null, true));
+
+    verify(unitDSpy, atLeast(2)).getDisplayName();
   }
 
   @Test


### PR DESCRIPTION
The selected user database language is skipped when displaying OU hierarchy in Pivot table/DV.
This PR fixes this problem.