### PR TITLE
fix: avoid federated join inside Doris COMPLETENESS removeUpdatedData() DELETE

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
@@ -65,6 +65,8 @@ import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.dataapproval.DataApprovalLevelService;
+import org.hisp.dhis.db.model.Column;
+import org.hisp.dhis.db.model.Table;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.PeriodDataProvider;
@@ -178,40 +180,98 @@ public class JdbcCompletenessTableManager extends AbstractJdbcTableManager {
   @Override
   public void removeUpdatedData(List<AnalyticsTable> tables) {
     AnalyticsTablePartition partition = getLatestTablePartition(tables);
+
+    if (sqlBuilder.requiresUniqueKeyAnalyticsTables()) {
+      removeUpdatedDataViaStagingKeys(partition);
+    } else {
+      removeUpdatedDataViaSubquery(partition);
+    }
+  }
+
+  /**
+   * Removes updated and deleted data on databases which require a unique key for analytics tables
+   * (Doris). The equivalent single {@code delete ... using <federated table>} statement is avoided
+   * here because it joins a live federated table (the operational database's {@code
+   * completedatasetregistration}) against local tables inside a {@code delete}, which is
+   * dramatically slower than the same join shape used as a plain {@code select} (as {@link
+   * #populateTable} already does). Instead, the matching rows' {@code id} values are first
+   * materialized into a small native staging table via that proven-fast federated {@code select},
+   * and the actual delete runs entirely locally against that staging table. Unlike {@link
+   * JdbcAnalyticsTableManager}'s equivalent fix, only {@code id} is staged (no {@code year}) —
+   * {@code analytics_completeness} has no literal {@code pe}/{@code ou}/{@code ao} columns to match
+   * on naturally, and {@code id} alone (it embeds the period, which encodes the year) is confirmed
+   * sufficient to uniquely locate and delete the row regardless of which Doris partition it lives
+   * in.
+   */
+  private void removeUpdatedDataViaStagingKeys(AnalyticsTablePartition partition) {
+    String keysTableName = getAnalyticsTableType().getTableName() + "_delete_keys";
+    Table keysTable = new Table(keysTableName, List.of(new Column("id", VARCHAR_255)), List.of());
+
+    invokeTimeAndLog(
+        sqlBuilder.dropTableIfExistsCascade(keysTableName), "Drop delete-keys staging table (pre)");
+
+    invokeTimeAndLog(sqlBuilder.createTable(keysTable), "Create delete-keys staging table");
+
+    String insertSql =
+        replaceQualify(
+            sqlBuilder,
+            """
+            insert into ${keysTableName} (id) \
+            select concat(ds.uid,'-',ps.iso,'-',ous.organisationunituid,'-',acs.categoryoptioncombouid) \
+            from ${completedatasetregistration} cdr \
+            inner join ${dataset} ds on cdr.datasetid=ds.datasetid \
+            inner join analytics_rs_periodstructure ps on cdr.periodid=ps.periodid \
+            inner join analytics_rs_orgunitstructure ous on cdr.sourceid=ous.organisationunitid \
+            inner join analytics_rs_categorystructure acs on cdr.attributeoptioncomboid=acs.categoryoptioncomboid \
+            where cdr.lastupdated >= '${startDate}' and cdr.lastupdated < '${endDate}';""",
+            Map.of(
+                "keysTableName", quote(keysTableName),
+                "startDate", toLongDate(partition.getStartDate()),
+                "endDate", toLongDate(partition.getEndDate())));
+
+    invokeTimeAndLog(insertSql, "Populate delete-keys staging table");
+
+    String deleteSql =
+        replace(
+            """
+            delete from ${tableName} ax \
+            using ${keysTableName} k \
+            where ax.id=k.id;""",
+            Map.of(
+                "tableName", quote(getAnalyticsTableType().getTableName()),
+                "keysTableName", quote(keysTableName)));
+
+    invokeTimeAndLog(deleteSql, "Remove updated data values");
+
+    invokeTimeAndLog(
+        sqlBuilder.dropTableIfExistsCascade(keysTableName),
+        "Drop delete-keys staging table (post)");
+  }
+
+  /**
+   * Removes updated and deleted data on databases which do not require a unique key for analytics
+   * tables (Postgres, ClickHouse). Runs entirely against local tables, so the federated-join
+   * problem {@link #removeUpdatedDataViaStagingKeys} works around does not apply here.
+   */
+  private void removeUpdatedDataViaSubquery(AnalyticsTablePartition partition) {
     String sql =
-        sqlBuilder.requiresUniqueKeyAnalyticsTables()
-            ? replaceQualify(
-                sqlBuilder,
-                """
-                delete from ${tableName} ax \
-                using ${completedatasetregistration} cdr \
-                inner join ${dataset} ds on cdr.datasetid=ds.datasetid \
-                inner join analytics_rs_periodstructure ps on cdr.periodid=ps.periodid \
-                inner join analytics_rs_orgunitstructure ous on cdr.sourceid=ous.organisationunitid \
-                inner join analytics_rs_categorystructure acs on cdr.attributeoptioncomboid=acs.categoryoptioncomboid \
-                where ax.id = concat(ds.uid,'-',ps.iso,'-',ous.organisationunituid,'-',acs.categoryoptioncombouid) \
-                and cdr.lastupdated >= '${startDate}' and cdr.lastupdated < '${endDate}';""",
-                Map.of(
-                    "tableName", quote(getAnalyticsTableType().getTableName()),
-                    "startDate", toLongDate(partition.getStartDate()),
-                    "endDate", toLongDate(partition.getEndDate())))
-            : replaceQualify(
-                sqlBuilder,
-                """
-                delete from ${tableName} ax \
-                where ax.id in ( \
-                select concat(ds.uid,'-',ps.iso,'-',ous.organisationunituid,'-',acs.categoryoptioncombouid) as id \
-                from ${completedatasetregistration} cdr \
-                inner join ${dataset} ds on cdr.datasetid=ds.datasetid \
-                inner join analytics_rs_periodstructure ps on cdr.periodid=ps.periodid \
-                inner join analytics_rs_orgunitstructure ous on cdr.sourceid=ous.organisationunitid \
-                inner join analytics_rs_categorystructure acs on cdr.attributeoptioncomboid=acs.categoryoptioncomboid \
-                where cdr.lastupdated >= '${startDate}' \
-                and cdr.lastupdated < '${endDate}');""",
-                Map.of(
-                    "tableName", quote(getAnalyticsTableType().getTableName()),
-                    "startDate", toLongDate(partition.getStartDate()),
-                    "endDate", toLongDate(partition.getEndDate())));
+        replaceQualify(
+            sqlBuilder,
+            """
+            delete from ${tableName} ax \
+            where ax.id in ( \
+            select concat(ds.uid,'-',ps.iso,'-',ous.organisationunituid,'-',acs.categoryoptioncombouid) as id \
+            from ${completedatasetregistration} cdr \
+            inner join ${dataset} ds on cdr.datasetid=ds.datasetid \
+            inner join analytics_rs_periodstructure ps on cdr.periodid=ps.periodid \
+            inner join analytics_rs_orgunitstructure ous on cdr.sourceid=ous.organisationunitid \
+            inner join analytics_rs_categorystructure acs on cdr.attributeoptioncomboid=acs.categoryoptioncomboid \
+            where cdr.lastupdated >= '${startDate}' \
+            and cdr.lastupdated < '${endDate}');""",
+            Map.of(
+                "tableName", quote(getAnalyticsTableType().getTableName()),
+                "startDate", toLongDate(partition.getStartDate()),
+                "endDate", toLongDate(partition.getEndDate())));
 
     invokeTimeAndLog(sql, "Remove updated data values");
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManagerDorisTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManagerDorisTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -156,7 +157,7 @@ class JdbcCompletenessTableManagerDorisTest {
   }
 
   @Test
-  void testRemoveUpdatedDataUsesUsingJoinNotSubquery() {
+  void testRemoveUpdatedDataMaterializesKeysNatively() {
     Date lastFullTableUpdate = new DateTime(2019, 3, 1, 2, 0).toDate();
     Date lastLatestPartitionUpdate = new DateTime(2019, 3, 1, 9, 0).toDate();
     Date startTime = new DateTime(2019, 3, 1, 10, 0).toDate();
@@ -178,10 +179,52 @@ class JdbcCompletenessTableManagerDorisTest {
     subject.removeUpdatedData(tables);
 
     ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
-    verify(jdbcTemplate).execute(sql.capture());
+    verify(jdbcTemplate, times(5)).execute(sql.capture());
+    List<String> statements = sql.getAllValues();
 
-    assertTrue(sql.getValue().contains("using"));
-    assertTrue(sql.getValue().contains("ax.id ="));
-    assertTrue(!sql.getValue().contains("in ("));
+    String drop1 = statements.get(0);
+    assertTrue(drop1.toLowerCase().contains("drop table if exists"));
+    assertTrue(drop1.contains("analytics_completeness_delete_keys"));
+
+    String create = statements.get(1);
+    assertTrue(create.toLowerCase().contains("create table"));
+    assertTrue(create.contains("analytics_completeness_delete_keys"));
+    assertTrue(create.contains("`id`"));
+    assertTrue(
+        create.contains("varchar(1020)"),
+        () -> "Expected staging id column to use a bounded varchar type, got: " + create);
+    assertFalse(
+        create.contains("`id` string"),
+        () -> "Staging id column must not use the unbounded string type, got: " + create);
+
+    String insert = statements.get(2);
+    assertTrue(insert.toLowerCase().contains("insert into"));
+    assertTrue(insert.contains("analytics_completeness_delete_keys"));
+    assertTrue(insert.contains("completedatasetregistration"));
+    assertTrue(insert.contains("analytics_rs_periodstructure"));
+    assertTrue(insert.contains("analytics_rs_orgunitstructure"));
+    assertTrue(insert.contains("analytics_rs_categorystructure"));
+    assertTrue(
+        insert.contains(
+            "concat(ds.uid,'-',ps.iso,'-',ous.organisationunituid,'-',acs.categoryoptioncombouid)"),
+        () -> "Expected the id concat expression in the staging select, got: " + insert);
+    assertTrue(insert.contains("cdr.lastupdated >="));
+    assertTrue(insert.contains("cdr.lastupdated <"));
+
+    String delete = statements.get(3);
+    assertTrue(delete.toLowerCase().contains("delete from"));
+    assertTrue(delete.toLowerCase().contains("using"));
+    assertTrue(delete.contains("analytics_completeness_delete_keys"));
+    assertTrue(delete.contains("ax.id=k.id"));
+    assertFalse(
+        delete.contains("completedatasetregistration"),
+        () -> "Delete statement must not reference the federated table, got: " + delete);
+    assertFalse(
+        delete.contains("analytics_rs_"),
+        () -> "Delete statement must not reference federated join tables, got: " + delete);
+
+    String drop2 = statements.get(4);
+    assertTrue(drop2.toLowerCase().contains("drop table"));
+    assertTrue(drop2.contains("analytics_completeness_delete_keys"));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManagerTest.java
@@ -29,23 +29,94 @@
  */
 package org.hisp.dhis.analytics.table;
 
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.hisp.dhis.period.PeriodType.PERIOD_TYPES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.hisp.dhis.analytics.AnalyticsTableHookService;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
+import org.hisp.dhis.analytics.partition.PartitionManager;
+import org.hisp.dhis.analytics.table.model.AnalyticsTable;
+import org.hisp.dhis.analytics.table.setting.AnalyticsTableSettings;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.configuration.Configuration;
+import org.hisp.dhis.configuration.ConfigurationService;
+import org.hisp.dhis.dataapproval.DataApprovalLevelService;
 import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.period.PeriodDataProvider;
+import org.hisp.dhis.resourcetable.ResourceTableService;
+import org.hisp.dhis.setting.SystemSettings;
+import org.hisp.dhis.setting.SystemSettingsProvider;
 import org.hisp.dhis.util.DateUtils;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class JdbcCompletenessTableManagerTest {
+  @Mock private IdentifiableObjectManager idObjectManager;
+
+  @Mock private OrganisationUnitService organisationUnitService;
+
+  @Mock private CategoryService categoryService;
+
+  @Mock private SystemSettingsProvider settingsProvider;
+
+  @Mock private SystemSettings settings;
+
+  @Mock private DataApprovalLevelService dataApprovalLevelService;
+
+  @Mock private ResourceTableService resourceTableService;
+
+  @Mock private AnalyticsTableHookService analyticsTableHookService;
+
+  @Mock private PartitionManager partitionManager;
+
+  @Mock private JdbcTemplate jdbcTemplate;
+
+  @Mock private AnalyticsTableSettings analyticsTableSettings;
+
+  @Mock private PeriodDataProvider periodDataProvider;
+
+  @Mock private ConfigurationService configurationService;
+
+  @Mock private Configuration configuration;
+
   @Spy private SqlBuilder sqlBuilder = new PostgreSqlBuilder();
 
   @InjectMocks private JdbcCompletenessTableManager manager;
+
+  @BeforeEach
+  void setUp() {
+    when(settingsProvider.getCurrentSettings()).thenReturn(settings);
+    when(settings.getLastSuccessfulResourceTablesUpdate()).thenReturn(new Date(0L));
+    when(configurationService.getConfiguration()).thenReturn(configuration);
+    when(configuration.getDataOutputPeriodTypes())
+        .thenReturn(PERIOD_TYPES.stream().collect(toUnmodifiableSet()));
+  }
 
   @Test
   void testGetDataYearsQueryWithLastYears() {
@@ -67,5 +138,47 @@ class JdbcCompletenessTableManagerTest {
         """;
 
     assertEquals(expected, manager.getDataYearsQuery(params));
+  }
+
+  @Test
+  void testRemoveUpdatedDataUsesSubqueryDeleteForPostgres() {
+    Date lastFullTableUpdate = new DateTime(2019, 3, 1, 2, 0).toDate();
+    Date lastLatestPartitionUpdate = new DateTime(2019, 3, 1, 9, 0).toDate();
+    Date startTime = new DateTime(2019, 3, 1, 10, 0).toDate();
+
+    AnalyticsTableUpdateParams params =
+        AnalyticsTableUpdateParams.newBuilder().startTime(startTime).build().withLatestPartition();
+
+    List<Map<String, Object>> queryResp = new ArrayList<>();
+    queryResp.add(Map.of("datasetid", 1));
+
+    when(settings.getLastSuccessfulAnalyticsTablesUpdate()).thenReturn(lastFullTableUpdate);
+    when(settings.getLastSuccessfulLatestAnalyticsPartitionUpdate())
+        .thenReturn(lastLatestPartitionUpdate);
+    when(jdbcTemplate.queryForList(anyString())).thenReturn(queryResp);
+
+    List<AnalyticsTable> tables = manager.getAnalyticsTables(params);
+    assertEquals(1, tables.size());
+
+    manager.removeUpdatedData(tables);
+
+    ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+    verify(jdbcTemplate, times(1)).execute(sql.capture());
+
+    String delete = sql.getValue();
+    assertTrue(delete.toLowerCase().contains("delete from"));
+    assertTrue(delete.contains("where ax.id in ("));
+    assertTrue(
+        delete.contains(
+            "select concat(ds.uid,'-',ps.iso,'-',ous.organisationunituid,'-',acs.categoryoptioncombouid) as id"));
+    assertTrue(delete.contains("completedatasetregistration"));
+    assertTrue(delete.contains("cdr.lastupdated >="));
+    assertTrue(delete.contains("cdr.lastupdated <"));
+    assertFalse(
+        delete.toLowerCase().contains("using"),
+        () ->
+            "Postgres path must use the subquery delete, not the Doris staging-keys using-join"
+                + " delete, got: "
+                + delete);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManagerTest.java
@@ -32,8 +32,6 @@ package org.hisp.dhis.analytics.table;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.hisp.dhis.period.PeriodType.PERIOD_TYPES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -166,19 +164,10 @@ class JdbcCompletenessTableManagerTest {
     verify(jdbcTemplate, times(1)).execute(sql.capture());
 
     String delete = sql.getValue();
-    assertTrue(delete.toLowerCase().contains("delete from"));
-    assertTrue(delete.contains("where ax.id in ("));
-    assertTrue(
-        delete.contains(
-            "select concat(ds.uid,'-',ps.iso,'-',ous.organisationunituid,'-',acs.categoryoptioncombouid) as id"));
-    assertTrue(delete.contains("completedatasetregistration"));
-    assertTrue(delete.contains("cdr.lastupdated >="));
-    assertTrue(delete.contains("cdr.lastupdated <"));
-    assertFalse(
-        delete.toLowerCase().contains("using"),
-        () ->
-            "Postgres path must use the subquery delete, not the Doris staging-keys using-join"
-                + " delete, got: "
-                + delete);
+    String expected =
+        """
+        delete from "analytics_completeness" ax where ax.id in ( select concat(ds.uid,'-',ps.iso,'-',ous.organisationunituid,'-',acs.categoryoptioncombouid) as id from "completedatasetregistration" cdr inner join "dataset" ds on cdr.datasetid=ds.datasetid inner join analytics_rs_periodstructure ps on cdr.periodid=ps.periodid inner join analytics_rs_orgunitstructure ous on cdr.sourceid=ous.organisationunitid inner join analytics_rs_categorystructure acs on cdr.attributeoptioncomboid=acs.categoryoptioncomboid where cdr.lastupdated >= '2019-03-01T02:00:00' and cdr.lastupdated < '2019-03-01T10:00:00');""";
+
+    assertEquals(expected, delete);
   }
 }


### PR DESCRIPTION
## Summary
- Same federated-join-inside-DELETE bug already fixed for DATA_VALUE and EVENT on #24440, now fixed for COMPLETENESS.
- Stages matching `id` values into a small native table via a plain SELECT (fast), then deletes locally against that staging table — no federated join inside the DELETE anymore.
- Unlike DATA_VALUE/EVENT, only `id` is staged (no `year`): `analytics_completeness` has no literal `pe`/`ou`/`ao` columns to match on naturally, and `id` alone was live-confirmed sufficient (it embeds the period, which encodes the year) — Doris correctly finds and deletes the row regardless of partition.
- Postgres/ClickHouse behavior unchanged (verified byte-for-byte identical to the pre-change SQL, and now regression-tested).

## Test plan
- [x] Unit tests pass: `JdbcCompletenessTableManagerDorisTest`, `JdbcCompletenessTableManagerTest` (2066/2066 module suite green)
- [x] Spotless clean
- [x] Live-validated on the Doris test instance: real completeness create/update/un-complete cycle through the continuous-analytics job (not a hand-typed DELETE), against a dataset spanning two years/partitions
  - Update batch (rows with bumped `lastupdated`, still complete): purged then correctly re-merged in both years (188/188, 12/12)
  - "Un-complete" batch (bumped `lastupdated`, `completed=false`): purged and correctly *not* re-merged in both years (169/0, 31/0)
  - Confirms the `DELETE ... USING` staging-key form is correct across a partition boundary with no `year` in the predicate
  - Fast: remove-updated-data in 0.196s, whole table update in 1.178s — no federated-join hang