### PR TITLE
chore: Use Locale type in translations

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -316,8 +316,8 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
     }
 
     return translationCache.computeIfAbsent(
-        Translation.getCacheKey(locale.toString(), translationKey),
-        key -> getTranslationValue(locale.toString(), translationKey, defaultTranslation));
+        Translation.getCacheKey(locale, translationKey),
+        key -> getTranslationValue(locale, translationKey, defaultTranslation));
   }
 
   @Override
@@ -550,10 +550,10 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
    *
    * @return Translation value if exists, otherwise return default value.
    */
-  private String getTranslationValue(String locale, String translationKey, String defaultValue) {
+  private String getTranslationValue(Locale locale, String translationKey, String defaultValue) {
     for (Translation translation : translations) {
       if (locale.equals(translation.getLocale())
-          && translationKey.equals(translation.getProperty())
+          && translationKey.equalsIgnoreCase(translation.getProperty())
           && !StringUtils.isEmpty(translation.getValue())) {
         return translation.getValue();
       }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Locale.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Locale.java
@@ -65,7 +65,6 @@ public record Locale(
    * @throws IllegalArgumentException in case the input is not a valid locale string
    */
   @Nonnull
-  @JsonCreator
   public static Locale of(@Nonnull String locale) throws IllegalArgumentException {
     int len = locale.length();
     // is it just ll or lll

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Locale.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Locale.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.common;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,6 +65,7 @@ public record Locale(
    * @throws IllegalArgumentException in case the input is not a valid locale string
    */
   @Nonnull
+  @JsonCreator
   public static Locale of(@Nonnull String locale) throws IllegalArgumentException {
     int len = locale.length();
     // is it just ll or lll
@@ -173,6 +175,7 @@ public record Locale(
   }
 
   @Override
+  @JsonValue
   public String toString() {
     if (region == null && script == null) return language;
     if (script == null) return language + "_" + region;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/TranslatableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/TranslatableObject.java
@@ -104,8 +104,8 @@ public class TranslatableObject {
     }
 
     return translationCache.computeIfAbsent(
-        Translation.getCacheKey(locale.toString(), translationKey),
-        key -> getTranslationValue(locale.toString(), translationKey, defaultTranslation));
+        Translation.getCacheKey(locale, translationKey),
+        key -> getTranslationValue(locale, translationKey, defaultTranslation));
   }
 
   /**
@@ -113,10 +113,10 @@ public class TranslatableObject {
    *
    * @return Translation value if exists, otherwise return default value.
    */
-  private String getTranslationValue(String locale, String translationKey, String defaultValue) {
+  private String getTranslationValue(Locale locale, String translationKey, String defaultValue) {
     for (Translation translation : translations) {
       if (locale.equals(translation.getLocale())
-          && translationKey.equals(translation.getProperty())
+          && translationKey.equalsIgnoreCase(translation.getProperty())
           && !StringUtils.isEmpty(translation.getValue())) {
         return translation.getValue();
       }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/TranslationProperty.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/TranslationProperty.java
@@ -95,7 +95,7 @@ public class TranslationProperty implements Serializable {
    *
    * @return Translation value if exists, otherwise return default value.
    */
-  private String getTranslationValue(String locale, String translationKey, String defaultValue) {
+  private String getTranslationValue(Locale locale, String translationKey, String defaultValue) {
     for (Translation translation : translations) {
       if (locale.equals(translation.getLocale())
           && translationKey.equalsIgnoreCase(translation.getProperty())
@@ -125,8 +125,8 @@ public class TranslationProperty implements Serializable {
     }
 
     return translationCache.computeIfAbsent(
-        Translation.getCacheKey(locale.toString(), translationKey),
-        key -> getTranslationValue(locale.toString(), translationKey, defaultTranslation));
+        Translation.getCacheKey(locale, translationKey),
+        key -> getTranslationValue(locale, translationKey, defaultTranslation));
   }
 
   /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
@@ -86,6 +86,7 @@ import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableProperty;
+import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.common.NameableObject;
 import org.hisp.dhis.common.ObjectStyle;
 import org.hisp.dhis.common.OpenApi;
@@ -750,14 +751,14 @@ public class Program extends BaseMetadataObject
       return defaultValue;
     }
     return translationCache.computeIfAbsent(
-        Translation.getCacheKey(locale.toString(), translationKey),
-        key -> getTranslationValue(locale.toString(), translationKey, defaultTranslation));
+        Translation.getCacheKey(locale, translationKey),
+        key -> getTranslationValue(locale, translationKey, defaultTranslation));
   }
 
-  private String getTranslationValue(String locale, String translationKey, String defaultValue) {
+  private String getTranslationValue(Locale locale, String translationKey, String defaultValue) {
     for (Translation translation : getTranslations()) {
       if (locale.equals(translation.getLocale())
-          && translationKey.equals(translation.getProperty())
+          && translationKey.equalsIgnoreCase(translation.getProperty())
           && !StringUtils.isEmpty(translation.getValue())) {
         return translation.getValue();
       }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/Translation.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/Translation.java
@@ -35,22 +35,29 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import java.util.Objects;
+
+import lombok.Setter;
 import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.Locale;
 
 /**
  * @author Viet Nguyen <viet@dhis2.org>
  */
+@Setter
 @JacksonXmlRootElement(localName = "translations", namespace = DxfNamespaces.DXF_2_0)
 public class Translation implements Serializable {
-  private String locale;
 
+  public static Translation ofLanguage(Locale locale, String property, String value) {
+    return new Translation(Locale.of(locale.language()), property, value);
+  }
+
+  private Locale locale;
   private String property;
-
   private String value;
 
   public Translation() {}
 
-  public Translation(String locale, String property, String value) {
+  public Translation(Locale locale, String property, String value) {
     this.locale = locale;
     this.property = property;
     this.value = value;
@@ -63,19 +70,10 @@ public class Translation implements Serializable {
 
   @Override
   public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-
-    if (obj == null || getClass() != obj.getClass()) {
-      return false;
-    }
-
-    final Translation other = (Translation) obj;
-
-    return Objects.equals(this.locale, other.locale)
-        && Objects.equals(this.property, other.property)
-        && Objects.equals(this.value, other.value);
+    return obj instanceof Translation other
+        && Objects.equals(locale, other.locale)
+        && Objects.equals(property, other.property)
+        && Objects.equals(value, other.value);
   }
 
   /**
@@ -86,7 +84,7 @@ public class Translation implements Serializable {
    * @return a unique cache key valid for a given translated objects, or null if either locale or
    *     property is null.
    */
-  public static String getCacheKey(String locale, String property) {
+  public static String getCacheKey(Locale locale, String property) {
     return locale != null && property != null ? (locale + property) : null;
   }
 
@@ -96,12 +94,8 @@ public class Translation implements Serializable {
 
   @JsonProperty
   @JacksonXmlProperty(isAttribute = true)
-  public String getLocale() {
+  public Locale getLocale() {
     return locale;
-  }
-
-  public void setLocale(String locale) {
-    this.locale = locale;
   }
 
   @JsonProperty
@@ -110,26 +104,14 @@ public class Translation implements Serializable {
     return property;
   }
 
-  public void setProperty(String property) {
-    this.property = property;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(isAttribute = true)
   public String getValue() {
     return value;
   }
 
-  public void setValue(String value) {
-    this.value = value;
-  }
-
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("locale", locale)
-        .add("property", property)
-        .add("value", value)
-        .toString();
+    return "%s(%s)=%s".formatted(property, locale, value);
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/Translation.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/Translation.java
@@ -32,10 +32,8 @@ package org.hisp.dhis.translation;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import java.util.Objects;
-
 import lombok.Setter;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.Locale;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
@@ -101,7 +101,7 @@ public class TranslationsCheck implements ObjectValidationCheck {
     Set<String> setPropertyLocales = new HashSet<>();
 
     for (Translation translation : translations) {
-      String key = String.join("_", translation.getProperty(), translation.getLocale());
+      String key = String.join("_", translation.getProperty(), translation.getLocale().toString());
 
       if (setPropertyLocales.contains(key)) {
         objectReport.addErrorReport(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.common.collection.CollectionUtils;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -100,36 +101,34 @@ public class TranslationsCheck implements ObjectValidationCheck {
 
     Set<String> setPropertyLocales = new HashSet<>();
 
-    for (Translation translation : translations) {
-      String key = String.join("_", translation.getProperty(), translation.getLocale().toString());
-
-      if (setPropertyLocales.contains(key)) {
-        objectReport.addErrorReport(
-            new ErrorReport(
-                    Translation.class,
-                    ErrorCode.E1106,
-                    translation.getProperty(),
-                    translation.getLocale(),
-                    klass.getSimpleName(),
-                    object.getUid())
-                .setErrorKlass(klass));
-      } else {
-        setPropertyLocales.add(key);
-      }
-
-      if (translation.getLocale() == null) {
+    for (Translation t : translations) {
+      Locale locale = t.getLocale();
+      String property = t.getProperty();
+      String value = t.getValue();
+      if (locale == null) {
         objectReport.addErrorReport(
             new ErrorReport(Translation.class, ErrorCode.E4000, "locale").setErrorKlass(klass));
-      }
-
-      if (translation.getProperty() == null) {
+      } else if (property == null) {
         objectReport.addErrorReport(
             new ErrorReport(Translation.class, ErrorCode.E4000, "property").setErrorKlass(klass));
-      }
-
-      if (translation.getValue() == null) {
+      } else if (value == null) {
         objectReport.addErrorReport(
             new ErrorReport(Translation.class, ErrorCode.E4000, "value").setErrorKlass(klass));
+      } else {
+        String key = String.join("_", property, locale.toString());
+        if (setPropertyLocales.contains(key)) {
+          objectReport.addErrorReport(
+              new ErrorReport(
+                      Translation.class,
+                      ErrorCode.E1106,
+                      property,
+                      locale,
+                      klass.getSimpleName(),
+                      object.getUid())
+                  .setErrorKlass(klass));
+        } else {
+          setPropertyLocales.add(key);
+        }
       }
     }
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonBinaryTypeTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonBinaryTypeTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
-
 import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.render.DeviceRenderTypeMap;
 import org.hisp.dhis.render.RenderDevice;

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonBinaryTypeTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonBinaryTypeTest.java
@@ -35,6 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
+
+import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.render.DeviceRenderTypeMap;
 import org.hisp.dhis.render.RenderDevice;
 import org.hisp.dhis.render.type.ValueTypeRenderingObject;
@@ -57,7 +59,7 @@ class JsonBinaryTypeTest {
   @BeforeEach
   void setUp() {
     translation1 = new Translation();
-    translation1.setLocale("en");
+    translation1.setLocale(Locale.of("en"));
     translation1.setValue("English Test 1");
     jsonBinaryType = new JsonBinaryType();
     jsonBinaryType.init(Translation.class);

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonListBinaryTypeTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonListBinaryTypeTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import java.util.ArrayList;
 import java.util.List;
 import org.hamcrest.Matchers;
+import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.translation.Translation;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,10 +59,10 @@ class JsonListBinaryTypeTest {
   @BeforeEach
   void setUp() {
     translation1 = new Translation();
-    translation1.setLocale("en");
+    translation1.setLocale(Locale.of("en"));
     translation1.setValue("English Test 1");
     translation2 = new Translation();
-    translation2.setLocale("no");
+    translation2.setLocale(Locale.of("no"));
     translation2.setValue("Norwegian Test 1");
     translations = new ArrayList<>();
     translations.add(translation1);

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonSetBinaryTypeTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/hibernate/jsonb/type/JsonSetBinaryTypeTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.util.HashSet;
 import java.util.Set;
 import org.hamcrest.Matchers;
+import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.translation.Translation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,10 +59,10 @@ class JsonSetBinaryTypeTest {
   @BeforeEach
   void setUp() {
     translation1 = new Translation();
-    translation1.setLocale("en");
+    translation1.setLocale(Locale.of("en"));
     translation1.setValue("English Test 1");
     translation2 = new Translation();
-    translation2.setLocale("no");
+    translation2.setLocale(Locale.of("no"));
     translation2.setValue("Norwegian Test 1");
     translations = new HashSet<>();
     translations.add(translation1);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/indicator/IndicatorServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/indicator/IndicatorServiceTest.java
@@ -288,9 +288,9 @@ class IndicatorServiceTest extends PostgresIntegrationTestBase {
     String denominatorTranslated = "Denominator description translated";
     Set<Translation> listObjectTranslation = new HashSet<>(indicatorA.getTranslations());
     listObjectTranslation.add(
-        new Translation(locale.language(), "NUMERATOR_DESCRIPTION", numeratorTranslated));
+        Translation.ofLanguage(locale, "NUMERATOR_DESCRIPTION", numeratorTranslated));
     listObjectTranslation.add(
-        new Translation(locale.language(), "DENOMINATOR_DESCRIPTION", denominatorTranslated));
+        Translation.ofLanguage(locale, "DENOMINATOR_DESCRIPTION", denominatorTranslated));
     identifiableObjectManager.updateTranslations(indicatorA, listObjectTranslation);
     assertEquals(numeratorTranslated, indicatorA.getDisplayNumeratorDescription());
     assertEquals(denominatorTranslated, indicatorA.getDisplayDenominatorDescription());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/legend/LegendSetServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/legend/LegendSetServiceTest.java
@@ -407,7 +407,7 @@ class LegendSetServiceTest extends PostgresIntegrationTestBase {
 
     String translatedName = "translatedName";
     Set<Translation> translations = new HashSet<>(legendSetA.getTranslations());
-    translations.add(new Translation(locale.language(), "NAME", translatedName));
+    translations.add(Translation.ofLanguage(locale, "NAME", translatedName));
     objectManager.updateTranslations(legendSetA, translations);
 
     LegendSet retrieved = legendSetService.getLegendSet(idA);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
@@ -207,12 +207,10 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     evA.setSubtitle("SubTitle");
     manager.save(evA);
     Set<Translation> translations = new HashSet<>();
-    translations.add(
-        Translation.ofLanguage(locale, "baseLineLabel", "translated BaseLineLabel"));
+    translations.add(Translation.ofLanguage(locale, "baseLineLabel", "translated BaseLineLabel"));
     translations.add(
         Translation.ofLanguage(locale, "domainAxisLabel", "translated DomainAxisLabel"));
-    translations.add(
-        Translation.ofLanguage(locale, "rangeAxisLabel", "translated RangeAxisLabel"));
+    translations.add(Translation.ofLanguage(locale, "rangeAxisLabel", "translated RangeAxisLabel"));
     translations.add(
         Translation.ofLanguage(locale, "targetLineLabel", "translated TargetLineLabel"));
     translations.add(Translation.ofLanguage(locale, "title", "translated Title"));
@@ -238,12 +236,10 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     visualization.setSubtitle("SubTitle");
     manager.save(visualization);
     Set<Translation> translations = new HashSet<>();
-    translations.add(
-        Translation.ofLanguage(locale, "baseLineLabel", "translated BaseLineLabel"));
+    translations.add(Translation.ofLanguage(locale, "baseLineLabel", "translated BaseLineLabel"));
     translations.add(
         Translation.ofLanguage(locale, "domainAxisLabel", "translated DomainAxisLabel"));
-    translations.add(
-        Translation.ofLanguage(locale, "rangeAxisLabel", "translated RangeAxisLabel"));
+    translations.add(Translation.ofLanguage(locale, "rangeAxisLabel", "translated RangeAxisLabel"));
     translations.add(
         Translation.ofLanguage(locale, "targetLineLabel", "translated TargetLineLabel"));
     translations.add(Translation.ofLanguage(locale, "title", "translated Title"));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/translation/TranslationServiceTest.java
@@ -103,9 +103,9 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     String translatedShortName = "translatedShortName";
     String translatedDescription = "translatedDescription";
     Set<Translation> translations = new HashSet<>(dataElementA.getTranslations());
-    translations.add(new Translation(locale.language(), "NAME", translatedName));
-    translations.add(new Translation(locale.language(), "SHORT_NAME", translatedShortName));
-    translations.add(new Translation(locale.language(), "DESCRIPTION", translatedDescription));
+    translations.add(Translation.ofLanguage(locale, "NAME", translatedName));
+    translations.add(Translation.ofLanguage(locale, "SHORT_NAME", translatedShortName));
+    translations.add(Translation.ofLanguage(locale, "DESCRIPTION", translatedDescription));
     manager.updateTranslations(dataElementA, translations);
     assertEquals(translatedName, dataElementA.getDisplayName());
     assertEquals(translatedShortName, dataElementA.getDisplayShortName());
@@ -118,7 +118,7 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     manager.save(categoryCombo);
     String translatedName = "translatedName";
     Set<Translation> translations = new HashSet<>(categoryCombo.getTranslations());
-    translations.add(new Translation(locale.language(), "NAME", translatedName));
+    translations.add(Translation.ofLanguage(locale, "NAME", translatedName));
     manager.updateTranslations(categoryCombo, translations);
     assertEquals(translatedName, categoryCombo.getDisplayName());
   }
@@ -133,7 +133,7 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     manager.save(option);
     Set<Translation> translations = new HashSet<>(option.getTranslations());
     String translatedValue = "Option FormName Translated";
-    translations.add(new Translation(locale.language(), "FORM_NAME", translatedValue));
+    translations.add(Translation.ofLanguage(locale, "FORM_NAME", translatedValue));
     manager.updateTranslations(option, translations);
     assertEquals(translatedValue, option.getDisplayFormName());
   }
@@ -144,7 +144,7 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     manager.save(programStageSection);
     String translatedValue = "ProgramStageSection FormName Translated";
     Set<Translation> translations = new HashSet<>(programStageSection.getTranslations());
-    translations.add(new Translation(locale.language(), "FORM_NAME", translatedValue));
+    translations.add(Translation.ofLanguage(locale, "FORM_NAME", translatedValue));
     manager.updateTranslations(programStageSection, translations);
     assertEquals(translatedValue, programStageSection.getDisplayFormName());
   }
@@ -155,7 +155,7 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     manager.save(programStage);
     String translatedValue = "ProgramStage FormName Translated";
     Set<Translation> translations = new HashSet<>(programStage.getTranslations());
-    translations.add(new Translation(locale.language(), "FORM_NAME", translatedValue));
+    translations.add(Translation.ofLanguage(locale, "FORM_NAME", translatedValue));
     manager.updateTranslations(programStage, translations);
     assertEquals(translatedValue, programStage.getDisplayFormName());
   }
@@ -169,7 +169,7 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     manager.save(programSection);
     String translatedValue = "ProgramSection FormName Translated";
     Set<Translation> translations = new HashSet<>(programSection.getTranslations());
-    translations.add(new Translation(locale.language(), "FORM_NAME", translatedValue));
+    translations.add(Translation.ofLanguage(locale, "FORM_NAME", translatedValue));
     manager.updateTranslations(programSection, translations);
     assertEquals(translatedValue, programSection.getDisplayFormName());
   }
@@ -184,9 +184,9 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     String toFromNameTranslated = "To from name translated";
     Set<Translation> translations = new HashSet<>();
     translations.add(
-        new Translation(locale.language(), "RELATIONSHIP_TO_FROM_NAME", toFromNameTranslated));
+        Translation.ofLanguage(locale, "RELATIONSHIP_TO_FROM_NAME", toFromNameTranslated));
     translations.add(
-        new Translation(locale.language(), "RELATIONSHIP_FROM_TO_NAME", fromToNameTranslated));
+        Translation.ofLanguage(locale, "RELATIONSHIP_FROM_TO_NAME", fromToNameTranslated));
     manager.updateTranslations(relationshipType, translations);
     assertEquals(fromToNameTranslated, relationshipType.getDisplayFromToName());
     assertEquals(toFromNameTranslated, relationshipType.getDisplayToFromName());
@@ -208,15 +208,15 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     manager.save(evA);
     Set<Translation> translations = new HashSet<>();
     translations.add(
-        new Translation(locale.language(), "baseLineLabel", "translated BaseLineLabel"));
+        Translation.ofLanguage(locale, "baseLineLabel", "translated BaseLineLabel"));
     translations.add(
-        new Translation(locale.language(), "domainAxisLabel", "translated DomainAxisLabel"));
+        Translation.ofLanguage(locale, "domainAxisLabel", "translated DomainAxisLabel"));
     translations.add(
-        new Translation(locale.language(), "rangeAxisLabel", "translated RangeAxisLabel"));
+        Translation.ofLanguage(locale, "rangeAxisLabel", "translated RangeAxisLabel"));
     translations.add(
-        new Translation(locale.language(), "targetLineLabel", "translated TargetLineLabel"));
-    translations.add(new Translation(locale.language(), "title", "translated Title"));
-    translations.add(new Translation(locale.language(), "subtitle", "translated SubTitle"));
+        Translation.ofLanguage(locale, "targetLineLabel", "translated TargetLineLabel"));
+    translations.add(Translation.ofLanguage(locale, "title", "translated Title"));
+    translations.add(Translation.ofLanguage(locale, "subtitle", "translated SubTitle"));
     manager.updateTranslations(evA, translations);
     EventVisualization updated = manager.get(EventVisualization.class, evA.getUid());
     assertEquals("translated BaseLineLabel", updated.getDisplayBaseLineLabel());
@@ -239,15 +239,15 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     manager.save(visualization);
     Set<Translation> translations = new HashSet<>();
     translations.add(
-        new Translation(locale.language(), "baseLineLabel", "translated BaseLineLabel"));
+        Translation.ofLanguage(locale, "baseLineLabel", "translated BaseLineLabel"));
     translations.add(
-        new Translation(locale.language(), "domainAxisLabel", "translated DomainAxisLabel"));
+        Translation.ofLanguage(locale, "domainAxisLabel", "translated DomainAxisLabel"));
     translations.add(
-        new Translation(locale.language(), "rangeAxisLabel", "translated RangeAxisLabel"));
+        Translation.ofLanguage(locale, "rangeAxisLabel", "translated RangeAxisLabel"));
     translations.add(
-        new Translation(locale.language(), "targetLineLabel", "translated TargetLineLabel"));
-    translations.add(new Translation(locale.language(), "title", "translated Title"));
-    translations.add(new Translation(locale.language(), "subtitle", "translated SubTitle"));
+        Translation.ofLanguage(locale, "targetLineLabel", "translated TargetLineLabel"));
+    translations.add(Translation.ofLanguage(locale, "title", "translated Title"));
+    translations.add(Translation.ofLanguage(locale, "subtitle", "translated SubTitle"));
     manager.updateTranslations(visualization, translations);
     Visualization updated = manager.get(Visualization.class, visualization.getUid());
     assertNotNull(updated);
@@ -269,7 +269,7 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
     map.setMapService(MapService.TMS);
     manager.save(map);
     Set<Translation> translations = new HashSet<>();
-    translations.add(new Translation(locale.language(), "NAME", "translated Name"));
+    translations.add(Translation.ofLanguage(locale, "NAME", "translated Name"));
     manager.updateTranslations(map, translations);
     ExternalMapLayer updatedMap = manager.get(ExternalMapLayer.class, map.getUid());
     assertEquals("translated Name", updatedMap.getDisplayName());
@@ -286,11 +286,11 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
             Calendar.getInstance().getTime());
     manager.save(template);
     Set<Translation> translations = new HashSet<>();
-    translations.add(new Translation(locale.language(), "NAME", "translated Name"));
+    translations.add(Translation.ofLanguage(locale, "NAME", "translated Name"));
     translations.add(
-        new Translation(locale.language(), "SUBJECT_TEMPLATE", "translated SUBJECT TEMPLATE"));
+        Translation.ofLanguage(locale, "SUBJECT_TEMPLATE", "translated SUBJECT TEMPLATE"));
     translations.add(
-        new Translation(locale.language(), "MESSAGE_TEMPLATE", "translated MESSAGE TEMPLATE"));
+        Translation.ofLanguage(locale, "MESSAGE_TEMPLATE", "translated MESSAGE TEMPLATE"));
     manager.updateTranslations(template, translations);
     template = manager.get(ProgramNotificationTemplate.class, template.getUid());
     assertEquals("translated Name", template.getDisplayName());
@@ -315,12 +315,12 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
             "AVG(#{" + dataElementA.getUid() + "})+1.5*STDDEV(#{" + dataElementA.getUid() + "})",
             "descriptionA");
     expressionA.setTranslations(
-        Set.of(new Translation(locale.language(), "DESCRIPTION", "translated descriptionA")));
+        Set.of(Translation.ofLanguage(locale, "DESCRIPTION", "translated descriptionA")));
     Expression expressionB =
         new Expression(
             "AVG(#{" + dataElementB.getUid() + "." + defaultCombo.getUid() + "})", "descriptionB");
     expressionB.setTranslations(
-        Set.of(new Translation(locale.language(), "DESCRIPTION", "translated descriptionB")));
+        Set.of(Translation.ofLanguage(locale, "DESCRIPTION", "translated descriptionB")));
     Predictor predictor =
         createPredictor(
             dataElementX,
@@ -335,7 +335,7 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
             0);
     manager.save(predictor);
     manager.updateTranslations(
-        predictor, Set.of(new Translation(locale.language(), "NAME", "translated Predictor Name")));
+        predictor, Set.of(Translation.ofLanguage(locale, "NAME", "translated Predictor Name")));
     predictor = manager.get(Predictor.class, predictor.getUid());
     assertEquals("translated Predictor Name", predictor.getDisplayName());
     assertEquals("translated descriptionA", predictor.getGenerator().getDisplayDescription());
@@ -358,7 +358,7 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
 
     String translatedText = "Translated Dashboard Item";
     Set<Translation> translations = new HashSet<>();
-    translations.add(new Translation(locale.language(), "TEXT", translatedText));
+    translations.add(Translation.ofLanguage(locale, "TEXT", translatedText));
     manager.updateTranslations(dashboardItem, translations);
     dashboardItem = manager.get(DashboardItem.class, dashboardItem.getUid());
     assertEquals(translatedText, dashboardItem.getDisplayText());
@@ -373,7 +373,7 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
 
     String translatedText = "Translated Dashboard Item";
     Set<Translation> translations = new HashSet<>();
-    translations.add(new Translation(locale.language(), "text", translatedText));
+    translations.add(Translation.ofLanguage(locale, "text", translatedText));
     manager.updateTranslations(dashboardItem, translations);
     dashboardItem = manager.get(DashboardItem.class, dashboardItem.getUid());
     assertEquals(translatedText, dashboardItem.getDisplayText());
@@ -386,7 +386,7 @@ class TranslationServiceTest extends PostgresIntegrationTestBase {
 
     String translatedText = "Translated CategoryCombo";
     Set<Translation> translations = new HashSet<>();
-    translations.add(new Translation(locale.language(), "NAME", translatedText));
+    translations.add(Translation.ofLanguage(locale, "NAME", translatedText));
     manager.updateTranslations(categoryCombo, translations);
     categoryCombo = manager.get(CategoryCombo.class, categoryCombo.getUid());
     assertEquals(translatedText, categoryCombo.getDisplayName());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
@@ -1674,8 +1674,7 @@ class ValidationServiceTest extends PostgresIntegrationTestBase {
     validationRuleService.saveValidationRule(rule);
     String instructionTranslated = "Validation rule instruction translated";
     Set<Translation> listObjectTranslation = new HashSet<>(rule.getTranslations());
-    listObjectTranslation.add(
-        Translation.ofLanguage(locale, "INSTRUCTION", instructionTranslated));
+    listObjectTranslation.add(Translation.ofLanguage(locale, "INSTRUCTION", instructionTranslated));
     identifiableObjectManager.updateTranslations(rule, listObjectTranslation);
     assertEquals(instructionTranslated, rule.getDisplayInstruction());
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
@@ -1675,7 +1675,7 @@ class ValidationServiceTest extends PostgresIntegrationTestBase {
     String instructionTranslated = "Validation rule instruction translated";
     Set<Translation> listObjectTranslation = new HashSet<>(rule.getTranslations());
     listObjectTranslation.add(
-        new Translation(locale.language(), "INSTRUCTION", instructionTranslated));
+        Translation.ofLanguage(locale, "INSTRUCTION", instructionTranslated));
     identifiableObjectManager.updateTranslations(rule, listObjectTranslation);
     assertEquals(instructionTranslated, rule.getDisplayInstruction());
   }


### PR DESCRIPTION
Uses `Locale` in `Translation` and escalates the type to directly affected code only. 

This cleanup was extracted from #24522 to make that change smaller.

I noticed that `getTranslationValue` that is duplicated multiple times did use `equalsIgnoreCase` in one of the copies and `equals` in other and decided to make that consistent again using `equalsIgnoreCase` to be more lenient when comparing translation keys. 