### PR TITLE
fix: Remove obsolete fk from trackedentityaudit table [DHIS2-18694](2.41)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_60__drop_trackedentityaudit_foreign_key.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_60__drop_trackedentityaudit_foreign_key.sql
@@ -1,0 +1,18 @@
+-- https://dhis2.atlassian.net/browse/DHIS2-18694
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT c.conname
+        FROM pg_constraint c
+                 JOIN unnest(c.conkey) AS k(attnum) ON true
+                 JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+        WHERE c.contype = 'f'
+          AND c.conrelid = 'trackedentityaudit'::regclass
+          AND a.attname = 'trackedentity'
+        LOOP
+            EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I',
+                           'trackedentityaudit', r.conname);
+        END LOOP;
+END $$;


### PR DESCRIPTION
Backport of https://github.com/dhis2/dhis2-core/pull/24607.
The migration is idempotent and can be applied to older versions.