### PR TITLE
feat: Apply sharing at attribute level [DHIS2-18467]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
@@ -169,6 +169,11 @@ public class DefaultTrackedEntityAttributeService implements TrackedEntityAttrib
                   .collect(toList())));
     }
 
+    // Attribute-level restriction: on top of the parent program/type data-read gating above, honor
+    // each attribute's own metadata sharing. canRead (not canDataRead) is used because a
+    // TrackedEntityAttribute is metadata-shareable only; canDataRead is always false for it.
+    attributes.removeIf(attribute -> !aclService.canRead(userDetails, attribute));
+
     return attributes;
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -395,6 +395,24 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void shouldNotReturnAttributeValueWhenUserCannotReadAttribute() throws NotFoundException {
+    // Remove metadata read access to the attribute for the current user. The enrollment is still
+    // accessible, but its attribute value must not be returned.
+    trackedEntityAttributeA.getSharing().setOwner(admin);
+    trackedEntityAttributeA.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
+    manager.updateNoAcl(trackedEntityAttributeA);
+    manager.flush();
+    manager.clear();
+
+    EnrollmentFields fields = EnrollmentFields.builder().includeAttributes().build();
+
+    Enrollment enrollment = enrollmentService.getEnrollment(UID.of(enrollmentA), fields);
+
+    assertNotNull(enrollment);
+    assertTrue(attributeUids(enrollment).isEmpty());
+  }
+
+  @Test
   void shouldFailGettingEnrollmentWhenUserHasNoAccessToProgramsTrackedEntityType() {
     trackedEntityTypeA.getSharing().setOwner(admin);
     trackedEntityTypeA.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityChangeLogServiceTest.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.tracker.export.trackedentity;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -42,7 +43,9 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.Page;
 import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.TestSetup;
@@ -288,6 +291,36 @@ class TrackedEntityChangeLogServiceTest extends PostgresIntegrationTestBase {
                 "updated program attribute value",
                 changeLogs.getItems().get(0)),
         () -> assertCreate(programAttribute, "Frank PTEA", changeLogs.getItems().get(1)));
+  }
+
+  @Test
+  void shouldNotReturnChangeLogsForAttributeWhenUserCannotReadAttribute()
+      throws NotFoundException, ForbiddenException, BadRequestException {
+    String trackedEntity = "QS6w44flWAf";
+    String integerAttr = "integerAttr";
+
+    // Remove metadata read access to the integer attribute. The import user is a superuser and
+    // bypasses attribute sharing, so query as a regular user who can access the tracked entity
+    // (matching org unit and publicly data-readable type) but is not allowed to read that
+    // attribute.
+    TrackedEntityAttribute attribute = manager.get(TrackedEntityAttribute.class, integerAttr);
+    attribute.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
+    manager.updateNoAcl(attribute);
+    manager.flush();
+    manager.clear();
+
+    injectSecurityContextUser(manager.get(User.class, "Z7870757a75"));
+
+    Page<TrackedEntityChangeLog> changeLogs =
+        trackedEntityChangeLogService.getTrackedEntityChangeLog(
+            UID.of(trackedEntity), null, defaultOperationParams, defaultPageParams);
+
+    // The restricted attribute is filtered out, while change logs of other readable attributes of
+    // the same tracked entity are still returned.
+    assertNumberOfChanges(0, filterTrackedEntityAttribute(changeLogs, integerAttr));
+    assertFalse(
+        changeLogs.getItems().isEmpty(),
+        "expected change logs of other readable attributes to be returned");
   }
 
   private static void assertNumberOfChanges(int expected, List<TrackedEntityChangeLog> changeLogs) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -798,6 +798,30 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void shouldReturnOnlyReadableAttributesWhenUserCannotReadSomeAttributes()
+      throws ForbiddenException, NotFoundException, BadRequestException {
+    // Remove metadata read access to attribute C for the current user; A and B stay readable. The
+    // export must return only the attribute values the user is allowed to read.
+    injectSecurityContextUser(superuser);
+    teaC.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
+    manager.updateNoAcl(teaC);
+    injectSecurityContextUser(user);
+
+    TrackedEntityOperationParams operationParams =
+        TrackedEntityOperationParams.builder()
+            .organisationUnits(orgUnitA)
+            .orgUnitMode(SELECTED)
+            .program(programA)
+            .fields(TrackedEntityFields.builder().includeAttributes().build())
+            .build();
+
+    List<TrackedEntity> trackedEntities = trackedEntityService.findTrackedEntities(operationParams);
+
+    assertContainsOnly(
+        Set.of("A", "B"), attributeNames(trackedEntities.get(0).getTrackedEntityAttributeValues()));
+  }
+
+  @Test
   void shouldReturnEnrollmentsFromSpecifiedProgramWhenRequestingSingleTrackedEntity()
       throws ForbiddenException, NotFoundException {
     Enrollment enrollmentProgramB = createEnrollment(programB, trackedEntityA, orgUnitA);

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -32,11 +32,10 @@ package org.hisp.dhis.tracker.export.trackedentity;
 import static org.hisp.dhis.audit.AuditOperationType.SEARCH;
 import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
+import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -298,27 +297,29 @@ class DefaultTrackedEntityService implements TrackedEntityService {
    * readable attribute UIDs from the metadata (which honors both the parent program/type data-read
    * access and each attribute's own metadata sharing) and filter the values by UID.
    *
-   * <p>The program scope is constant across the result set, but the tracked entity type can differ
-   * per tracked entity, so the readable set is resolved and cached per type.
+   * <p>The program scope is taken from the query and is the same for all results, while the tracked
+   * entity type can differ per tracked entity. The readable set is therefore resolved once for all
+   * types present in the result and applied to every tracked entity; this is safe because the store
+   * only attaches attribute values belonging to a tracked entity's own type (and the queried
+   * program).
    */
   private void filterReadableAttributeValues(
       List<TrackedEntity> trackedEntities, TrackedEntityQueryParams queryParams) {
     Program program = queryParams.getEnrolledInTrackerProgram();
     List<Program> programs = program != null ? List.of(program) : List.of();
+    Set<TrackedEntityType> trackedEntityTypes =
+        trackedEntities.stream()
+            .map(TrackedEntity::getTrackedEntityType)
+            .collect(Collectors.toSet());
 
-    Map<TrackedEntityType, Set<String>> readableAttributesByType = new HashMap<>();
+    Set<String> readableAttributes =
+        trackedEntityAttributeService
+            .getAllUserReadableTrackedEntityAttributes(
+                programs, new ArrayList<>(trackedEntityTypes))
+            .stream()
+            .map(BaseIdentifiableObject::getUid)
+            .collect(Collectors.toSet());
     for (TrackedEntity trackedEntity : trackedEntities) {
-      Set<String> readableAttributes =
-          readableAttributesByType.computeIfAbsent(
-              trackedEntity.getTrackedEntityType(),
-              trackedEntityType ->
-                  trackedEntityAttributeService
-                      .getAllUserReadableTrackedEntityAttributes(
-                          programs, List.of(trackedEntityType))
-                      .stream()
-                      .map(BaseIdentifiableObject::getUid)
-                      .collect(Collectors.toSet()));
-
       Set<TrackedEntityAttributeValue> filtered =
           trackedEntity.getTrackedEntityAttributeValues().stream()
               .filter(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -33,13 +33,17 @@ import static org.hisp.dhis.audit.AuditOperationType.SEARCH;
 import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IndirectTransactional;
 import org.hisp.dhis.common.NonTransactional;
 import org.hisp.dhis.common.UID;
@@ -51,6 +55,8 @@ import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.fileresource.ImageFileDimension;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.Page;
 import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.TrackerType;
@@ -84,6 +90,8 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   private final OperationsParamsValidator operationsParamsValidator;
 
   private final TrackedEntityOperationParamsMapper mapper;
+
+  private final TrackedEntityAttributeService trackedEntityAttributeService;
 
   @Override
   @IndirectTransactional
@@ -276,9 +284,49 @@ class DefaultTrackedEntityService implements TrackedEntityService {
                 trackedEntity, queryParams.getEnrolledInTrackerProgram()));
       }
     }
+    if (operationParams.getFields().isIncludesAttributes()) {
+      filterReadableAttributeValues(trackedEntities, queryParams);
+    }
     trackedEntityAuditService.addTrackedEntityAudit(SEARCH, user.getUsername(), trackedEntities);
 
     return trackedEntities;
+  }
+
+  /**
+   * Removes attribute values the user is not allowed to read. The attribute objects carried by the
+   * exported values are lightweight and hold no sharing information, so we resolve the set of
+   * readable attribute UIDs from the metadata (which honors both the parent program/type data-read
+   * access and each attribute's own metadata sharing) and filter the values by UID.
+   *
+   * <p>The program scope is constant across the result set, but the tracked entity type can differ
+   * per tracked entity, so the readable set is resolved and cached per type.
+   */
+  private void filterReadableAttributeValues(
+      List<TrackedEntity> trackedEntities, TrackedEntityQueryParams queryParams) {
+    Program program = queryParams.getEnrolledInTrackerProgram();
+    List<Program> programs = program != null ? List.of(program) : List.of();
+
+    Map<TrackedEntityType, Set<String>> readableAttributesByType = new HashMap<>();
+    for (TrackedEntity trackedEntity : trackedEntities) {
+      Set<String> readableAttributes =
+          readableAttributesByType.computeIfAbsent(
+              trackedEntity.getTrackedEntityType(),
+              trackedEntityType ->
+                  trackedEntityAttributeService
+                      .getAllUserReadableTrackedEntityAttributes(
+                          programs, List.of(trackedEntityType))
+                      .stream()
+                      .map(BaseIdentifiableObject::getUid)
+                      .collect(Collectors.toSet()));
+
+      Set<TrackedEntityAttributeValue> filtered =
+          trackedEntity.getTrackedEntityAttributeValues().stream()
+              .filter(
+                  attributeValue ->
+                      readableAttributes.contains(attributeValue.getAttribute().getUid()))
+              .collect(Collectors.toCollection(LinkedHashSet::new));
+      trackedEntity.setTrackedEntityAttributeValues(filtered);
+    }
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityChangeLogStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityChangeLogStore.java
@@ -99,6 +99,13 @@ public class HibernateTrackedEntityChangeLogStore {
       throw new UnsupportedOperationException("pageTotal is not supported");
     }
 
+    // The caller passes the set of attributes the user is allowed to read. An empty set means the
+    // user cannot read any attribute of this tracked entity, so no change logs must be returned.
+    // Applying no filter here would leak every change log, hence the explicit short-circuit.
+    if (attributes.isEmpty()) {
+      return new Page<>(List.of(), pageParams);
+    }
+
     String hql =
         """
         select \
@@ -134,12 +141,10 @@ public class HibernateTrackedEntityChangeLogStore {
           """;
     }
 
-    if (!attributes.isEmpty()) {
-      hql +=
-          """
-          and tea.uid in (:attributes) \
-          """;
-    }
+    hql +=
+        """
+        and tea.uid in (:attributes) \
+        """;
 
     Pair<String, QueryFilter> filter = operationParams.getFilter();
     if (filter != null) {
@@ -162,10 +167,8 @@ public class HibernateTrackedEntityChangeLogStore {
       query.setParameter("program", program.getValue());
     }
 
-    if (!attributes.isEmpty()) {
-      query.setParameter(
-          "attributes", attributes.stream().map(UID::getValue).collect(Collectors.toSet()));
-    }
+    query.setParameter(
+        "attributes", attributes.stream().map(UID::getValue).collect(Collectors.toSet()));
 
     query.setFirstResult(pageParams.getOffset());
     query.setMaxResults(


### PR DESCRIPTION
## Summary

Applies metadata sharing at the individual tracked entity attribute level across the tracker export paths [DHIS2-18467]. Previously, attribute values were gated only by the parent program/type data-read access; now each attribute's own metadata sharing is also honored, so a user who can access a tracked entity or enrollment but is not allowed to read a specific attribute no longer sees that attribute's value (or its change logs).

## Changes

- **Attribute readability gating** (`DefaultTrackedEntityAttributeService`): on top of the
  existing program/type data-read filtering, the readable-attributes resolution now removes any attribute the user cannot read via `aclService.canRead`. `canRead` (not `canDataRead`) is used because a `TrackedEntityAttribute` is metadata-shareable only.
- **Tracked entity export** (`DefaultTrackedEntityService`): `findTrackedEntities` now filters each returned tracked entity's attribute values down to the set of readable attribute UIDs when attributes are requested. The exported attribute objects are lightweight and carry no sharing info, so the readable set is resolved once from the metadata for the queried program and the tracked-entity types present in the result, then applied by UID.
- **Change log export** (`HibernateTrackedEntityChangeLogStore`): the attribute filter is now always applied, and an empty readable-attribute set short-circuits to an empty page. This prevents a user with no readable attributes from leaking every change log of a tracked entity.
- **Tests**: added integration coverage in `TrackedEntityServiceTest`, `EnrollmentServiceTest`, and `TrackedEntityChangeLogServiceTest` verifying that restricted attributes (and their change logs) are filtered out while other readable attributes of the same tracked entity are still returned.

## Performance

Attribute-level ACL filtering adds work on the export paths, so both a load test and the smoke
suite were run to confirm there is no regression.

### Load test

Compared against `master` baseline (3 baseline runs vs 3 candidate runs). Load-test runs:
- https://github.com/dhis2/dhis2-core/actions/runs/30624054967
- https://github.com/dhis2/dhis2-core/actions/runs/30624052370
- https://github.com/dhis2/dhis2-core/actions/runs/30624049739

#### 95th Percentile Response Time (p95) (ms)

| Requests | baseline | req/s | candidate | req/s | Diff (ms) | Change |
|:---|---:|---:|---:|---:|---:|:---|
| Get ANC events / Get one event / Get first event | 69 | 0.22 | 72 | 0.22 | +3 | :arrow_up: +4.8% |
| Get ANC events / Get one event / Get relationships for first event | 6 | 0.22 | 6 | 0.22 | +0 | +0.0% |
| Get ANC events / Go to first page | 87 | 0.22 | 92 | 0.23 | +5 | :arrow_up: +5.7% |
| Get ANC events / Go to second page | 96 | 0.22 | 94 | 0.23 | -2 | :arrow_down: -2.1% |
| Get ANC events / Search not assigned | 93 | 0.22 | 94 | 0.22 | +1 | :arrow_up: +1.1% |
| Get ANC events / Search by date range | 412 | 0.22 | 412 | 0.22 | -0 | :arrow_down: -0.1% |
| Get Child Programme TEs / Go to single enrollment / Get one event / Get first event from enrollment | 74 | 0.10 | 74 | 0.11 | +0 | :arrow_up: +0.5% |
| Get Child Programme TEs / Go to single enrollment / Get one event / Get relationships for first event | 7 | 0.10 | 7 | 0.11 | +0 | :arrow_up: +2.9% |
| Get Child Programme TEs / Go to single enrollment / Get first tracked entity | 86 | 0.10 | 88 | 0.11 | +2 | :arrow_up: +2.1% |
| Get Child Programme TEs / Go to single enrollment / Get first enrollment | 26 | 0.10 | 25 | 0.11 | -1 | :arrow_down: -2.3% |
| Get Child Programme TEs / Go to single enrollment / Get relationships for first tracked entity | 7 | 0.10 | 7 | 0.11 | +0 | +0.0% |
| Get Child Programme TEs / Not found TE by name with like operator | 80 | 0.11 | 85 | 0.11 | +5 | :arrow_up: +6.1% |
| Get Child Programme TEs / Not found TE by name with eq operator | 15 | 0.11 | 19 | 0.11 | +4 | :arrow_up: +26.7% |
| Get Child Programme TEs / Search TE by name with like operator | 136 | 0.11 | 143 | 0.11 | +7 | :arrow_up: +5.1% |
| Get Child Programme TEs / Search TE by name with eq operator | 91 | 0.11 | 74 | 0.11 | -17 | :arrow_down: -18.7% |
| Get Child Programme TEs / Search Birth events | 126 | 0.11 | 115 | 0.11 | -11 | :arrow_down: -8.8% |
| Get Child Programme TEs / Get TEs from events | 11 | 0.11 | 12 | 0.11 | +1 | :arrow_up: +9.1% |
| Get Child Programme TEs / Get first page of TEs | 134 | 0.11 | 141 | 0.11 | +7 | :arrow_up: +5.2% |
| Get Child Programme TEs / Get TEs with enrollment status | 155 | 0.10 | 160 | 0.10 | +6 | :arrow_up: +3.5% |
| Login | 181 | 0.05 | 127 | 0.05 | -54 | :arrow_down: -29.9% |
| MNCH import | 646 | 0.14 | 638 | 0.14 | -8 | :arrow_down: -1.3% |
| Child Programme import | 204 | 0.14 | 195 | 0.14 | -9 | :arrow_down: -4.4% |
| ANC import | 668 | 0.14 | 675 | 0.14 | +6 | :arrow_up: +0.9% |

_:arrow_down: = faster, :arrow_up: = slower_

_Percentiles use the inclusive definition (e.g. p95 = X means 95% of requests responded in X ms or less) and are computed over OK + KO responses._

### Smoke test

Compared against `master` baseline (3 baseline runs vs 3 candidate runs). Smoke runs:
- https://github.com/dhis2/dhis2-core/actions/runs/30827403464
- https://github.com/dhis2/dhis2-core/actions/runs/30637014444
- https://github.com/dhis2/dhis2-core/actions/runs/30637010610

#### 95th Percentile Response Time (p95) (ms)

| Requests | baseline | req/s | candidate | req/s | Diff (ms) | Change |
|:---|---:|---:|---:|---:|---:|:---|
| Get ANC events / Get one event / Get first event | 32 | 2.81 | 17 | 3.00 | -15 | :arrow_down: -47.3% |
| Get ANC events / Get one event / Get relationships for first event | 7 | 2.81 | 5 | 3.00 | -2 | :arrow_down: -28.6% |
| Get ANC events / Go to first page | 21 | 2.81 | 14 | 3.00 | -7 | :arrow_down: -33.3% |
| Get ANC events / Go to second page | 24 | 2.81 | 15 | 3.00 | -9 | :arrow_down: -37.5% |
| Get ANC events / Search not assigned | 19 | 2.81 | 15 | 3.00 | -4 | :arrow_down: -21.1% |
| Get ANC events / Search by date range | 25 | 2.81 | 21 | 3.00 | -4 | :arrow_down: -15.8% |
| Get Child Programme TEs / Go to single enrollment / Get one event / Get first event from enrollment | 30 | 2.81 | 28 | 3.00 | -2 | :arrow_down: -6.7% |
| Get Child Programme TEs / Go to single enrollment / Get one event / Get relationships for first event | 6 | 2.81 | 5 | 3.00 | -1 | :arrow_down: -16.7% |
| Get Child Programme TEs / Go to single enrollment / Get first tracked entity | 25 | 2.81 | 22 | 3.00 | -3 | :arrow_down: -11.8% |
| Get Child Programme TEs / Go to single enrollment / Get first enrollment | 10 | 2.81 | 12 | 3.00 | +2 | :arrow_up: +20.9% |
| Get Child Programme TEs / Go to single enrollment / Get relationships for first tracked entity | 7 | 2.81 | 6 | 3.00 | -1 | :arrow_down: -14.3% |
| Get Child Programme TEs / Not found TE by name with like operator | 9 | 2.81 | 9 | 3.00 | +0 | +0.0% |
| Get Child Programme TEs / Not found TE by name with eq operator | 7 | 2.81 | 7 | 3.00 | +0 | +0.0% |
| Get Child Programme TEs / Search TE by name with like operator | 33 | 2.81 | 31 | 3.00 | -2 | :arrow_down: -6.2% |
| Get Child Programme TEs / Search TE by name with eq operator | 26 | 2.81 | 25 | 3.00 | -1 | :arrow_down: -3.8% |
| Get Child Programme TEs / Search Birth events | 26 | 2.81 | 30 | 3.00 | +4 | :arrow_up: +15.2% |
| Get Child Programme TEs / Get TEs from events | 9 | 2.81 | 10 | 3.00 | +1 | :arrow_up: +11.1% |
| Get Child Programme TEs / Get first page of TEs | 39 | 2.81 | 36 | 3.00 | -3 | :arrow_down: -7.7% |
| Get Child Programme TEs / Get TEs with enrollment status | 46 | 2.81 | 42 | 3.00 | -4 | :arrow_down: -8.7% |
| Login | 130 | 0.14 | 131 | 0.15 | +1 | :arrow_up: +0.6% |
| MNCH import | 197 | 0.28 | 95 | 0.30 | -102 | :arrow_down: -51.8% |
| Child Programme import | 122 | 0.28 | 81 | 0.30 | -40 | :arrow_down: -33.2% |
| ANC import | 53 | 0.28 | 47 | 0.30 | -7 | :arrow_down: -12.3% |

_:arrow_down: = faster, :arrow_up: = slower_

_Percentiles use the inclusive definition (e.g. p95 = X means 95% of requests responded in X ms or less) and are computed over OK + KO responses._

**Verdict:** Neutral. No measurable regression from the added attribute-level ACL filtering; all deltas are within run-to-run noise.


[DHIS2-18467]: https://dhis2.atlassian.net/browse/DHIS2-18467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ