### PR TITLE
fix: native SQL bulk-load teiSearchOrganisationUnits on user list [DHIS2-21907]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -898,6 +898,16 @@ public interface UserService {
    * @throws ForbiddenException if the current user lacks permission to manage any of the source
    *     user's groups
    */
+
+  /**
+   * Bulk-loads {@link User#getTeiSearchOrganisationUnits()} for the given users with one native SQL
+   * query (DHIS2-21907), replacing each user's lazy collection with a concrete set so field-filter
+   * serialization of {@code teiSearchOrganisationUnits[id,path]} does not N+1.
+   *
+   * <p>No-op when {@code users} is null or empty.
+   */
+  void loadTeiSearchOrganisationUnits(@Nonnull Collection<User> users);
+
   User replicateUser(User existingUser, String username, String password)
       throws ConflictException, NotFoundException, BadRequestException, ForbiddenException;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -339,5 +339,22 @@ public interface UserStore extends IdentifiableObjectStore<User> {
    * subsequent lookups by username reflect the new row rather than a stale cached result. Only the
    * username query region is evicted; all other query cache regions are left intact.
    */
+
+  /**
+   * Bulk-loads TEI-search organisation units for the given user primary keys in a single native
+   * SQL query (DHIS2-21907). Returns lightweight {@link OrganisationUnit} shells populated with
+   * {@code id}, {@code uid}, and {@code path} only — enough for field-filter
+   * {@code teiSearchOrganisationUnits[id,path]} without Hibernate collection selects.
+   *
+   * <p>Users with no TEI-search OUs are absent from the map (callers should treat missing keys as
+   * empty).
+   *
+   * @param userIds userinfo primary keys
+   * @return map of userinfoid → TEI-search organisation units
+   */
+  @Nonnull
+  Map<Long, Set<OrganisationUnit>> getTeiSearchOrganisationUnitsByUserIds(
+      @Nonnull Collection<Long> userIds);
+
   void clearUserQueryCache();
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -1558,6 +1558,27 @@ public class DefaultUserService implements UserService {
     userStore.setActiveLinkedAccounts(actingUser, activeUsername);
   }
 
+  
+  @Override
+  @Transactional(readOnly = true)
+  public void loadTeiSearchOrganisationUnits(@Nonnull Collection<User> users) {
+    if (users == null || users.isEmpty()) {
+      return;
+    }
+    List<Long> userIds =
+        users.stream().map(User::getId).filter(id -> id > 0).distinct().toList();
+    if (userIds.isEmpty()) {
+      return;
+    }
+    Map<Long, Set<OrganisationUnit>> byUser =
+        userStore.getTeiSearchOrganisationUnitsByUserIds(userIds);
+    for (User user : users) {
+      Set<OrganisationUnit> ous = byUser.getOrDefault(user.getId(), Set.of());
+      // Replace the lazy PersistentSet so field-filter getters do not hit the DB.
+      user.setTeiSearchOrganisationUnits(new HashSet<>(ous));
+    }
+  }
+
   @Override
   @Transactional
   public User replicateUser(User existingUser, String username, String password)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -45,6 +45,8 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -951,6 +953,39 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
           userUid.getValue());
     }
   }
+
+
+  @Override
+  @Nonnull
+  public Map<Long, Set<OrganisationUnit>> getTeiSearchOrganisationUnitsByUserIds(
+      @Nonnull Collection<Long> userIds) {
+    if (userIds.isEmpty()) {
+      return Map.of();
+    }
+    // One native query: only columns needed for teiSearchOrganisationUnits[id,path].
+    String placeholders = String.join(",", Collections.nCopies(userIds.size(), "?"));
+    String sql =
+        "SELECT t.userinfoid, o.organisationunitid, o.uid, o.path "
+            + "FROM userteisearchorgunits t "
+            + "INNER JOIN organisationunit o ON o.organisationunitid = t.organisationunitid "
+            + "WHERE t.userinfoid IN ("
+            + placeholders
+            + ")";
+    Map<Long, Set<OrganisationUnit>> result = new HashMap<>();
+    jdbcTemplate.query(
+        sql,
+        userIds.toArray(),
+        rs -> {
+          long userId = rs.getLong(1);
+          OrganisationUnit ou = new OrganisationUnit();
+          ou.setId(rs.getLong(2));
+          ou.setUid(rs.getString(3));
+          ou.setPath(rs.getString(4));
+          result.computeIfAbsent(userId, k -> new HashSet<>()).add(ou);
+        });
+    return result;
+  }
+
 
   @Override
   public void clearUserQueryCache() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserTeiSearchOrganisationUnitsQueryCountTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserTeiSearchOrganisationUnitsQueryCountTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.test.config.QueryCountDataSourceProxy;
+import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Regression for DHIS2-21907 (native-SQL variant): {@code GET /api/users} with
+ * {@code teiSearchOrganisationUnits} in the field filter must not select from
+ * {@code userteisearchorgunits} once per listed user. Native bulk load replaces the lazy
+ * collection before field-filter serialization.
+ *
+ * <p>Author: Morten (Morty)
+ */
+@Transactional
+@ContextConfiguration(classes = {QueryCountDataSourceProxy.class})
+class UserTeiSearchOrganisationUnitsQueryCountTest extends PostgresControllerIntegrationTestBase {
+
+  private static final int USER_COUNT = 12;
+
+  @Test
+  @DisplayName("User list teiSearchOrganisationUnits are batch-loaded, not fetched per user")
+  void teiSearchOrganisationUnitsAreNotLoadedPerUser() {
+    OrganisationUnit ou = createOrganisationUnit('T');
+    manager.save(ou);
+
+    for (int i = 0; i < USER_COUNT; i++) {
+      User user = createUserWithAuth("teiq" + i, "ALL");
+      user.getTeiSearchOrganisationUnits().add(ou);
+      userService.updateUser(user);
+    }
+
+    // Persist and drop first-level cache so the list request reloads collections from the DB.
+    manager.flush();
+    manager.clear();
+    injectSecurityContextUser(getAdminUser());
+    QueryCountDataSourceProxy.clearCapturedSql();
+
+    // Avoid {placeholders} colliding with field-filter brackets; use filter + fixed pageSize.
+    var response =
+        GET(
+            "/users?fields=id,username,teiSearchOrganisationUnits[id]"
+                + "&filter=username:like:teiq&pageSize=50&paging=true");
+    assertEquals(
+        USER_COUNT,
+        response.content().getArray("users").size(),
+        "expected the seeded teiq* users in the list response");
+
+    long teiSearchQueries =
+        QueryCountDataSourceProxy.countCapturedSqlMatching("userteisearchorgunits");
+    assertTrue(
+        teiSearchQueries <= 1,
+        "teiSearchOrganisationUnits must be batch-loaded, but userteisearchorgunits was queried "
+            + teiSearchQueries
+            + " times for "
+            + USER_COUNT
+            + " users");
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -101,6 +101,7 @@ import org.hisp.dhis.user.PasswordValidationResult;
 import org.hisp.dhis.user.PasswordValidationService;
 import org.hisp.dhis.user.RestoreOptions;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserGroupService;
@@ -217,6 +218,23 @@ public class UserController
     @OpenApi.Description(
         "Shorthand for `canManage=true` + `authSubset=true` (takes precedence over individual parameters)")
     boolean manage;
+  }
+
+  /**
+   * DHIS2-21907: when the list field filter includes {@code teiSearchOrganisationUnits}, bulk-load
+   * those associations with one native SQL query before field-filter serialization (avoids one
+   * Hibernate select per listed user).
+   */
+  @Override
+  protected void getEntityListPostProcess(GetUserObjectListParams params, List<User> entities) {
+    if (entities == null || entities.isEmpty()) {
+      return;
+    }
+    String fields = params.getFieldsJsonList();
+    if (fields == null || !fields.contains("teiSearchOrganisationUnits")) {
+      return;
+    }
+    userService.loadTeiSearchOrganisationUnits(entities);
   }
 
   @Override


### PR DESCRIPTION
## Summary
Alternate fix for [DHIS2-21907](https://dhis2.atlassian.net/browse/DHIS2-21907) (companion to #24659).

Cold `GET /api/users` with `teiSearchOrganisationUnits[id,path]` was N+1 on `userteisearchorgunits` (one select per listed user).

This variant does **not** use Hibernate `batch-size`. Instead:
- One `JdbcTemplate` query loads `userinfoid`, OU `id`/`uid`/`path` for all listed users
- `UserController.getEntityListPostProcess` replaces lazy collections before field-filter when `fields` include `teiSearchOrganisationUnits`
- Same regression test as #24659 (`UserTeiSearchOrganisationUnitsQueryCountTest`)

## Why a second PR
Side-by-side comparison with the batch-size approach (#24659). Pick one; do not merge both.

## Verification
- queryhound cold `f-ceb1c8efc8ab`: FAIL 50 unfixed
- Local THESIS: FAIL 50 → PASS observed=0 hibernate lines (JDBC path) cold ×3
- Unit/integration: `UserTeiSearchOrganisationUnitsQueryCountTest` green

## Test plan
- [ ] CI green
- [ ] Compare with #24659; merge at most one

[DHIS2-21907]: https://dhis2.atlassian.net/browse/DHIS2-21907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ