### PR TITLE
feat: Apply sharing at data element level [DHIS2-18466]

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/singleevent/SingleEventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/singleevent/SingleEventChangeLogServiceTest.java
@@ -30,20 +30,27 @@
 package org.hisp.dhis.tracker.export.singleevent;
 
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
+import static org.hisp.dhis.security.acl.AccessStringHelper.DEFAULT;
+import static org.hisp.dhis.security.acl.AccessStringHelper.READ_ONLY;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.tracker.Page;
 import org.hisp.dhis.tracker.PageParams;
@@ -176,6 +183,37 @@ class SingleEventChangeLogServiceTest extends PostgresIntegrationTestBase {
 
     assertNumberOfChanges(1, changeLogs);
     assertDataElementCreate(dataElement, "13", changeLogs.get(0));
+  }
+
+  @Test
+  void shouldNotReturnChangeLogsForDataElementWhenUserCannotReadDataElement()
+      throws NotFoundException {
+    String event = "kWjSezkXHVp";
+
+    // Give a non-superuser read access to the single event program and stage but remove metadata
+    // read access to GieVkTxp4HH. The event is accessible but the user cannot read that data
+    // element, so its change logs must not be returned while change logs of the other (readable)
+    // data elements of the event still are.
+    grantPublicAccess(manager.get(Program.class, "iS7eutanDry"), READ_ONLY);
+    grantPublicAccess(manager.get(ProgramStage.class, "qLZC0lvvxQH"), READ_ONLY);
+    grantPublicAccess(manager.get(DataElement.class, "GieVkTxp4HH"), DEFAULT);
+    manager.flush();
+    manager.clear();
+
+    injectSecurityContextUser(manager.get(User.class, "Hop98yh65pL"));
+
+    Page<EventChangeLog> changeLogs =
+        singleEventChangeLogService.getEventChangeLog(
+            UID.of(event), defaultOperationParams, defaultPageParams);
+
+    List<EventChangeLog> dataElementChangeLogs = getDataElementChangeLogs(changeLogs);
+    assertFalse(
+        dataElementChangeLogs.isEmpty(),
+        "expected change logs of the other readable data elements to be returned");
+    assertTrue(
+        dataElementChangeLogs.stream()
+            .noneMatch(cl -> "GieVkTxp4HH".equals(cl.dataElement().getUid())),
+        "expected no change logs of the restricted data element to be returned");
   }
 
   @Test
@@ -503,6 +541,11 @@ class SingleEventChangeLogServiceTest extends PostgresIntegrationTestBase {
 
   private void testAsUser(String user) {
     injectSecurityContextUser(manager.get(User.class, user));
+  }
+
+  private void grantPublicAccess(IdentifiableObject object, String access) {
+    object.getSharing().setPublicAccess(access);
+    manager.updateNoAcl(object);
   }
 
   private static void assertNumberOfChanges(int expected, List<EventChangeLog> changeLogs) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/singleevent/SingleEventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/singleevent/SingleEventServiceTest.java
@@ -31,6 +31,8 @@ package org.hisp.dhis.tracker.export.singleevent;
 
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
+import static org.hisp.dhis.security.acl.AccessStringHelper.DEFAULT;
+import static org.hisp.dhis.security.acl.AccessStringHelper.READ_ONLY;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.tracker.Assertions.assertNotes;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -51,10 +53,14 @@ import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.test.utils.Assertions;
 import org.hisp.dhis.tracker.Page;
@@ -367,6 +373,42 @@ class SingleEventServiceTest extends PostgresIntegrationTestBase {
                                             .collect(Collectors.toSet()))))
             .toList();
     assertAll("all events should have the same category option combo and options", executables);
+  }
+
+  @Test
+  void shouldNotReturnDataElementValueWhenUserCannotReadDataElement()
+      throws ForbiddenException, BadRequestException {
+    // Give a non-superuser read access to the single event program and stage but remove metadata
+    // read access to GieVkTxp4HH. The event stays accessible, but the value of the restricted data
+    // element must not be returned while the other data elements of the event still are.
+    grantPublicAccess(get(Program.class, "iS7eutanDry"), READ_ONLY);
+    grantPublicAccess(get(ProgramStage.class, "qLZC0lvvxQH"), READ_ONLY);
+    grantPublicAccess(get(DataElement.class, "GieVkTxp4HH"), DEFAULT);
+    manager.flush();
+    manager.clear();
+
+    injectSecurityContextUser(userService.getUser("Hop98yh65pL"));
+
+    SingleEventOperationParams params =
+        SingleEventOperationParams.builderForEvent(UID.of("kWjSezkXHVp"))
+            .orgUnitMode(ACCESSIBLE)
+            .build();
+
+    List<SingleEvent> events = singleEventService.findEvents(params);
+
+    assertContainsOnly(
+        Set.of("GieVkTxp4HG", "DATAEL00005", "DATAEL00007"), dataElements(events.get(0)));
+  }
+
+  private void grantPublicAccess(IdentifiableObject object, String access) {
+    object.getSharing().setPublicAccess(access);
+    manager.updateNoAcl(object);
+  }
+
+  private static Set<String> dataElements(SingleEvent event) {
+    return event.getEventDataValues().stream()
+        .map(EventDataValue::getDataElement)
+        .collect(Collectors.toSet());
   }
 
   private <T extends IdentifiableObject> T get(Class<T> type, String uid) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackerevent/TrackerEventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackerevent/TrackerEventChangeLogServiceTest.java
@@ -30,11 +30,14 @@
 package org.hisp.dhis.tracker.export.trackerevent;
 
 import static org.hisp.dhis.changelog.ChangeLogType.UPDATE;
+import static org.hisp.dhis.security.acl.AccessStringHelper.DEFAULT;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -165,6 +168,37 @@ class TrackerEventChangeLogServiceTest extends PostgresIntegrationTestBase {
 
     assertNumberOfChanges(1, changeLogs);
     assertDataElementCreate(dataElement, "value00001", changeLogs.get(0));
+  }
+
+  @Test
+  void shouldNotReturnChangeLogsForDataElementWhenUserCannotReadDataElement()
+      throws NotFoundException {
+    String event = "pTzf9KYMk72";
+
+    // Remove metadata read access to DATAEL00001 for the basic user. The event is accessible but
+    // the user cannot read that data element, so its change logs must not be returned while change
+    // logs of the other (readable) data elements of the event still are.
+    DataElement dataElement = manager.get(DataElement.class, "DATAEL00001");
+    dataElement.getSharing().setPublicAccess(DEFAULT);
+    manager.updateNoAcl(dataElement);
+    manager.flush();
+    manager.clear();
+
+    injectSecurityContextUser(manager.get(User.class, "Z7870757a75"));
+
+    Page<EventChangeLog> changeLogs =
+        trackerEventChangeLogService.getEventChangeLog(
+            UID.of(event), defaultOperationParams, defaultPageParams);
+
+    List<EventChangeLog> dataElementChangeLogs =
+        changeLogs.getItems().stream().filter(cl -> cl.dataElement() != null).toList();
+    assertFalse(
+        dataElementChangeLogs.isEmpty(),
+        "expected change logs of the other readable data elements to be returned");
+    assertTrue(
+        dataElementChangeLogs.stream()
+            .noneMatch(cl -> "DATAEL00001".equals(cl.dataElement().getUid())),
+        "expected no change logs of the restricted data element to be returned");
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackerevent/TrackerEventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackerevent/TrackerEventServiceTest.java
@@ -32,6 +32,7 @@ package org.hisp.dhis.tracker.export.trackerevent;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
 import static org.hisp.dhis.security.acl.AccessStringHelper.DATA_READ;
+import static org.hisp.dhis.security.acl.AccessStringHelper.DEFAULT;
 import static org.hisp.dhis.security.acl.AccessStringHelper.READ;
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
@@ -54,6 +55,8 @@ import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -677,6 +680,30 @@ class TrackerEventServiceTest extends PostgresIntegrationTestBase {
     assertIsEmpty(getEvents(operationParamsBuilder.build()));
   }
 
+  @Test
+  void shouldNotReturnDataElementValueWhenUserCannotReadDataElement()
+      throws ForbiddenException, BadRequestException {
+    // Remove metadata read access to DATAEL00001 for the basic user. The event stays accessible,
+    // but the value of the restricted data element must not be returned while the other data
+    // elements of the event still are.
+    DataElement dataElement = get(DataElement.class, "DATAEL00001");
+    dataElement.getSharing().setPublicAccess(DEFAULT);
+    manager.updateNoAcl(dataElement);
+    manager.flush();
+    manager.clear();
+
+    injectSecurityContextUser(userService.getUser("Z7870757a75"));
+
+    TrackerEventOperationParams params =
+        TrackerEventOperationParams.builderForEvent(UID.of("D9PbzJY8bJM")).build();
+
+    List<TrackerEvent> events = trackerEventService.findEvents(params);
+
+    assertContainsOnly(
+        Set.of("DATAEL00002", "DATAEL00005", "DATAEL00006", "DATAEL00007", "GieVkTxp4HH"),
+        dataElements(events.get(0)));
+  }
+
   private <T extends IdentifiableObject> T get(Class<T> type, String uid) {
     T t = manager.get(type, uid);
     assertNotNull(
@@ -694,6 +721,12 @@ class TrackerEventServiceTest extends PostgresIntegrationTestBase {
 
   private static List<String> uids(List<? extends IdentifiableObject> identifiableObject) {
     return identifiableObject.stream().map(IdentifiableObject::getUid).toList();
+  }
+
+  private static Set<String> dataElements(TrackerEvent event) {
+    return event.getEventDataValues().stream()
+        .map(EventDataValue::getDataElement)
+        .collect(Collectors.toSet());
   }
 
   private void updatePublicAccessSharing(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.tracker.export.event;
 
 import static java.util.Map.entry;
+import static org.hisp.dhis.query.JpaQueryUtils.generateHqlQueryForSharingCheck;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
@@ -48,9 +49,12 @@ import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.UserInfoSnapshot;
+import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.tracker.Page;
 import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.export.Order;
+import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.UserDetails;
 
 public abstract class HibernateEventChangeLogStore<T, S extends SoftDeletableEntity> {
   private static final String COLUMN_CHANGELOG_CREATED = "ecl.created";
@@ -135,6 +139,16 @@ public abstract class HibernateEventChangeLogStore<T, S extends SoftDeletableEnt
 
       hql += String.format(" and %s = :filterValue ", filterField);
     }
+
+    // Honor data element (metadata) sharing: a user may access the event but not be allowed to read
+    // some of its data elements. Change logs for those data elements must not be returned, while
+    // change logs of event fields (which have no data element) always are. The sharing check is
+    // applied in the query so pagination stays correct; it resolves to 1=1 for superusers.
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
+    hql +=
+        " and (ecl.dataElement is null or "
+            + generateHqlQueryForSharingCheck("d", currentUser, AclService.LIKE_READ_METADATA)
+            + ") ";
 
     hql += String.format("order by %s".formatted(sortExpressions(operationParams.getOrder())));
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/singleevent/DefaultSingleEventService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/singleevent/DefaultSingleEventService.java
@@ -32,10 +32,13 @@ package org.hisp.dhis.tracker.export.singleevent;
 import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
 import java.util.Date;
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IdScheme;
@@ -52,6 +55,7 @@ import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.fileresource.ImageFileDimension;
+import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.tracker.Page;
 import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.TrackerIdScheme;
@@ -62,6 +66,7 @@ import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.relationship.RelationshipService;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.model.SingleEvent;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -80,6 +85,8 @@ class DefaultSingleEventService implements SingleEventService {
   private final SingleEventOperationParamsMapper paramsMapper;
 
   private final RelationshipService relationshipService;
+
+  private final AclService aclService;
 
   @Override
   @Transactional(readOnly = true)
@@ -198,33 +205,9 @@ class DefaultSingleEventService implements SingleEventService {
     if (events.getItems().isEmpty()) {
       throw new NotFoundException(Event.class, eventUid.getValue());
     }
-    SingleEvent event = events.getItems().get(0);
-
-    Set<EventDataValue> dataValues = new HashSet<>(event.getEventDataValues().size());
-    for (EventDataValue dataValue : event.getEventDataValues()) {
-      DataElement dataElement = null;
-      TrackerIdSchemeParam dataElementIdScheme = idSchemeParams.getDataElementIdScheme();
-      if (TrackerIdScheme.UID == dataElementIdScheme.getIdScheme()) {
-        dataElement = dataElementService.getDataElement(dataValue.getDataElement());
-      } else if (TrackerIdScheme.CODE == dataElementIdScheme.getIdScheme()) {
-        dataElement = manager.getByCode(DataElement.class, dataValue.getDataElement());
-      } else if (TrackerIdScheme.NAME == dataElementIdScheme.getIdScheme()) {
-        dataElement = manager.getByName(DataElement.class, dataValue.getDataElement());
-      } else if (TrackerIdScheme.ATTRIBUTE == dataElementIdScheme.getIdScheme()) {
-        dataElement =
-            manager.getObject(
-                DataElement.class,
-                new IdScheme(IdentifiableProperty.ATTRIBUTE, dataElementIdScheme.getAttributeUid()),
-                dataValue.getDataElement());
-      }
-
-      if (dataElement != null) {
-        dataValues.add(dataValue);
-      }
-    }
-    event.setEventDataValues(dataValues);
-
-    return event;
+    // findEvents already dropped data values whose data element cannot be resolved for the
+    // requested idScheme or the user is not allowed to read.
+    return events.getItems().get(0);
   }
 
   @Nonnull
@@ -234,6 +217,7 @@ class DefaultSingleEventService implements SingleEventService {
       throws BadRequestException, ForbiddenException {
     SingleEventQueryParams queryParams = paramsMapper.map(operationParams, getCurrentUserDetails());
     List<SingleEvent> events = eventStore.getEvents(queryParams);
+    filterReadableDataValues(events, queryParams.getIdSchemeParams());
     if (operationParams.getFields().isIncludesRelationships()) {
       for (SingleEvent event : events) {
         event.setRelationshipItems(
@@ -263,6 +247,7 @@ class DefaultSingleEventService implements SingleEventService {
       throws BadRequestException, ForbiddenException {
     SingleEventQueryParams queryParams = paramsMapper.map(operationParams, getCurrentUserDetails());
     Page<SingleEvent> events = eventStore.getEvents(queryParams, pageParams);
+    filterReadableDataValues(events.getItems(), queryParams.getIdSchemeParams());
     if (operationParams.getFields().isIncludesRelationships()) {
       for (SingleEvent event : events.getItems()) {
         event.setRelationshipItems(
@@ -274,6 +259,52 @@ class DefaultSingleEventService implements SingleEventService {
       }
     }
     return events;
+  }
+
+  /**
+   * Removes the data values whose data element the user is not allowed to read. Data values only
+   * carry the data element identifier (a UID, code or name depending on the requested idScheme)
+   * stored in the {@code eventdatavalues} jsonb column, not the data element metadata, so we
+   * resolve each data element and honor its (metadata) sharing. Data values whose data element
+   * cannot be resolved for the requested idScheme are dropped as well. The readability of a data
+   * element is cached per call since the same data element is typically shared across many events.
+   */
+  private void filterReadableDataValues(
+      List<SingleEvent> events, TrackerIdSchemeParams idSchemeParams) {
+    UserDetails user = getCurrentUserDetails();
+    Map<String, Boolean> readableByIdentifier = new HashMap<>();
+    for (SingleEvent event : events) {
+      Set<EventDataValue> readable =
+          event.getEventDataValues().stream()
+              .filter(
+                  dataValue ->
+                      readableByIdentifier.computeIfAbsent(
+                          dataValue.getDataElement(),
+                          identifier -> isDataElementReadable(identifier, idSchemeParams, user)))
+              .collect(Collectors.toCollection(LinkedHashSet::new));
+      event.setEventDataValues(readable);
+    }
+  }
+
+  private boolean isDataElementReadable(
+      String identifier, TrackerIdSchemeParams idSchemeParams, UserDetails user) {
+    DataElement dataElement = null;
+    TrackerIdSchemeParam dataElementIdScheme = idSchemeParams.getDataElementIdScheme();
+    if (TrackerIdScheme.UID == dataElementIdScheme.getIdScheme()) {
+      dataElement = dataElementService.getDataElement(identifier);
+    } else if (TrackerIdScheme.CODE == dataElementIdScheme.getIdScheme()) {
+      dataElement = manager.getByCode(DataElement.class, identifier);
+    } else if (TrackerIdScheme.NAME == dataElementIdScheme.getIdScheme()) {
+      dataElement = manager.getByName(DataElement.class, identifier);
+    } else if (TrackerIdScheme.ATTRIBUTE == dataElementIdScheme.getIdScheme()) {
+      dataElement =
+          manager.getObject(
+              DataElement.class,
+              new IdScheme(IdentifiableProperty.ATTRIBUTE, dataElementIdScheme.getAttributeUid()),
+              identifier);
+    }
+
+    return dataElement != null && aclService.canRead(user, dataElement);
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackerevent/DefaultTrackerEventService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackerevent/DefaultTrackerEventService.java
@@ -31,10 +31,13 @@ package org.hisp.dhis.tracker.export.trackerevent;
 
 import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IdScheme;
@@ -51,6 +54,7 @@ import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.fileresource.ImageFileDimension;
+import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.tracker.Page;
 import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.TrackerIdScheme;
@@ -61,6 +65,7 @@ import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.relationship.RelationshipService;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.model.TrackerEvent;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -80,6 +85,8 @@ class DefaultTrackerEventService implements TrackerEventService {
   private final TrackerEventOperationParamsMapper paramsMapper;
 
   private final RelationshipService relationshipService;
+
+  private final AclService aclService;
 
   @Override
   public FileResourceStream getFileResource(@Nonnull UID event, @Nonnull UID dataElement)
@@ -192,33 +199,9 @@ class DefaultTrackerEventService implements TrackerEventService {
     if (events.getItems().isEmpty()) {
       throw new NotFoundException(Event.class, eventUid.getValue());
     }
-    TrackerEvent event = events.getItems().get(0);
-
-    Set<EventDataValue> dataValues = new HashSet<>(event.getEventDataValues().size());
-    for (EventDataValue dataValue : event.getEventDataValues()) {
-      DataElement dataElement = null;
-      TrackerIdSchemeParam dataElementIdScheme = idSchemeParams.getDataElementIdScheme();
-      if (TrackerIdScheme.UID == dataElementIdScheme.getIdScheme()) {
-        dataElement = dataElementService.getDataElement(dataValue.getDataElement());
-      } else if (TrackerIdScheme.CODE == dataElementIdScheme.getIdScheme()) {
-        dataElement = manager.getByCode(DataElement.class, dataValue.getDataElement());
-      } else if (TrackerIdScheme.NAME == dataElementIdScheme.getIdScheme()) {
-        dataElement = manager.getByName(DataElement.class, dataValue.getDataElement());
-      } else if (TrackerIdScheme.ATTRIBUTE == dataElementIdScheme.getIdScheme()) {
-        dataElement =
-            manager.getObject(
-                DataElement.class,
-                new IdScheme(IdentifiableProperty.ATTRIBUTE, dataElementIdScheme.getAttributeUid()),
-                dataValue.getDataElement());
-      }
-
-      if (dataElement != null) {
-        dataValues.add(dataValue);
-      }
-    }
-    event.setEventDataValues(dataValues);
-
-    return event;
+    // findEvents already dropped data values whose data element cannot be resolved for the
+    // requested idScheme or the user is not allowed to read.
+    return events.getItems().get(0);
   }
 
   @Nonnull
@@ -228,6 +211,7 @@ class DefaultTrackerEventService implements TrackerEventService {
     TrackerEventQueryParams queryParams =
         paramsMapper.map(operationParams, getCurrentUserDetails());
     List<TrackerEvent> events = eventStore.getEvents(queryParams);
+    filterReadableDataValues(events, queryParams.getIdSchemeParams());
     if (operationParams.getFields().isIncludesRelationships()) {
       for (TrackerEvent event : events) {
         event.setRelationshipItems(
@@ -249,6 +233,7 @@ class DefaultTrackerEventService implements TrackerEventService {
     TrackerEventQueryParams queryParams =
         paramsMapper.map(operationParams, getCurrentUserDetails());
     Page<TrackerEvent> events = eventStore.getEvents(queryParams, pageParams);
+    filterReadableDataValues(events.getItems(), queryParams.getIdSchemeParams());
     if (operationParams.getFields().isIncludesRelationships()) {
       for (TrackerEvent event : events.getItems()) {
         event.setRelationshipItems(
@@ -260,6 +245,52 @@ class DefaultTrackerEventService implements TrackerEventService {
       }
     }
     return events;
+  }
+
+  /**
+   * Removes the data values whose data element the user is not allowed to read. Data values only
+   * carry the data element identifier (a UID, code or name depending on the requested idScheme)
+   * stored in the {@code eventdatavalues} jsonb column, not the data element metadata, so we
+   * resolve each data element and honor its (metadata) sharing. Data values whose data element
+   * cannot be resolved for the requested idScheme are dropped as well. The readability of a data
+   * element is cached per call since the same data element is typically shared across many events.
+   */
+  private void filterReadableDataValues(
+      List<TrackerEvent> events, TrackerIdSchemeParams idSchemeParams) {
+    UserDetails user = getCurrentUserDetails();
+    Map<String, Boolean> readableByIdentifier = new HashMap<>();
+    for (TrackerEvent event : events) {
+      Set<EventDataValue> readable =
+          event.getEventDataValues().stream()
+              .filter(
+                  dataValue ->
+                      readableByIdentifier.computeIfAbsent(
+                          dataValue.getDataElement(),
+                          identifier -> isDataElementReadable(identifier, idSchemeParams, user)))
+              .collect(Collectors.toCollection(LinkedHashSet::new));
+      event.setEventDataValues(readable);
+    }
+  }
+
+  private boolean isDataElementReadable(
+      String identifier, TrackerIdSchemeParams idSchemeParams, UserDetails user) {
+    DataElement dataElement = null;
+    TrackerIdSchemeParam dataElementIdScheme = idSchemeParams.getDataElementIdScheme();
+    if (TrackerIdScheme.UID == dataElementIdScheme.getIdScheme()) {
+      dataElement = dataElementService.getDataElement(identifier);
+    } else if (TrackerIdScheme.CODE == dataElementIdScheme.getIdScheme()) {
+      dataElement = manager.getByCode(DataElement.class, identifier);
+    } else if (TrackerIdScheme.NAME == dataElementIdScheme.getIdScheme()) {
+      dataElement = manager.getByName(DataElement.class, identifier);
+    } else if (TrackerIdScheme.ATTRIBUTE == dataElementIdScheme.getIdScheme()) {
+      dataElement =
+          manager.getObject(
+              DataElement.class,
+              new IdScheme(IdentifiableProperty.ATTRIBUTE, dataElementIdScheme.getAttributeUid()),
+              identifier);
+    }
+
+    return dataElement != null && aclService.canRead(user, dataElement);
   }
 
   @Override


### PR DESCRIPTION
## Summary

Applies metadata sharing at the individual data element level across the tracker event export paths [DHIS2-18466]. Previously, an event's data values were returned in full to any user who could access the event; now each data element's own metadata sharing is honored, so a user who can access an event but is not allowed to read one of its data elements no longer sees that data value (or its change logs).

## Changes

- **Event export** (`DefaultSingleEventService`, `DefaultTrackerEventService`): `findEvents` now filters each event's data values through a new `filterReadableDataValues`, dropping any value whose data element cannot be resolved for the requested idScheme or that the user is not allowed to `canRead`. Readability is resolved once per data element identifier and cached per call (`Map<identifier, Boolean>`), since the same data element is shared across many events. The old per-`getEvent` resolution loop is removed because `findEvents` now handles the filtering for both the single-event and paged paths.
- **Change log export** (`HibernateEventChangeLogStore`): adds a metadata sharing check to the HQL (`ecl.dataElement is null or <sharing check>`) so change logs for data elements the user cannot read are excluded, while change logs of event fields (which have no data element) are always returned. The check is applied in-query to keep pagination correct and resolves to `1=1` for superusers.

## Performance

Data element-level ACL filtering adds per-data-element resolution on the event export paths, so
both a load test and the smoke suite were run to confirm there is no regression.

### Load test

Compared against `master` baseline (3 baseline runs vs 3 candidate runs). Load-test runs:
- https://github.com/dhis2/dhis2-core/actions/runs/30890618008
- https://github.com/dhis2/dhis2-core/actions/runs/30890614651
- https://github.com/dhis2/dhis2-core/actions/runs/30890611114

#### 95th Percentile Response Time (p95) (ms)

| Requests | baseline | req/s | candidate | req/s | Diff (ms) | Change |
|:---|---:|---:|---:|---:|---:|:---|
| Get ANC events / Get one event / Get first event | 72 | 0.22 | 69 | 0.22 | -3 | :arrow_down: -4.0% |
| Get ANC events / Get one event / Get relationships for first event | 6 | 0.22 | 6 | 0.22 | +0 | +0.0% |
| Get ANC events / Go to first page | 93 | 0.23 | 89 | 0.23 | -4 | :arrow_down: -4.3% |
| Get ANC events / Go to second page | 96 | 0.23 | 98 | 0.22 | +2 | :arrow_up: +1.6% |
| Get ANC events / Search not assigned | 98 | 0.22 | 98 | 0.22 | +0 | :arrow_up: +0.1% |
| Get ANC events / Search by date range | 415 | 0.22 | 414 | 0.22 | -1 | :arrow_down: -0.2% |
| Get Child Programme TEs / Go to single enrollment / Get one event / Get first event from enrollment | 74 | 0.10 | 80 | 0.10 | +5 | :arrow_up: +7.3% |
| Get Child Programme TEs / Go to single enrollment / Get one event / Get relationships for first event | 7 | 0.10 | 8 | 0.10 | +1 | :arrow_up: +9.6% |
| Get Child Programme TEs / Go to single enrollment / Get first tracked entity | 92 | 0.11 | 78 | 0.10 | -13 | :arrow_down: -14.6% |
| Get Child Programme TEs / Go to single enrollment / Get first enrollment | 26 | 0.11 | 24 | 0.10 | -2 | :arrow_down: -7.7% |
| Get Child Programme TEs / Go to single enrollment / Get relationships for first tracked entity | 7 | 0.11 | 7 | 0.10 | +0 | +0.0% |
| Get Child Programme TEs / Not found TE by name with like operator | 84 | 0.11 | 83 | 0.11 | -1 | :arrow_down: -1.4% |
| Get Child Programme TEs / Not found TE by name with eq operator | 15 | 0.11 | 15 | 0.11 | +0 | +0.0% |
| Get Child Programme TEs / Search TE by name with like operator | 141 | 0.11 | 139 | 0.11 | -2 | :arrow_down: -1.5% |
| Get Child Programme TEs / Search TE by name with eq operator | 95 | 0.11 | 93 | 0.11 | -2 | :arrow_down: -2.1% |
| Get Child Programme TEs / Search Birth events | 819 | 0.11 | 825 | 0.11 | +6 | :arrow_up: +0.8% |
| Get Child Programme TEs / Get TEs from events | 11 | 0.11 | 10 | 0.11 | -1 | :arrow_down: -9.1% |
| Get Child Programme TEs / Get first page of TEs | 128 | 0.11 | 131 | 0.11 | +3 | :arrow_up: +2.5% |
| Get Child Programme TEs / Get TEs with enrollment status | 154 | 0.10 | 157 | 0.10 | +3 | :arrow_up: +2.1% |
| Login | 199 | 0.05 | 185 | 0.05 | -14 | :arrow_down: -7.0% |
| MNCH import | 608 | 0.14 | 581 | 0.14 | -27 | :arrow_down: -4.5% |
| Child Programme import | 237 | 0.14 | 205 | 0.14 | -32 | :arrow_down: -13.5% |
| ANC import | 564 | 0.14 | 169 | 0.14 | -395 | :arrow_down: -70.0% |

_:arrow_down: = faster, :arrow_up: = slower_

_Percentiles use the inclusive definition (e.g. p95 = X means 95% of requests responded in X ms or less) and are computed over OK + KO responses._

### Smoke test

Compared against `master` baseline (3 baseline runs vs 3 candidate runs). Smoke runs:
- https://github.com/dhis2/dhis2-core/actions/runs/30888673623
- https://github.com/dhis2/dhis2-core/actions/runs/30888670833
- https://github.com/dhis2/dhis2-core/actions/runs/30888667782

#### 95th Percentile Response Time (p95) (ms)

| Requests | baseline | req/s | candidate | req/s | Diff (ms) | Change |
|:---|---:|---:|---:|---:|---:|:---|
| Get ANC events / Get one event / Get first event | 17 | 2.63 | 16 | 2.30 | -1 | :arrow_down: -5.6% |
| Get ANC events / Get one event / Get relationships for first event | 5 | 2.63 | 4 | 2.30 | -1 | :arrow_down: -19.0% |
| Get ANC events / Go to first page | 65 | 2.63 | 66 | 2.30 | +1 | :arrow_up: +1.6% |
| Get ANC events / Go to second page | 66 | 2.63 | 66 | 2.30 | +0 | +0.0% |
| Get ANC events / Search not assigned | 65 | 2.63 | 66 | 2.30 | +1 | :arrow_up: +1.5% |
| Get ANC events / Search by date range | 22 | 2.63 | 23 | 2.30 | +1 | :arrow_up: +4.5% |
| Get Child Programme TEs / Go to single enrollment / Get one event / Get first event from enrollment | 27 | 2.63 | 26 | 2.30 | -1 | :arrow_down: -3.7% |
| Get Child Programme TEs / Go to single enrollment / Get one event / Get relationships for first event | 6 | 2.63 | 5 | 2.30 | -1 | :arrow_down: -16.7% |
| Get Child Programme TEs / Go to single enrollment / Get first tracked entity | 20 | 2.63 | 26 | 2.30 | +6 | :arrow_up: +29.7% |
| Get Child Programme TEs / Go to single enrollment / Get first enrollment | 8 | 2.63 | 7 | 2.30 | -1 | :arrow_down: -12.5% |
| Get Child Programme TEs / Go to single enrollment / Get relationships for first tracked entity | 6 | 2.63 | 6 | 2.30 | -0 | :arrow_down: -0.8% |
| Get Child Programme TEs / Not found TE by name with like operator | 8 | 2.63 | 7 | 2.30 | -1 | :arrow_down: -12.5% |
| Get Child Programme TEs / Not found TE by name with eq operator | 5 | 2.63 | 5 | 2.30 | +0 | +0.0% |
| Get Child Programme TEs / Search TE by name with like operator | 28 | 2.63 | 31 | 2.30 | +3 | :arrow_up: +10.9% |
| Get Child Programme TEs / Search TE by name with eq operator | 20 | 2.63 | 24 | 2.30 | +4 | :arrow_up: +20.2% |
| Get Child Programme TEs / Search Birth events | 27 | 2.63 | 30 | 2.30 | +3 | :arrow_up: +10.9% |
| Get Child Programme TEs / Get TEs from events | 8 | 2.63 | 8 | 2.30 | +0 | +0.0% |
| Get Child Programme TEs / Get first page of TEs | 34 | 2.63 | 36 | 2.30 | +2 | :arrow_up: +5.9% |
| Get Child Programme TEs / Get TEs with enrollment status | 42 | 2.63 | 43 | 2.30 | +1 | :arrow_up: +2.5% |
| Login | 113 | 0.13 | 135 | 0.12 | +22 | :arrow_up: +19.1% |
| MNCH import | 105 | 0.26 | 103 | 0.23 | -2 | :arrow_down: -1.8% |
| Child Programme import | 67 | 0.26 | 73 | 0.23 | +6 | :arrow_up: +8.9% |
| ANC import | 37 | 0.26 | 68 | 0.23 | +32 | :arrow_up: +86.9% |

_:arrow_down: = faster, :arrow_up: = slower_

_Percentiles use the inclusive definition (e.g. p95 = X means 95% of requests responded in X ms or less) and are computed over OK + KO responses._

**Verdict:** Neutral — no measurable regression from the added data element-level ACL filtering. Under the (more stable) load test, read endpoints move within ±9% and imports are flat-to-faster (`ANC import` p95 564→169 ms). The large p50 spikes on the ANC event-list endpoints in the smoke run (`Go to first page`/`Go to second page`/`Search not assigned`, +392%) are a smoke-run artifact: their p95 is ~66 ms on both baseline and candidate, and the same endpoints are flat under load (p95 −4.3% / +1.6% / +0.1%), so this is baseline bimodality/noise rather than a regression.


[DHIS2-18466]: https://dhis2.atlassian.net/browse/DHIS2-18466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ