### PR TITLE
fix: batch-load userRole authorities/restrictions for UserDetails [DHIS2-21909]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.twofa.TwoFactorType;
 import org.hisp.dhis.user.UserDetailsImpl.UserDetailsImplBuilder;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 public interface UserDetails
     extends org.springframework.security.core.userdetails.UserDetails, UidObject {
@@ -138,6 +139,8 @@ public interface UserDetails
         searchOrgUnitUids,
         dataViewUnitUids,
         loadOrgUnits,
+        null,
+        null,
         null);
   }
 
@@ -148,6 +151,34 @@ public interface UserDetails
    * User#getManagedGroups()} (which initialises {@code getManagedGroups()} once per group). When
    * null, the managed groups are resolved from the entity (legacy behaviour) for callers without
    * access to a store.
+   */
+  @CheckForNull
+  static UserDetails createUserDetails(
+      @CheckForNull User user,
+      boolean accountNonLocked,
+      boolean credentialsNonExpired,
+      @CheckForNull Set<String> orgUnitUids,
+      @CheckForNull Set<String> searchOrgUnitUids,
+      @CheckForNull Set<String> dataViewUnitUids,
+      boolean loadOrgUnits,
+      @CheckForNull Set<Long> managedGroupLongIds) {
+    return createUserDetails(
+        user,
+        accountNonLocked,
+        credentialsNonExpired,
+        orgUnitUids,
+        searchOrgUnitUids,
+        dataViewUnitUids,
+        loadOrgUnits,
+        managedGroupLongIds,
+        null,
+        null);
+  }
+
+  /**
+   * Variant that also accepts pre-resolved role authorities and restrictions. When non-null, these
+   * sets are used instead of walking each {@link UserRole} lazy element-collection (DHIS2-21909).
+   * When null, legacy per-role lazy loads remain.
    */
   // TODO(DHIS2-21896) this overload chain has grown too many parameters (java:S107); replace with
   // a parameter object and change the Set<String> UID params to Set<UID>.
@@ -160,7 +191,9 @@ public interface UserDetails
       @CheckForNull Set<String> searchOrgUnitUids,
       @CheckForNull Set<String> dataViewUnitUids,
       boolean loadOrgUnits,
-      @CheckForNull Set<Long> managedGroupLongIds) {
+      @CheckForNull Set<Long> managedGroupLongIds,
+      @CheckForNull Set<String> roleAuthorities,
+      @CheckForNull Set<String> roleRestrictions) {
 
     if (user == null) {
       return null;
@@ -170,6 +203,26 @@ public interface UserDetails
         managedGroupLongIds != null
             ? managedGroupLongIds
             : (user.getUid() == null ? Set.of() : setOfPrimaryKeys(user.getManagedGroups()));
+
+    final Collection<GrantedAuthority> grantedAuthorities;
+    final Set<String> allAuthorities;
+    final boolean isSuper;
+    if (roleAuthorities != null) {
+      allAuthorities = Set.copyOf(roleAuthorities);
+      List<GrantedAuthority> granted = new java.util.ArrayList<>(allAuthorities.size());
+      for (String authority : allAuthorities) {
+        granted.add(new SimpleGrantedAuthority(authority));
+      }
+      grantedAuthorities = granted;
+      isSuper = allAuthorities.contains(Authorities.ALL.toString());
+    } else {
+      grantedAuthorities = new java.util.ArrayList<>(user.getAuthorities());
+      allAuthorities =
+          grantedAuthorities.stream()
+              .map(GrantedAuthority::getAuthority)
+              .collect(Collectors.toSet());
+      isSuper = user.isSuper();
+    }
 
     UserDetailsImplBuilder userDetailsImplBuilder =
         UserDetailsImpl.builder()
@@ -191,14 +244,9 @@ public interface UserDetails
             .accountNonLocked(accountNonLocked)
             .credentialsNonExpired(credentialsNonExpired)
             .dataViewMaxOrganisationUnitLevel(user.getDataViewMaxOrganisationUnitLevel())
-            .authorities(user.getAuthorities())
-            .allAuthorities(
-                new HashSet<>(
-                    Set.copyOf(
-                        user.getAuthorities().stream()
-                            .map(GrantedAuthority::getAuthority)
-                            .toList())))
-            .isSuper(user.isSuper())
+            .authorities(grantedAuthorities)
+            .allAuthorities(new HashSet<>(allAuthorities))
+            .isSuper(isSuper)
             .userRoleIds(new HashSet<>(setOfIds(user.getUserRoles())))
             .userGroupIds(
                 new HashSet<>(user.getUid() == null ? Set.of() : setOfIds(user.getGroups())))
@@ -227,12 +275,17 @@ public interface UserDetails
               ? setOfIds(user.getDataViewOrganisationUnitsWithFallback())
               : (dataViewUnitUids.isEmpty() ? orgUnitUids : dataViewUnitUids);
 
+      Set<String> resolvedRestrictions =
+          roleRestrictions != null
+              ? new HashSet<>(roleRestrictions)
+              : new HashSet<>(user.getAllRestrictions());
+
       userDetailsImplBuilder
           .userOrgUnitIds(new HashSet<>(userOrgUnitIds))
           .userSearchOrgUnitIds(new HashSet<>(userSearchOrgUnitIds))
           .userEffectiveSearchOrgUnitIds(new HashSet<>(userEffectiveSearchOrgUnitIds))
           .userDataOrgUnitIds(new HashSet<>(userDataOrgUnitIds))
-          .allRestrictions(new HashSet<>(user.getAllRestrictions()));
+          .allRestrictions(resolvedRestrictions);
 
     } else {
       userDetailsImplBuilder

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserRoleStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserRoleStore.java
@@ -29,6 +29,9 @@
  */
 package org.hisp.dhis.user;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.common.UID;
@@ -62,4 +65,28 @@ public interface UserRoleStore extends IdentifiableObjectStore<UserRole> {
    * @param targetUserUid UID of the user to copy to
    */
   void copyRoleMemberships(@Nonnull UID sourceUserUid, @Nonnull UID targetUserUid);
+
+  /**
+   * Batch-loads authorities for the given user-role primary keys in a single SQL query.
+   *
+   * <p>Used by {@code UserService#createUserDetails(User)} so authentication does not lazy-load
+   * {@code userroleauthorities} once per role (DHIS2-21909).
+   *
+   * @param userRoleIds user-role primary keys; empty yields an empty map
+   * @return map of role id to authorities (missing keys mean the role has no authorities)
+   */
+  @Nonnull
+  Map<Long, Set<String>> getAuthoritiesByUserRoleIds(@Nonnull Collection<Long> userRoleIds);
+
+  /**
+   * Batch-loads restrictions for the given user-role primary keys in a single SQL query.
+   *
+   * <p>Companion to {@link #getAuthoritiesByUserRoleIds(Collection)} for the {@code
+   * userrolerestrictions} element-collection (DHIS2-21909).
+   *
+   * @param userRoleIds user-role primary keys; empty yields an empty map
+   * @return map of role id to restrictions (missing keys mean the role has no restrictions)
+   */
+  @Nonnull
+  Map<Long, Set<String>> getRestrictionsByUserRoleIds(@Nonnull Collection<Long> userRoleIds);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -73,6 +73,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Hibernate;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.attribute.AttributeValues;
@@ -957,6 +958,10 @@ public class DefaultUserService implements UserService {
             : user.getGroups().stream().map(UserGroup::getId).collect(Collectors.toSet());
     Set<Long> managedGroupLongIds = userGroupService.getManagedGroupIds(userGroupPrimaryKeys);
 
+    // Batch-load role authorities/restrictions (DHIS2-21909) without mutating UserRole entities.
+    Set<String> roleAuthorities = resolveRoleAuthorities(user);
+    Set<String> roleRestrictions = resolveRoleRestrictions(user);
+
     return UserDetails.createUserDetails(
         user,
         accountNonLocked,
@@ -965,7 +970,65 @@ public class DefaultUserService implements UserService {
         new HashSet<>(searchOrganisationUnitsUidsByUser),
         new HashSet<>(dataViewOrganisationUnitsUidsByUser),
         true,
-        managedGroupLongIds);
+        managedGroupLongIds,
+        roleAuthorities,
+        roleRestrictions);
+  }
+
+  /**
+   * Collects the user's role authorities, batch-loading only roles whose authorities collection is
+   * still lazy. Transient roles and already-initialised collections keep their in-memory values so
+   * unflushed inserts (admin bootstrap) are not lost to a separate JDBC connection.
+   */
+  private Set<String> resolveRoleAuthorities(User user) {
+    Set<UserRole> roles = user.getUserRoles();
+    if (roles == null || roles.isEmpty()) {
+      return Set.of();
+    }
+    Set<String> result = new HashSet<>();
+    Set<Long> batchIds = new HashSet<>();
+    for (UserRole role : roles) {
+      if (role == null) {
+        continue;
+      }
+      if (role.getId() <= 0 || Hibernate.isInitialized(role.getAuthorities())) {
+        if (role.getAuthorities() != null) {
+          result.addAll(role.getAuthorities());
+        }
+      } else {
+        batchIds.add(role.getId());
+      }
+    }
+    if (!batchIds.isEmpty()) {
+      userRoleStore.getAuthoritiesByUserRoleIds(batchIds).values().forEach(result::addAll);
+    }
+    return result;
+  }
+
+  /** Same batching strategy as {@link #resolveRoleAuthorities(User)} for role restrictions. */
+  private Set<String> resolveRoleRestrictions(User user) {
+    Set<UserRole> roles = user.getUserRoles();
+    if (roles == null || roles.isEmpty()) {
+      return Set.of();
+    }
+    Set<String> result = new HashSet<>();
+    Set<Long> batchIds = new HashSet<>();
+    for (UserRole role : roles) {
+      if (role == null) {
+        continue;
+      }
+      if (role.getId() <= 0 || Hibernate.isInitialized(role.getRestrictions())) {
+        if (role.getRestrictions() != null) {
+          result.addAll(role.getRestrictions());
+        }
+      } else {
+        batchIds.add(role.getId());
+      }
+    }
+    if (!batchIds.isEmpty()) {
+      userRoleStore.getRestrictionsByUserRoleIds(batchIds).values().forEach(result::addAll);
+    }
+    return result;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserRoleStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserRoleStore.java
@@ -30,6 +30,12 @@
 package org.hisp.dhis.user.hibernate;
 
 import jakarta.persistence.EntityManager;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import org.hibernate.query.Query;
 import org.hisp.dhis.common.UID;
@@ -90,5 +96,43 @@ public class HibernateUserRoleStore extends HibernateIdentifiableObjectStore<Use
     query.setParameter("dataSet", dataSet);
 
     return query.getSingleResult().intValue();
+  }
+
+  @Override
+  @Nonnull
+  public Map<Long, Set<String>> getAuthoritiesByUserRoleIds(@Nonnull Collection<Long> userRoleIds) {
+    return loadElementCollectionByRoleIds(
+        userRoleIds, "select userroleid, authority from userroleauthorities where userroleid in (");
+  }
+
+  @Override
+  @Nonnull
+  public Map<Long, Set<String>> getRestrictionsByUserRoleIds(
+      @Nonnull Collection<Long> userRoleIds) {
+    return loadElementCollectionByRoleIds(
+        userRoleIds,
+        "select userroleid, restriction from userrolerestrictions where userroleid in (");
+  }
+
+  @Nonnull
+  private Map<Long, Set<String>> loadElementCollectionByRoleIds(
+      @Nonnull Collection<Long> userRoleIds, @Nonnull String sqlPrefix) {
+    if (userRoleIds.isEmpty()) {
+      return Map.of();
+    }
+    String placeholders = String.join(",", Collections.nCopies(userRoleIds.size(), "?"));
+    String sql = sqlPrefix + placeholders + ")";
+    Map<Long, Set<String>> result = new HashMap<>();
+    jdbcTemplate.query(
+        sql,
+        rs -> {
+          long roleId = rs.getLong(1);
+          String value = rs.getString(2);
+          if (value != null) {
+            result.computeIfAbsent(roleId, id -> new HashSet<>()).add(value);
+          }
+        },
+        userRoleIds.toArray());
+    return result;
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/LoginConfigControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/LoginConfigControllerTest.java
@@ -33,8 +33,10 @@ import static org.hisp.dhis.http.HttpClientAdapter.Body;
 import static org.hisp.dhis.http.HttpClientAdapter.ContentType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Properties;
+import java.util.Set;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonArray;
@@ -49,6 +51,10 @@ import org.hisp.dhis.setting.SystemSettingsService;
 import org.hisp.dhis.setting.SystemSettingsTranslationService;
 import org.hisp.dhis.system.SystemService;
 import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
+import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserRole;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -224,5 +230,40 @@ class LoginConfigControllerTest extends PostgresControllerIntegrationTestBase {
     POST("/systemSettings/maxPasswordLength", "100").content(HttpStatus.OK);
     response = GET("/loginConfig").content();
     assertEquals("100", response.getString("maxPasswordLength").string());
+  }
+
+  /**
+   * Regression for DHIS2-21909: createUserDetails must batch-load role authorities and restrictions
+   * so authenticated /api/loginConfig does not N+1 on userroleauthorities / userrolerestrictions.
+   */
+  @Test
+  void testCreateUserDetails_BatchLoadsRoleAuthoritiesAndRestrictions() {
+    User user = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+
+    for (int i = 0; i < 5; i++) {
+      char c = (char) ('A' + i);
+      UserRole role = createUserRole(c, "F_QH21909_" + c);
+      role.getRestrictions().add("RESTR_" + c);
+      userService.addUserRole(role);
+      user.getUserRoles().add(role);
+    }
+    userService.updateUser(user);
+
+    // Drop first-level cache so role element-collections are lazy again. Reload by uid (not
+    // username) so the username query cache cannot return a stale User without the new roles.
+    manager.flush();
+    manager.clear();
+
+    User reloaded = userService.getUser(user.getUid());
+    UserDetails details = userService.createUserDetails(reloaded);
+
+    assertTrue(details.getAllAuthorities().contains("F_QH21909_A"));
+    assertTrue(details.getAllAuthorities().contains("F_QH21909_E"));
+    assertTrue(details.hasAnyRestrictions(Set.of("RESTR_A")));
+    assertTrue(details.hasAnyRestrictions(Set.of("RESTR_E")));
+
+    // Endpoint still serves config under auth after the UserDetails path runs.
+    JsonObject response = GET("/loginConfig").content();
+    assertEquals(systemService.getSystemInfoVersion(), response.getString("apiVersion").string());
   }
 }


### PR DESCRIPTION
## Summary
Authenticated requests that build `UserDetails` (including cold `GET /api/loginConfig`) lazy-loaded each `UserRole` authorities and restrictions collection one-by-one (Hibernate N+1 on `userroleauthorities` / `userrolerestrictions`).

Batch-load those collections in `DefaultUserService.createUserDetails` and pass the resolved sets into `UserDetails`, matching the managed-groups batch pattern from DHIS2-21908.

## Jira
[DHIS2-21909](https://dhis2.atlassian.net/browse/DHIS2-21909)

## Evidence
- queryhound cold FAIL: observed_dup=13 (authorities + restrictions)
- THESIS baseline FAIL 14 → fixed PASS 0 (cold + restart)
- Regression: `LoginConfigControllerTest#testCreateUserDetails_BatchLoadsRoleAuthoritiesAndRestrictions`

## Test plan
- [x] THESIS gate PASS×2 independent
- [x] LoginConfigControllerTest new method + MeControllerTest#testGetCurrentUser
- [ ] CI

[DHIS2-21909]: https://dhis2.atlassian.net/browse/DHIS2-21909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ