### PR TITLE
fix: no data for subExpression single value [DHIS2-19094]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
@@ -238,6 +238,11 @@ public class JdbcSubexpressionQueryGenerator {
     String subexItemColumns =
         subex.getItems().stream().map(this::getItemSql).distinct().collect(joining(","));
 
+    // Dimensions can be empty if the query is a Single Value query.
+    if (StringUtils.isBlank(dimensionColumns)) {
+      return "select " + subexItemColumns + " ";
+    }
+
     return "select " + dimensionColumns + ", " + subexItemColumns + " ";
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGeneratorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGeneratorTest.java
@@ -248,6 +248,82 @@ class JdbcSubexpressionQueryGeneratorTest {
     assertEquals(expected, actual.trim());
   }
 
+  @Test
+  void testGetSql_withoutQueryDimensions() {
+    OrganisationUnit ouA = createOrganisationUnit('A');
+
+    PeriodDimension peA = PeriodDimension.of(createPeriod("202305"));
+
+    QueryModifiers queryModsMin = QueryModifiers.builder().aggregationType(MIN).build();
+
+    DataElement deA = createDataElement('A');
+    DataElement deB = createDataElement('B');
+    DataElement deC = createDataElement('C');
+    DataElement deD = createDataElement('D');
+    DataElement deE = createDataElement('E');
+
+    deE.setQueryMods(queryModsMin);
+
+    CategoryOptionCombo cocA = createCategoryOptionCombo('A');
+    CategoryOptionCombo cocB = createCategoryOptionCombo('B');
+    CategoryOptionCombo cocC = createCategoryOptionCombo('C');
+    CategoryOptionCombo cocD = createCategoryOptionCombo('D');
+
+    DataElementOperand deoA = new DataElementOperand(deB, cocA);
+    DataElementOperand deoB = new DataElementOperand(deC, cocB, cocC);
+    DataElementOperand deoC = new DataElementOperand(deD, null, cocD);
+
+    List<DimensionalItemObject> items = List.of(deA, deoA, deoB, deoC, deE);
+
+    String deACol = getItemColumnName(deA.getUid(), null, null, null);
+    String deoACol = getItemColumnName(deB.getUid(), cocA.getUid(), null, null);
+    String deoBCol = getItemColumnName(deC.getUid(), cocB.getUid(), cocC.getUid(), null);
+    String deoCCol = getItemColumnName(deD.getUid(), null, cocD.getUid(), null);
+    String deECol = getItemColumnName(deE.getUid(), null, null, queryModsMin);
+
+    String subexSql = deACol + "*(" + deoACol + "+" + deoBCol + ")+" + deoCCol + "-" + deECol;
+
+    SubexpressionDimensionItem subex = new SubexpressionDimensionItem(subexSql, items, null);
+
+    DataQueryParams params =
+        DataQueryParams.newBuilder()
+            .withDataType(DataType.NUMERIC)
+            .withTableName("analytics")
+            .withAggregationType(AnalyticsAggregationType.SUM)
+            .addDimension(
+                new BaseDimensionalObject(DATA_X_DIM_ID, DimensionType.DATA_X, getList(subex)))
+            .addFilters(
+                List.of(
+                    new BaseDimensionalObject(
+                        ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, getList(ouA)),
+                    new BaseDimensionalObject(PERIOD_DIM_ID, DimensionType.PERIOD, getList(peA))))
+            .withPeriodType("monthly")
+            .build();
+
+    JdbcSubexpressionQueryGenerator target =
+        new JdbcSubexpressionQueryGenerator(manager, params, DATA_VALUE);
+
+    String expected =
+        "select 'subexprxUID' as \"dx\","
+            + "sum(\"deabcdefghA\"*(\"deabcdefghB_cuabcdefghA\"+\"deabcdefghC_cuabcdefghB_cuabcdefghC\")+\"deabcdefghD__cuabcdefghD\"-\"deabcdefghE_agg_MIN\") as \"value\" "
+            + "from (select "
+            + "sum(case when ax.\"dx\"='deabcdefghA' then \"value\"::numeric else null end) as \"deabcdefghA\","
+            + "sum(case when ax.\"dx\"='deabcdefghB' and ax.\"co\"='cuabcdefghA' then \"value\"::numeric else null end) as \"deabcdefghB_cuabcdefghA\","
+            + "sum(case when ax.\"dx\"='deabcdefghC' and ax.\"co\"='cuabcdefghB' and ax.\"ao\"='cuabcdefghC' then \"value\"::numeric else null end) as \"deabcdefghC_cuabcdefghB_cuabcdefghC\","
+            + "sum(case when ax.\"dx\"='deabcdefghD' and ax.\"ao\"='cuabcdefghD' then \"value\"::numeric else null end) as \"deabcdefghD__cuabcdefghD\","
+            + "min(case when ax.\"dx\"='deabcdefghE' then \"value\"::numeric else null end) as \"deabcdefghE_agg_MIN\" "
+            + "from analytics as ax "
+            + "where ( ax.\"pe\" in ('202305') ) "
+            + "and ( ax.\"ou\" in ('ouabcdefghA') ) "
+            + "and ax.\"dx\" in ('deabcdefghA','deabcdefghB','deabcdefghC','deabcdefghD','deabcdefghE')  "
+            + "group by ax.\"monthly\",ax.\"ou\") as ax "
+            + "where \"deabcdefghA\"*(\"deabcdefghB_cuabcdefghA\"+\"deabcdefghC_cuabcdefghB_cuabcdefghC\")+\"deabcdefghD__cuabcdefghD\"-\"deabcdefghE_agg_MIN\" is not null ";
+
+    String actual = anonymize(target.getSql());
+
+    assertEquals(expected, actual);
+  }
+
   // -------------------------------------------------------------------------
   // Supportive methods
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv15AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv15AutoTest.java
@@ -42,6 +42,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.hisp.dhis.AnalyticsApiTest;
 import org.hisp.dhis.test.e2e.actions.RestApiActions;
+import org.hisp.dhis.test.e2e.dependsOn.DependsOn;
+import org.hisp.dhis.test.e2e.dependsOn.Resource;
 import org.hisp.dhis.test.e2e.dto.ApiResponse;
 import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
 import org.json.JSONException;
@@ -132,6 +134,44 @@ public class AnalyticsQueryDv15AutoTest extends AnalyticsApiTest {
         .body(
             "message",
             equalTo("Periods as filter not supported with Indicator with period offset"));
+  }
+
+  @Test
+  @EnabledIf(value = "isPostgres", disabledReason = "subExpressions are only supported in Postgres")
+  @DependsOn(
+      files = {"ind-subexpression-no-offset.json"},
+      delete = true)
+  public void subExpressionIndicatorWithPeriodAndOrgUnitAsFilter(List<Resource> dependencies) {
+    String indicatorUid = dependencies.get(0).uid();
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("filter=ou:Rp268JB6Ne4;cDw53Ej8rju;iPcreOldeV9;jjtzkzrmG7s,pe:2021")
+            .add("skipData=false")
+            .add("includeNumDen=false")
+            .add("displayProperty=NAME")
+            .add("skipMeta=true")
+            .add("dimension=dx:" + indicatorUid);
+
+    // When
+    ApiResponse response = actions.get(params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(2)))
+        .body("rows", hasSize(equalTo(1)))
+        .body("height", equalTo(1))
+        .body("width", equalTo(2));
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, true);
+    validateHeader(response, 1, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+
+    // Assert rows. Three of the four facilities reported ANC 1st visit in 2021.
+    validateRow(response, List.of(indicatorUid, "3.0"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/resources/dependencies/ind-subexpression-no-offset.json
+++ b/dhis-2/dhis-test-e2e/src/test/resources/dependencies/ind-subexpression-no-offset.json
@@ -1,0 +1,14 @@
+{
+  "type": "indicator",
+  "code": "SUBEXPNOOFFSET",
+  "name": "Facilities reporting ANC 1st visit",
+  "shortName": "Facilities reporting ANC 1st",
+  "numeratorDescription": "Facilities reporting ANC 1st visit",
+  "numerator": "subExpression(if(#{fbfJHSPpUQD} > 0, 1, 0))",
+  "denominatorDescription": "One",
+  "denominator": "1",
+  "indicatorType": {
+    "id": "JkWynlWMjJR"
+  },
+  "legendSets": []
+}


### PR DESCRIPTION
## Summary

Indicators whose numerator uses `subExpression(...)` returned no data in Single Value and Gauge charts. Those two chart types are the only ones that put **both** period and org unit in the filter position, which left the subexpression query with no query dimensions.

`JdbcSubexpressionQueryGenerator.getSelectSubquery()` built the inner select unconditionally as `"select " + dimensionColumns + ", " + subexItemColumns`, so with no dimensions it emitted `select , sum(...)`. 
The resulting `BadSqlGrammarException` is swallowed by `JdbcAnalyticsManager`'s
silent fallback and turned into an empty result — hence "no data" with no visible error, unnoticed since 2.41.

The outer `getSelect()` already guarded this exact case; the subquery simply never got the same guard. This adds it.