### PR TITLE
fix: enforce not-null on map created/lastupdated [DHIS2-21917]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_20__map_created_lastupdated_not_null.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_20__map_created_lastupdated_not_null.sql
@@ -1,0 +1,12 @@
+-- Backfill any existing rows with missing audit timestamps
+UPDATE map SET lastupdated = now() WHERE lastupdated IS NULL;
+UPDATE map SET created = now() WHERE created IS NULL;
+
+-- Enforce the invariant the application already assumes (BaseIdentifiableObject's
+-- Hibernate mapping declares both not-null="true"), and default to now() for any
+-- writer that omits these columns, mirroring setAutoFields() semantics.
+ALTER TABLE map
+    ALTER COLUMN created SET DEFAULT now(),
+    ALTER COLUMN lastupdated SET DEFAULT now(),
+    ALTER COLUMN created SET NOT NULL,
+    ALTER COLUMN lastupdated SET NOT NULL;


### PR DESCRIPTION
## Summary
- The `map` table's `created`/`lastupdated` columns allowed NULL at the DB level despite `BaseIdentifiableObject`'s Hibernate mapping (`identifiableProperties.hbm`) declaring both `not-null="true"`.
- Every application code path (REST API create/update, metadata import via `ObjectBundleService`/`IdentifiableObjectBundleHook`) already calls `setAutoFields()` before persisting, so the DB never actually enforced an invariant the app already assumes.
- A small number of rows in a production instance ended up with NULL `created`/`lastupdated`, almost certainly from an out-of-band write that bypassed Hibernate (raw SQL, restored/merged dump, etc). The Maps app frontend has no guard against this and crashes (`RangeError: Invalid time value`) when rendering the affected row's date, taking down the entire "Open a map" list.
- `V2_44_20__map_created_lastupdated_not_null.sql` backfills any existing NULLs to `now()`, then adds `DEFAULT now()` and `NOT NULL` on both columns — same pattern as the existing `V2_43_6__data_value_defaults.sql` fix for `datavalue`.

## Test plan
- [x] Verified locally against the `sl` database inside a rolled-back transaction: inserted a row with NULL `created`/`lastupdated`, ran the migration, confirmed backfill to `now()`, `NOT NULL` enforcement (a follow-up NULL insert correctly failed), and `DEFAULT now()` via `information_schema.columns`.
- [ ] CI migration/integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)