### PR TITLE
fix: Fix notification when sms/email is not set [DHIS2-21836]

### DIFF
--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/message/DefaultProgramMessageService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/message/DefaultProgramMessageService.java
@@ -34,10 +34,11 @@ import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUsername;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.DeliveryChannel;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -60,6 +61,7 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * @author Zubair <rajazubair.asghar@gmail.com>
  */
+@Slf4j
 @RequiredArgsConstructor
 @Service("org.hisp.dhis.tracker.program.message.ProgramMessageService")
 public class DefaultProgramMessageService implements ProgramMessageService {
@@ -248,12 +250,22 @@ public class DefaultProgramMessageService implements ProgramMessageService {
   }
 
   private ProgramMessage setAttributesBasedOnStrategy(ProgramMessage message) {
-    Set<DeliveryChannel> channels = message.getDeliveryChannels();
-
-    for (DeliveryChannel channel : channels) {
+    // Iterate over a copy: a channel the resolved recipient cannot receive on (e.g. an org unit
+    // contact with an email but no phone number) is dropped from the message so that the remaining
+    // deliverable channels are still sent, instead of aborting the whole send.
+    for (DeliveryChannel channel : new HashSet<>(message.getDeliveryChannels())) {
       for (DeliveryChannelStrategy strategy : strategies) {
         if (strategy.getDeliveryChannel().equals(channel)) {
-          strategy.setAttributes(message);
+          try {
+            strategy.setAttributes(message);
+          } catch (IllegalQueryException ex) {
+            log.warn(
+                "Skipping delivery channel {} for program message {}: {}",
+                channel,
+                message.getUid(),
+                ex.getMessage());
+            message.getDeliveryChannels().remove(channel);
+          }
         }
       }
     }

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/program/message/DefaultProgramMessageServiceTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/program/message/DefaultProgramMessageServiceTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.program.message;
+
+import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.common.DeliveryChannel;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.outboundmessage.OutboundMessageBatch;
+import org.hisp.dhis.outboundmessage.OutboundMessageBatchService;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.tracker.audit.TrackedEntityAuditService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link DefaultProgramMessageService#sendMessages(List)}, focusing on how delivery
+ * channels are resolved against the recipient's available contact details.
+ */
+@ExtendWith(MockitoExtension.class)
+class DefaultProgramMessageServiceTest {
+
+  private static final String OU_UID = "OrgUnitUid1";
+
+  private static final String OU_EMAIL = "orgunit@test.org";
+
+  private static final String OU_PHONE = "4712345678";
+
+  @Mock private IdentifiableObjectManager manager;
+
+  @Mock private ProgramMessageStore programMessageStore;
+
+  @Mock private OrganisationUnitService organisationUnitService;
+
+  @Mock private OutboundMessageBatchService messageBatchService;
+
+  @Mock private AclService aclService;
+
+  @Mock private ProgramMessageOperationParamMapper operationParamMapper;
+
+  @Mock private TrackedEntityAuditService trackedEntityAuditService;
+
+  @Captor private ArgumentCaptor<List<OutboundMessageBatch>> batchCaptor;
+
+  private DefaultProgramMessageService service;
+
+  @BeforeEach
+  void setUp() {
+    EmailDeliveryChannelStrategy emailStrategy = new EmailDeliveryChannelStrategy();
+    emailStrategy.organisationUnitService = organisationUnitService;
+    SmsDeliveryChannelStrategy smsStrategy = new SmsDeliveryChannelStrategy();
+    smsStrategy.organisationUnitService = organisationUnitService;
+
+    service =
+        new DefaultProgramMessageService(
+            manager,
+            programMessageStore,
+            organisationUnitService,
+            messageBatchService,
+            List.of(emailStrategy, smsStrategy),
+            List.of(new SmsMessageBatchCreatorService(), new EmailMessageBatchCreatorService()),
+            aclService,
+            operationParamMapper,
+            trackedEntityAuditService);
+  }
+
+  @Test
+  void shouldSendEmailAndDropSmsWhenOrgUnitContactHasEmailButNoPhoneNumber() {
+    OrganisationUnit orgUnit = orgUnitContact(OU_EMAIL, null);
+    ProgramMessage message =
+        orgUnitContactMessage(orgUnit, DeliveryChannel.SMS, DeliveryChannel.EMAIL);
+
+    when(organisationUnitService.getOrganisationUnit(OU_UID)).thenReturn(orgUnit);
+    when(messageBatchService.sendBatches(anyList())).thenReturn(List.of());
+
+    service.sendMessages(new ArrayList<>(List.of(message)));
+
+    // SMS is unreachable and must be dropped, leaving only the deliverable EMAIL channel.
+    assertContainsOnly(Set.of(DeliveryChannel.EMAIL), message.getDeliveryChannels());
+
+    verify(messageBatchService).sendBatches(batchCaptor.capture());
+    List<OutboundMessageBatch> batches = batchCaptor.getValue();
+    assertEquals(1, batches.size(), "only the EMAIL batch should be sent");
+    OutboundMessageBatch emailBatch = batches.get(0);
+    assertEquals(DeliveryChannel.EMAIL, emailBatch.getDeliveryChannel());
+    assertEquals(1, emailBatch.getMessages().size());
+    assertContainsOnly(Set.of(OU_EMAIL), emailBatch.getMessages().get(0).getRecipients());
+  }
+
+  @Test
+  void shouldSendBothChannelsWhenOrgUnitContactHasEmailAndPhoneNumber() {
+    OrganisationUnit orgUnit = orgUnitContact(OU_EMAIL, OU_PHONE);
+    ProgramMessage message =
+        orgUnitContactMessage(orgUnit, DeliveryChannel.SMS, DeliveryChannel.EMAIL);
+
+    when(organisationUnitService.getOrganisationUnit(OU_UID)).thenReturn(orgUnit);
+    when(messageBatchService.sendBatches(anyList())).thenReturn(List.of());
+
+    service.sendMessages(new ArrayList<>(List.of(message)));
+
+    assertContainsOnly(
+        Set.of(DeliveryChannel.SMS, DeliveryChannel.EMAIL), message.getDeliveryChannels());
+
+    verify(messageBatchService).sendBatches(batchCaptor.capture());
+    List<OutboundMessageBatch> batches = batchCaptor.getValue();
+    assertEquals(2, batches.size(), "both the SMS and EMAIL batches should be sent");
+  }
+
+  private static OrganisationUnit orgUnitContact(String email, String phoneNumber) {
+    OrganisationUnit orgUnit = new OrganisationUnit("Contact");
+    orgUnit.setUid(OU_UID);
+    orgUnit.setEmail(email);
+    orgUnit.setPhoneNumber(phoneNumber);
+    return orgUnit;
+  }
+
+  private static ProgramMessage orgUnitContactMessage(
+      OrganisationUnit orgUnit, DeliveryChannel... channels) {
+    ProgramMessageRecipients recipients = new ProgramMessageRecipients();
+    recipients.setOrganisationUnit(orgUnit);
+
+    ProgramMessage message = new ProgramMessage();
+    message.setSubject("subject");
+    message.setText("text");
+    message.setRecipients(recipients);
+    message.setDeliveryChannels(new HashSet<>(Set.of(channels)));
+    return message;
+  }
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                    
                                                                                                                                                                                                
  Fixes program notifications to `ORGANISATION_UNIT_CONTACT` recipients silently sending nothing when the template targets multiple delivery channels (SMS + EMAIL) but the org unit is missing 
  a contact detail for one of them. Previously, an org unit with an email but no phone number caused the SMS resolution to throw and abort the whole send, so the email was never delivered     
  either. Each deliverable channel is now sent independently. [DHIS2-21836]                                                                                                                     
                                                                                                                                                                                                
  ## Changes                                                                                                                                                                                    
                                                                                                                                                                                                
  - `DefaultProgramMessageService.setAttributesBasedOnStrategy`: resolve each delivery channel independently. When a channel's `DeliveryChannelStrategy` throws `IllegalQueryException` because the resolved recipient has no contact detail for that channel (e.g. an org-unit contact with an email but no phone number), that channel is now logged and dropped from the message instead of propagating the exception out of the `sendMessages` stream and aborting the entire send. Iteration runs over a copy of the channel set so the live set can be mutated safely; batch creators filter by channel membership, so a dropped channel simply produces no outbound message. 
  - Annotates the class with `@Slf4j` to emit a warning identifying the skipped channel, message, and reason.                                                                                   
  - Adds `DefaultProgramMessageServiceTest` covering the two cases: email is sent and SMS is dropped when the org-unit contact has an email but no phone number; both channels are sent when    
  both contact details are present.                                                                                                                                                             
                                                                                                                                                                                                
  Notes for reviewers:                                                                                                                                                                          
  - The `DeliveryChannelStrategy` contract is unchanged — strategies still throw when a channel cannot be resolved; the "skip this channel, keep the rest" decision is centralized in the caller.                                                                                                                                                                                       
  - This also covers the analogous `TRACKED_ENTITY_INSTANCE` recipient case (tracked entity with only one of email/phone), which hit the same abort.
  - The `ProgramMessageController` POST path previously returned a 400 in this situation; it now drops the undeliverable channel and sends the rest — strictly more lenient, no regression.

[DHIS2-21836]: https://dhis2.atlassian.net/browse/DHIS2-21836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ