### PR TITLE
fix: batch managed-group load for /api/me UserDetails [DHIS2-21908]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
@@ -65,6 +65,8 @@ import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonMeDto;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserGroup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -465,5 +467,33 @@ class MeControllerTest extends H2ControllerIntegrationTestBase {
     // Verify avatar is removed
     User userAfterRemoval = userService.getUserByUsername(currentUsername);
     assertNull(userAfterRemoval.getAvatar());
+  }
+
+  /**
+   * DHIS2-21908: /api/me must tolerate users who belong to membership groups that manage other
+   * groups. Building UserDetails via {@code userService.createUserDetails} batch-resolves managed
+   * group PKs; the legacy {@code UserDetails.fromUser} path N+1s on usergroupmanaged.
+   */
+  @Test
+  void testGetCurrentUser_WithManagedUserGroups() {
+    User user = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+
+    UserGroup managed = createUserGroup('Y', Set.of());
+    manager.save(managed);
+
+    UserGroup managing = createUserGroup('X', Set.of(user));
+    managing.addManagedGroup(managed);
+    manager.save(managing);
+
+    user.getGroups().add(managing);
+    userService.updateUser(user);
+
+    JsonMeDto me = GET("/me?fields=id").content().as(JsonMeDto.class);
+    assertEquals(user.getUid(), me.getId());
+
+    // Same choke point MeController now uses for UserDetails construction.
+    User reloaded = userService.getUser(user.getUid());
+    UserDetails details = userService.createUserDetails(reloaded);
+    assertTrue(details.getManagedGroupLongIds().contains(managed.getId()));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
@@ -161,7 +161,9 @@ public class MeController {
     List<String> programs =
         programService.getCurrentUserPrograms().stream().map(IdentifiableObject::getUid).toList();
 
-    UserDetails userDetails = UserDetails.fromUser(user);
+    // Use the service path so managed-group PKs are batch-resolved (one SQL) instead of
+    // UserDetails.fromUser walking User.getManagedGroups() (lazy N+1 per membership group).
+    UserDetails userDetails = userService.createUserDetails(user);
 
     List<String> dataSets =
         dataSetService.getUserDataRead(userDetails).stream()


### PR DESCRIPTION
## Summary
- Fix Hibernate N+1 on cold `GET /api/me` when the user belongs to many user groups.
- `MeController.getCurrentUser` used `UserDetails.fromUser`, which walks `User.getManagedGroups()` and lazy-loads `usergroupmanaged` once per membership group.
- Route through `userService.createUserDetails(user)` so managed-group PKs use the existing batch SQL path from #24097.

## Jira
[DHIS2-21908](https://dhis2.atlassian.net/browse/DHIS2-21908)

## Test plan
- [x] `MeControllerTest#testGetCurrentUser_WithManagedUserGroups` (local)
- [x] Local THESIS gate: admin member of 16 groups; cold `GET /api/me?fields=id`
  - before: 16x `usergroupmanaged` selects (FAIL)
  - after: 0 Hibernate `usergroupmanaged` N+1 lines (PASS), including `--restart`


## Notes
- #24097 already batched `DefaultUserService.createUserDetails`; `/api/me` still called `fromUser` and kept the N+1.
- Found via queryhound user-app hunt (`f-2c91b1d71e8c`).

AI Assisted

[DHIS2-21908]: https://dhis2.atlassian.net/browse/DHIS2-21908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ