### PR TITLE
fix: batch-load program stage dataElements on list [DHIS2-21903]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -73,6 +73,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
@@ -133,6 +134,8 @@ import org.hisp.dhis.user.sharing.UserGroupAccess;
 @Table(name = "dataelement")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+// Batch-load lazy DataElement proxies (e.g. ProgramStageDataElement.dataElement) [DHIS2-21903]
+@BatchSize(size = 100)
 @JacksonXmlRootElement(localName = "dataElement", namespace = DxfNamespaces.DXF_2_0)
 public class DataElement extends BaseMetadataObject
     implements DimensionalItemObject,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramStage.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramStage.hbm.xml
@@ -28,7 +28,7 @@
 
         <property name="repeatable" column="repeatable" not-null="true"/>
 
-        <set name="programStageDataElements" order-by="sort_order" cascade="all-delete-orphan">
+        <set name="programStageDataElements" order-by="sort_order" cascade="all-delete-orphan" batch-size="100">
             <key column="programstageid"/>
             <one-to-many class="org.hisp.dhis.program.ProgramStageDataElement"/>
         </set>

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramDataElementQueryCountTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramDataElementQueryCountTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageDataElement;
+import org.hisp.dhis.test.config.QueryCountDataSourceProxy;
+import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Regression for DHIS2-21903: Capture-app {@code GET /api/programs} field filter over nested
+ * {@code programStages.programStageDataElements.dataElement} must not select each data element
+ * by id once per PSDE row.
+ *
+ * <p>Author: Morten (Morty)
+ */
+@Transactional
+@ContextConfiguration(classes = {QueryCountDataSourceProxy.class})
+class ProgramDataElementQueryCountTest extends PostgresControllerIntegrationTestBase {
+
+  private static final int DATA_ELEMENT_COUNT = 12;
+
+  @Test
+  @DisplayName("Program list nested dataElements are batch-loaded, not fetched per PSDE")
+  void programStageDataElementsAreNotLoadedPerDataElement() {
+    Program program = createProgramWithoutRegistration('Q');
+    program.setName("QH21903-P");
+    program.setShortName("QH21903P");
+
+    ProgramStage stage = createProgramStage('Q', program);
+    stage.setName("QH21903-S");
+
+    Set<ProgramStageDataElement> psdes = new HashSet<>();
+    for (int i = 0; i < DATA_ELEMENT_COUNT; i++) {
+      char c = (char) ('a' + i);
+      DataElement de = createDataElement(c);
+      de.setName("QH21903-DE" + i);
+      de.setShortName("QH21903DE" + i);
+      manager.save(de);
+
+      ProgramStageDataElement psde = createProgramStageDataElement(stage, de, i + 1);
+      psdes.add(psde);
+    }
+    stage.setProgramStageDataElements(psdes);
+    program.getProgramStages().add(stage);
+
+    manager.save(program);
+    manager.save(stage);
+    for (ProgramStageDataElement psde : psdes) {
+      manager.save(psde);
+    }
+
+    // Drop first-level cache so the list request reloads associations from the DB.
+    manager.flush();
+    manager.clear();
+    injectSecurityContextUser(getAdminUser());
+    QueryCountDataSourceProxy.clearCapturedSql();
+
+    var response =
+        GET(
+            "/programs?fields=id,programStages[id,programStageDataElements[dataElement[id]]]"
+                + "&filter=name:eq:QH21903-P&pageSize=10&paging=true");
+    assertEquals(
+        1,
+        response.content().getArray("programs").size(),
+        "expected the seeded QH21903-P program in the list response");
+
+    long dataElementByIdQueries =
+        QueryCountDataSourceProxy.countCapturedSqlMatching(
+            "from dataelement");
+    // Batch fetch should collapse N lazy loads into a single (or very few) selects.
+    // Allow a small constant overhead for the program/stage graph itself, but never N.
+    assertTrue(
+        dataElementByIdQueries <= 2,
+        "dataElement must be batch-loaded, but dataelement was queried "
+            + dataElementByIdQueries
+            + " times for "
+            + DATA_ELEMENT_COUNT
+            + " nested data elements");
+  }
+}


### PR DESCRIPTION
## Summary
- Cold Capture `GET /api/programs` with nested `programStages.programStageDataElements.dataElement` was selecting each data element by id (queryhound 379× on Sierra Leone demo).
- Add Hibernate `@BatchSize(100)` on `DataElement` and `batch-size="100"` on `ProgramStage.programStageDataElements` so nested DEs batch-load.
- Regression: `ProgramDataElementQueryCountTest` (Postgres + query-count proxy).

## Verification
- queryhound cold repro `f-471144650f85`: FAIL 379 on unfixed master
- Local THESIS gate (N=20): FAIL 20 → PASS 0 (cold ×3)
- `mvn -pl dhis-test-web-api -am test -Dtest=ProgramDataElementQueryCountTest` green

Jira: https://dhis2.atlassian.net/browse/DHIS2-21903
Findings: queryhound `docs/thesis-DHIS2-21903/FINDINGS.md`