### PR TITLE
chore: batch user stats queries and rework sessions API

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -113,4 +113,10 @@ public interface CacheProvider {
   <V> Cache<V> createCorsWhitelistCache();
 
   <V> Cache<V> createNotificationTemplateCache();
+
+  <V> Cache<V> createSystemStatisticsOverviewCache();
+
+  <V> Cache<V> createSystemStatisticsDataCountsCache();
+
+  <V> Cache<V> createDataSummarySessionGaugesCache();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/cache/Region.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/cache/Region.java
@@ -69,6 +69,7 @@ public enum Region {
   queryAliasCache,
   corsWhitelistCache,
   notificationTemplateCache,
-  systemStatisticsSummary,
+  systemStatisticsOverview,
+  systemStatisticsDataCounts,
   dataSummarySessionGauges
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/cache/Region.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/cache/Region.java
@@ -68,5 +68,7 @@ public enum Region {
   dataIntegrityDetailsCache,
   queryAliasCache,
   corsWhitelistCache,
-  notificationTemplateCache
+  notificationTemplateCache,
+  systemStatisticsSummary,
+  dataSummarySessionGauges
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsEventStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsEventStore.java
@@ -50,6 +50,16 @@ public interface DataStatisticsEventStore extends GenericStore<DataStatisticsEve
   Map<DataStatisticsEventType, Long> getDataStatisticsEventCount(Date startDate, Date endDate);
 
   /**
+   * Returns the number of distinct usernames with at least one recorded event between each of the
+   * given start dates and the given end date. All counts are computed in a single query.
+   *
+   * @param startDates the window start dates.
+   * @param endDate the common end date of all windows.
+   * @return the distinct user counts in the same order as the given start dates.
+   */
+  List<Integer> getDistinctActiveUserCounts(List<Date> startDates, Date endDate);
+
+  /**
    * Returns top favorites by views
    *
    * @param eventType that should be counted

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsService.java
@@ -119,10 +119,4 @@ public interface DataStatisticsService {
    * @return a DataSummary with only the data count fields populated.
    */
   DataSummary getSystemStatisticsDataCounts();
-
-  /**
-   * Clears the cached system statistics (overview and data counts) so the next call recomputes
-   * them. Intended for tests.
-   */
-  void clearSystemStatisticsSummaryCache();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsService.java
@@ -95,15 +95,34 @@ public interface DataStatisticsService {
   FavoriteStatistics getFavoriteStatistics(String uid);
 
   /**
-   * Returns a DataSummary instance with Data Statistics about System.
+   * Returns a DataSummary instance with the full system statistics: the overview and the data
+   * counts combined. See {@link #getSystemStatisticsOverview()} and {@link
+   * #getSystemStatisticsDataCounts()}.
    *
    * @return a DataSummary instance with Data Statistics about System.
    */
   DataSummary getSystemStatisticsSummary();
 
   /**
-   * Clears the cached system statistics summary so the next call to {@link
-   * #getSystemStatisticsSummary()} recomputes it. Intended for tests.
+   * Returns the cheap part of the system statistics: object counts (approximate for the large data
+   * tables), logins, active users, user invitations and system info. Safe to compute frequently.
+   *
+   * @return a DataSummary with only the overview fields populated.
+   */
+  DataSummary getSystemStatisticsOverview();
+
+  /**
+   * Returns the expensive part of the system statistics: exact, windowed count queries over the
+   * largest tables (data values, tracker events, single events, enrollments). Cached for longer
+   * than the overview since these queries can be very costly on large databases.
+   *
+   * @return a DataSummary with only the data count fields populated.
+   */
+  DataSummary getSystemStatisticsDataCounts();
+
+  /**
+   * Clears the cached system statistics (overview and data counts) so the next call recomputes
+   * them. Intended for tests.
    */
   void clearSystemStatisticsSummaryCache();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsService.java
@@ -100,4 +100,10 @@ public interface DataStatisticsService {
    * @return a DataSummary instance with Data Statistics about System.
    */
   DataSummary getSystemStatisticsSummary();
+
+  /**
+   * Clears the cached system statistics summary so the next call to {@link
+   * #getSystemStatisticsSummary()} recomputes it. Intended for tests.
+   */
+  void clearSystemStatisticsSummaryCache();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -329,19 +329,13 @@ public interface UserService {
   void setLastLogin(String username);
 
   /**
-   * Returns the number of active users since the given number of days.
+   * Returns the number of users whose last login is on or after each of the given dates. All counts
+   * are computed in a single query.
    *
-   * @param days the number of days.
+   * @param sinceDates the last login cutoff dates.
+   * @return the user counts in the same order as the given dates.
    */
-  int getActiveUsersCount(int days);
-
-  /**
-   * Returns the number of active users since the given date.
-   *
-   * @param since the date to check for active users.
-   * @return the number of active users since the given date.
-   */
-  int getActiveUsersCount(Date since);
+  List<Integer> getActiveUsersCounts(List<Date> sinceDates);
 
   /**
    * Checks if the user account is not expired.
@@ -573,7 +567,19 @@ public interface UserService {
   List<SessionInformation> listSessions(UserDetails principal);
 
   /**
-   * Invalidate all sessions for all users WARNING: This does not work when using Redis sessions.
+   * Lists every session known to the session registry, including expired sessions.
+   *
+   * <p>Works for both the in-memory registry and the Redis-backed registry. Under Redis, principals
+   * are resolved from usernames rather than {@code SessionRegistry#getAllPrincipals()}, which is
+   * unsupported there.
+   *
+   * @return all session information entries
+   */
+  List<SessionInformation> listAllSessions();
+
+  /**
+   * Invalidate all sessions for all users. Works for both in-memory and Redis-backed session
+   * registries.
    */
   void invalidateAllSessions();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -83,6 +83,15 @@ public interface UserStore extends IdentifiableObjectStore<User> {
    */
   int getUserCount();
 
+  /**
+   * Returns the number of users whose last login is on or after each of the given dates. All counts
+   * are computed in a single query.
+   *
+   * @param sinceDates the last login cutoff dates.
+   * @return the user counts in the same order as the given dates.
+   */
+  List<Integer> getActiveUserCounts(List<Date> sinceDates);
+
   List<User> getExpiringUsers(UserQueryParams userQueryParams);
 
   /**
@@ -172,6 +181,14 @@ public interface UserStore extends IdentifiableObjectStore<User> {
    * @return a list of usernames.
    */
   List<String> getUsernamesByUserRole(@Nonnull UID roleUid);
+
+  /**
+   * Returns all usernames in the system. Cheap projection used when the session registry cannot
+   * enumerate principals (for example Redis-backed Spring Session).
+   *
+   * @return a list of all usernames
+   */
+  List<String> getAllUsernames();
 
   /**
    * Retrieves the most recently-used enabled User associated with the given open ID.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -183,8 +183,7 @@ public interface UserStore extends IdentifiableObjectStore<User> {
   List<String> getUsernamesByUserRole(@Nonnull UID roleUid);
 
   /**
-   * Returns all usernames in the system. Cheap projection used when the session registry cannot
-   * enumerate principals (for example Redis-backed Spring Session).
+   * Returns all usernames in the system.
    *
    * @return a list of all usernames
    */

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -644,19 +644,8 @@ public class DefaultUserService implements UserService {
 
   @Override
   @Transactional(readOnly = true)
-  public int getActiveUsersCount(int days) {
-    Calendar cal = PeriodType.createCalendarInstance();
-    cal.add(Calendar.DAY_OF_YEAR, (days * -1));
-
-    return getActiveUsersCount(cal.getTime());
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public int getActiveUsersCount(Date since) {
-    UserQueryParams params = new UserQueryParams();
-    params.setLastLogin(since);
-    return getUserCount(params);
+  public List<Integer> getActiveUsersCounts(List<Date> sinceDates) {
+    return userStore.getActiveUserCounts(sinceDates);
   }
 
   @Override
@@ -1027,10 +1016,18 @@ public class DefaultUserService implements UserService {
   }
 
   @Override
+  @Transactional(readOnly = true)
+  public List<SessionInformation> listAllSessions() {
+    return getAllSessionPrincipals().stream()
+        .flatMap(principal -> sessionRegistry.getAllSessions(principal, true).stream())
+        .toList();
+  }
+
+  @Override
   public void invalidateAllSessions() {
-    for (Object allPrincipal : sessionRegistry.getAllPrincipals()) {
-      for (SessionInformation allSession : sessionRegistry.getAllSessions(allPrincipal, true)) {
-        sessionRegistry.removeSessionInformation(allSession.getSessionId());
+    for (Object principal : getAllSessionPrincipals()) {
+      for (SessionInformation session : sessionRegistry.getAllSessions(principal, true)) {
+        sessionRegistry.removeSessionInformation(session.getSessionId());
       }
     }
   }
@@ -1043,6 +1040,21 @@ public class DefaultUserService implements UserService {
     List<SessionInformation> sessions =
         sessionRegistry.getAllSessions(sessionLookupPrincipal(username), false);
     sessions.forEach(SessionInformation::expireNow);
+  }
+
+  /**
+   * Returns every principal currently known to the session registry. Tries {@link
+   * SessionRegistry#getAllPrincipals()} first; when that is unsupported (Redis-backed Spring
+   * Session registry), falls back to looking up sessions by username for every user in the system.
+   */
+  private List<Object> getAllSessionPrincipals() {
+    try {
+      return List.copyOf(sessionRegistry.getAllPrincipals());
+    } catch (UnsupportedOperationException ex) {
+      return userStore.getAllUsernames().stream()
+          .map(username -> (Object) sessionLookupPrincipal(username))
+          .toList();
+    }
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -640,6 +640,11 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
   }
 
   @Override
+  public List<String> getAllUsernames() {
+    return getSession().createQuery("select u.username from User u", String.class).list();
+  }
+
+  @Override
   public void setActiveLinkedAccounts(
       @Nonnull String actingUsername, @Nonnull String activeUsername) {
 
@@ -950,6 +955,36 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
           attrUid.getValue(),
           userUid.getValue());
     }
+  }
+
+  @Override
+  public List<Integer> getActiveUserCounts(List<Date> sinceDates) {
+    if (sinceDates.isEmpty()) {
+      return List.of();
+    }
+    StringBuilder sql = new StringBuilder("select ");
+    for (int i = 0; i < sinceDates.size(); i++) {
+      if (i > 0) {
+        sql.append(", ");
+      }
+      sql.append("count(*) filter (where lastlogin >= ?) as c").append(i);
+    }
+    sql.append(" from userinfo");
+    return jdbcTemplate.query(
+        sql.toString(),
+        ps -> {
+          for (int i = 0; i < sinceDates.size(); i++) {
+            ps.setTimestamp(i + 1, new java.sql.Timestamp(sinceDates.get(i).getTime()));
+          }
+        },
+        rs -> {
+          rs.next();
+          List<Integer> counts = new ArrayList<>(sinceDates.size());
+          for (int i = 0; i < sinceDates.size(); i++) {
+            counts.add(rs.getInt(i + 1));
+          }
+          return counts;
+        });
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -39,14 +39,11 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.analytics.SortOrder;
 import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.cache.SimpleCacheBuilder;
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.common.Dhis2Info;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.cache.Region;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.datasummary.DataSummary;
 import org.hisp.dhis.datavalue.DataValueService;
@@ -71,7 +68,6 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Yrjan A. F. Fraschetti
  * @author Julie Hill Roa
  */
-@RequiredArgsConstructor
 @Service("org.hisp.dhis.datastatistics.DataStatisticsService")
 @Transactional
 public class DefaultDataStatisticsService implements DataStatisticsService {
@@ -91,7 +87,45 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
 
   private final SystemService systemService;
 
+  /**
+   * The system statistics overview covers object counts (approximate counts for the large data
+   * tables), logins, active users, user invitations and system info. These queries are cheap, but
+   * the result is still cached briefly so aggressive or misbehaving monitoring scrapers are bounded
+   * to one computation per TTL window, regardless of request rate.
+   */
+  private final Cache<DataSummary> overviewCache;
+
+  /**
+   * The data counts run exact, windowed count queries over the largest tables (data values, tracker
+   * events, single events, enrollments), which can be very expensive on databases with a lot of
+   * data. The result is therefore cached considerably longer than the overview; these counts move
+   * slowly and 30 minutes of staleness is acceptable.
+   */
+  private final Cache<DataSummary> dataCountsCache;
+
   static final ZoneId SERVER_ZONE = ZoneId.systemDefault();
+
+  public DefaultDataStatisticsService(
+      DataStatisticsStore dataStatisticsStore,
+      DataStatisticsEventStore dataStatisticsEventStore,
+      UserService userService,
+      IdentifiableObjectManager idObjectManager,
+      DataValueService dataValueService,
+      StatisticsProvider statisticsProvider,
+      EventVisualizationStore eventVisualizationStore,
+      SystemService systemService,
+      CacheProvider cacheProvider) {
+    this.dataStatisticsStore = dataStatisticsStore;
+    this.dataStatisticsEventStore = dataStatisticsEventStore;
+    this.userService = userService;
+    this.idObjectManager = idObjectManager;
+    this.dataValueService = dataValueService;
+    this.statisticsProvider = statisticsProvider;
+    this.eventVisualizationStore = eventVisualizationStore;
+    this.systemService = systemService;
+    this.overviewCache = cacheProvider.createSystemStatisticsOverviewCache();
+    this.dataCountsCache = cacheProvider.createSystemStatisticsDataCountsCache();
+  }
 
   // -------------------------------------------------------------------------
   // DataStatisticsService implementation
@@ -209,43 +243,8 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
   }
 
   /**
-   * The system statistics overview covers object counts (approximate counts for the large data
-   * tables), logins, active users, user invitations and system info. These queries are cheap, but
-   * the result is still cached briefly so aggressive or misbehaving monitoring scrapers are
-   * bounded to one computation per TTL window, regardless of request rate.
-   */
-  private static final Cache<DataSummary> OVERVIEW_CACHE =
-      new SimpleCacheBuilder<DataSummary>()
-          .forRegion(Region.systemStatisticsOverview.name())
-          .expireAfterWrite(5, TimeUnit.MINUTES)
-          .withInitialCapacity(1)
-          .withMaximumSize(1)
-          .build();
-
-  /**
-   * The data counts run exact, windowed count queries over the largest tables (data values,
-   * tracker events, single events, enrollments), which can be very expensive on databases with a
-   * lot of data. The result is therefore cached considerably longer than the overview; these
-   * counts move slowly and 30 minutes of staleness is acceptable.
-   */
-  private static final Cache<DataSummary> DATA_COUNTS_CACHE =
-      new SimpleCacheBuilder<DataSummary>()
-          .forRegion(Region.systemStatisticsDataCounts.name())
-          .expireAfterWrite(30, TimeUnit.MINUTES)
-          .withInitialCapacity(1)
-          .withMaximumSize(1)
-          .build();
-
-  /** Clears the cached system statistics (overview and data counts). Intended for tests only. */
-  @Override
-  public void clearSystemStatisticsSummaryCache() {
-    OVERVIEW_CACHE.invalidateAll();
-    DATA_COUNTS_CACHE.invalidateAll();
-  }
-
-  /**
    * Returns the full system statistics summary, composed of the cached overview (see {@link
-   * #OVERVIEW_CACHE}) and the cached data counts (see {@link #DATA_COUNTS_CACHE}).
+   * #overviewCache}) and the cached data counts (see {@link #dataCountsCache}).
    *
    * @return A DataSummary object containing the system statistics summary.
    */
@@ -270,12 +269,12 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
 
   @Override
   public DataSummary getSystemStatisticsOverview() {
-    return OVERVIEW_CACHE.get("overview", key -> computeSystemStatisticsOverview());
+    return overviewCache.get("overview", key -> computeSystemStatisticsOverview());
   }
 
   @Override
   public DataSummary getSystemStatisticsDataCounts() {
-    return DATA_COUNTS_CACHE.get("dataCounts", key -> computeSystemStatisticsDataCounts());
+    return dataCountsCache.get("dataCounts", key -> computeSystemStatisticsDataCounts());
   }
 
   private DataSummary computeSystemStatisticsOverview() {

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -43,6 +43,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.analytics.SortOrder;
 import org.hisp.dhis.common.Dhis2Info;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.cache.Region;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.datasummary.DataSummary;
 import org.hisp.dhis.datavalue.DataValueService;
@@ -212,7 +213,7 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
    */
   private static final org.hisp.dhis.cache.Cache<DataSummary> SUMMARY_CACHE =
       new org.hisp.dhis.cache.SimpleCacheBuilder<DataSummary>()
-          .forRegion("systemStatisticsSummary")
+          .forRegion(Region.systemStatisticsSummary.name())
           .expireAfterWrite(5, java.util.concurrent.TimeUnit.MINUTES)
           .withInitialCapacity(1)
           .withMaximumSize(1)

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -223,45 +223,20 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
 
     statistics.setObjectCounts(objectCounts);
 
-    // Logins
-    // Note that the source of active users and logins are different. This one is
-    // counting logins based on last login date stored in user table
-    Map<Integer, Integer> logins =
-        Map.ofEntries(
-            Map.entry(0, userService.getActiveUsersCount(hoursAgo(1))),
-            Map.entry(1, userService.getActiveUsersCount(startOfToday())),
-            Map.entry(2, userService.getActiveUsersCount(daysAgo(2))),
-            Map.entry(7, userService.getActiveUsersCount(daysAgo(7))),
-            Map.entry(30, userService.getActiveUsersCount(daysAgo(30))));
-    statistics.setLogins(logins);
+    // Distinct users by last login (userinfo.lastlogin) and by recorded view activity
+    // (datastatisticsevent), for the windows: last hour (key 0), since start of today (key 1),
+    // and the last 2, 7 and 30 days. Note that the two sources differ: logins cover all
+    // authentication, while active users only cover users generating view events in the
+    // analytics apps.
+    List<Integer> windowKeys = List.of(0, 1, 2, 7, 30);
+    List<Date> windowDates =
+        List.of(hoursAgo(1), startOfToday(), daysAgo(2), daysAgo(7), daysAgo(30));
 
-    // Active users based on DataStatisticsEventStore
-    // This one is counting active users based on activity stored in data statistics event table
-    // Consider to include all of the event types, since we are already querying them
-    Date base = new Date();
-    Map<DataStatisticsEventType, Long> eventCountMapOneHour =
-        dataStatisticsEventStore.getDataStatisticsEventCount(hoursAgo(1), base);
-    Map<DataStatisticsEventType, Long> eventCountMapToday =
-        dataStatisticsEventStore.getDataStatisticsEventCount(startOfToday(), base);
-    Map<DataStatisticsEventType, Long> eventCountMapLast2Days =
-        dataStatisticsEventStore.getDataStatisticsEventCount(daysAgo(2), base);
-    Map<DataStatisticsEventType, Long> eventCountMapLast7Days =
-        dataStatisticsEventStore.getDataStatisticsEventCount(daysAgo(7), base);
-    Map<DataStatisticsEventType, Long> eventCountMapLast30Days =
-        dataStatisticsEventStore.getDataStatisticsEventCount(daysAgo(30), base);
-    Map<Integer, Integer> activeUsersMap =
-        Map.ofEntries(
-            Map.entry(
-                0, (int) getOrZero(eventCountMapOneHour, DataStatisticsEventType.ACTIVE_USERS)),
-            Map.entry(1, (int) getOrZero(eventCountMapToday, DataStatisticsEventType.ACTIVE_USERS)),
-            Map.entry(
-                2, (int) getOrZero(eventCountMapLast2Days, DataStatisticsEventType.ACTIVE_USERS)),
-            Map.entry(
-                7, (int) getOrZero(eventCountMapLast7Days, DataStatisticsEventType.ACTIVE_USERS)),
-            Map.entry(
-                30,
-                (int) getOrZero(eventCountMapLast30Days, DataStatisticsEventType.ACTIVE_USERS)));
-    statistics.setActiveUsers(activeUsersMap);
+    statistics.setLogins(toWindowMap(windowKeys, userService.getActiveUsersCounts(windowDates)));
+    statistics.setActiveUsers(
+        toWindowMap(
+            windowKeys,
+            dataStatisticsEventStore.getDistinctActiveUserCounts(windowDates, new Date())));
 
     // User invitations
     Map<String, Integer> userInvitations = new HashMap<>();
@@ -346,6 +321,21 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
   private static long getOrZero(
       Map<DataStatisticsEventType, Long> map, DataStatisticsEventType type) {
     return map.getOrDefault(type, 0L);
+  }
+
+  /**
+   * Zips window keys with their counts into an unmodifiable map.
+   *
+   * @param keys the window keys.
+   * @param counts the counts, in the same order as the keys.
+   * @return a map from window key to count.
+   */
+  private static Map<Integer, Integer> toWindowMap(List<Integer> keys, List<Integer> counts) {
+    Map<Integer, Integer> map = new HashMap<>();
+    for (int i = 0; i < keys.size(); i++) {
+      map.put(keys.get(i), counts.get(i));
+    }
+    return Map.copyOf(map);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -39,8 +39,11 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.analytics.SortOrder;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.SimpleCacheBuilder;
 import org.hisp.dhis.common.Dhis2Info;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.cache.Region;
@@ -206,38 +209,76 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
   }
 
   /**
-   * The system statistics summary runs many count queries over the largest tables (data values,
-   * tracker events, enrollments), so the computed result is cached briefly. This bounds the cost of
-   * aggressive or misbehaving monitoring scrapers to one computation per TTL window, regardless of
-   * request rate. Stats move slowly; five minutes of staleness is acceptable.
+   * The system statistics overview covers object counts (approximate counts for the large data
+   * tables), logins, active users, user invitations and system info. These queries are cheap, but
+   * the result is still cached briefly so aggressive or misbehaving monitoring scrapers are
+   * bounded to one computation per TTL window, regardless of request rate.
    */
-  private static final org.hisp.dhis.cache.Cache<DataSummary> SUMMARY_CACHE =
-      new org.hisp.dhis.cache.SimpleCacheBuilder<DataSummary>()
-          .forRegion(Region.systemStatisticsSummary.name())
-          .expireAfterWrite(5, java.util.concurrent.TimeUnit.MINUTES)
+  private static final Cache<DataSummary> OVERVIEW_CACHE =
+      new SimpleCacheBuilder<DataSummary>()
+          .forRegion(Region.systemStatisticsOverview.name())
+          .expireAfterWrite(5, TimeUnit.MINUTES)
           .withInitialCapacity(1)
           .withMaximumSize(1)
           .build();
 
-  /** Clears the cached system statistics summary. Intended for tests only. */
+  /**
+   * The data counts run exact, windowed count queries over the largest tables (data values,
+   * tracker events, single events, enrollments), which can be very expensive on databases with a
+   * lot of data. The result is therefore cached considerably longer than the overview; these
+   * counts move slowly and 30 minutes of staleness is acceptable.
+   */
+  private static final Cache<DataSummary> DATA_COUNTS_CACHE =
+      new SimpleCacheBuilder<DataSummary>()
+          .forRegion(Region.systemStatisticsDataCounts.name())
+          .expireAfterWrite(30, TimeUnit.MINUTES)
+          .withInitialCapacity(1)
+          .withMaximumSize(1)
+          .build();
+
+  /** Clears the cached system statistics (overview and data counts). Intended for tests only. */
   @Override
   public void clearSystemStatisticsSummaryCache() {
-    SUMMARY_CACHE.invalidateAll();
+    OVERVIEW_CACHE.invalidateAll();
+    DATA_COUNTS_CACHE.invalidateAll();
   }
 
   /**
-   * Returns a summary of system statistics including object counts, active users, user invitations,
-   * data value counts, tracker event counts, single event counts, enrollment counts, and system
-   * information. The result is cached, see {@link #SUMMARY_CACHE}.
+   * Returns the full system statistics summary, composed of the cached overview (see {@link
+   * #OVERVIEW_CACHE}) and the cached data counts (see {@link #DATA_COUNTS_CACHE}).
    *
    * @return A DataSummary object containing the system statistics summary.
    */
   @Override
   public DataSummary getSystemStatisticsSummary() {
-    return SUMMARY_CACHE.get("summary", key -> computeSystemStatisticsSummary());
+    DataSummary overview = getSystemStatisticsOverview();
+    DataSummary dataCounts = getSystemStatisticsDataCounts();
+
+    DataSummary summary = new DataSummary();
+    summary.setObjectCounts(overview.getObjectCounts());
+    summary.setActiveUsers(overview.getActiveUsers());
+    summary.setLogins(overview.getLogins());
+    summary.setUserInvitations(overview.getUserInvitations());
+    summary.setSystem(overview.getSystem());
+    summary.setDataValueCount(dataCounts.getDataValueCount());
+    summary.setEventCount(dataCounts.getEventCount());
+    summary.setTrackerEventCount(dataCounts.getTrackerEventCount());
+    summary.setSingleEventCount(dataCounts.getSingleEventCount());
+    summary.setEnrollmentCount(dataCounts.getEnrollmentCount());
+    return summary;
   }
 
-  private DataSummary computeSystemStatisticsSummary() {
+  @Override
+  public DataSummary getSystemStatisticsOverview() {
+    return OVERVIEW_CACHE.get("overview", key -> computeSystemStatisticsOverview());
+  }
+
+  @Override
+  public DataSummary getSystemStatisticsDataCounts() {
+    return DATA_COUNTS_CACHE.get("dataCounts", key -> computeSystemStatisticsDataCounts());
+  }
+
+  private DataSummary computeSystemStatisticsOverview() {
     DataSummary statistics = new DataSummary();
 
     // Database objects
@@ -276,6 +317,14 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
         UserInvitationStatus.EXPIRED.getValue(), userService.getUserCount(inviteExpired));
 
     statistics.setUserInvitations(userInvitations);
+
+    statistics.setSystem(getDhis2Info());
+
+    return statistics;
+  }
+
+  private DataSummary computeSystemStatisticsDataCounts() {
+    DataSummary statistics = new DataSummary();
 
     Map<Integer, Integer> dataValueCount =
         Map.ofEntries(
@@ -324,8 +373,6 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
             Map.entry(
                 30, (long) idObjectManager.getCountByLastUpdated(Enrollment.class, daysAgo(30))));
     statistics.setEnrollmentCount(Map.copyOf(enrollmentCount));
-
-    statistics.setSystem(getDhis2Info());
 
     return statistics;
   }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -205,14 +205,38 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
   }
 
   /**
-   * Generates a summary of system statistics including object counts, active users, user
-   * invitations, data value counts, tracker event counts, single event counts, enrollment counts,
-   * and system information.
+   * The system statistics summary runs many count queries over the largest tables (data values,
+   * tracker events, enrollments), so the computed result is cached briefly. This bounds the cost of
+   * aggressive or misbehaving monitoring scrapers to one computation per TTL window, regardless of
+   * request rate. Stats move slowly; five minutes of staleness is acceptable.
+   */
+  private static final org.hisp.dhis.cache.Cache<DataSummary> SUMMARY_CACHE =
+      new org.hisp.dhis.cache.SimpleCacheBuilder<DataSummary>()
+          .forRegion("systemStatisticsSummary")
+          .expireAfterWrite(5, java.util.concurrent.TimeUnit.MINUTES)
+          .withInitialCapacity(1)
+          .withMaximumSize(1)
+          .build();
+
+  /** Clears the cached system statistics summary. Intended for tests only. */
+  @Override
+  public void clearSystemStatisticsSummaryCache() {
+    SUMMARY_CACHE.invalidateAll();
+  }
+
+  /**
+   * Returns a summary of system statistics including object counts, active users, user invitations,
+   * data value counts, tracker event counts, single event counts, enrollment counts, and system
+   * information. The result is cached, see {@link #SUMMARY_CACHE}.
    *
    * @return A DataSummary object containing the system statistics summary.
    */
   @Override
   public DataSummary getSystemStatisticsSummary() {
+    return SUMMARY_CACHE.get("summary", key -> computeSystemStatisticsSummary());
+  }
+
+  private DataSummary computeSystemStatisticsSummary() {
     DataSummary statistics = new DataSummary();
 
     // Database objects

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/hibernate/HibernateDataStatisticsEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/hibernate/HibernateDataStatisticsEventStore.java
@@ -33,6 +33,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.util.SqlUtils.escape;
 
 import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.List;
@@ -134,6 +135,40 @@ public class HibernateDataStatisticsEventStore extends HibernateGenericStore<Dat
         });
 
     return eventTypeCountMap;
+  }
+
+  @Override
+  public List<Integer> getDistinctActiveUserCounts(List<Date> startDates, Date endDate) {
+    if (startDates.isEmpty()) {
+      return List.of();
+    }
+    Date earliest = startDates.stream().min(Date::compareTo).orElseThrow();
+    StringBuilder sql = new StringBuilder("select ");
+    for (int i = 0; i < startDates.size(); i++) {
+      if (i > 0) {
+        sql.append(", ");
+      }
+      sql.append("count(distinct username) filter (where timestamp >= ?) as c").append(i);
+    }
+    sql.append(" from datastatisticsevent where timestamp between ? and ?");
+    return jdbcTemplate.query(
+        sql.toString(),
+        ps -> {
+          int i = 1;
+          for (Date startDate : startDates) {
+            ps.setTimestamp(i++, new java.sql.Timestamp(startDate.getTime()));
+          }
+          ps.setTimestamp(i++, new java.sql.Timestamp(earliest.getTime()));
+          ps.setTimestamp(i, new java.sql.Timestamp(endDate.getTime()));
+        },
+        rs -> {
+          rs.next();
+          List<Integer> counts = new ArrayList<>(startDates.size());
+          for (int i = 0; i < startDates.size(); i++) {
+            counts.add(rs.getInt(i + 1));
+          }
+          return counts;
+        });
   }
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -466,4 +466,34 @@ public class DefaultCacheProvider implements CacheProvider {
             .forceInMemory()
             .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_100))));
   }
+
+  @Override
+  public <V> Cache<V> createSystemStatisticsOverviewCache() {
+    return registerCache(
+        this.<V>newBuilder()
+            .forRegion(Region.systemStatisticsOverview.name())
+            .expireAfterWrite(5, MINUTES)
+            .forceInMemory()
+            .withMaximumSize(orZeroInTestRun(1)));
+  }
+
+  @Override
+  public <V> Cache<V> createSystemStatisticsDataCountsCache() {
+    return registerCache(
+        this.<V>newBuilder()
+            .forRegion(Region.systemStatisticsDataCounts.name())
+            .expireAfterWrite(30, MINUTES)
+            .forceInMemory()
+            .withMaximumSize(orZeroInTestRun(1)));
+  }
+
+  @Override
+  public <V> Cache<V> createDataSummarySessionGaugesCache() {
+    return registerCache(
+        this.<V>newBuilder()
+            .forRegion(Region.dataSummarySessionGauges.name())
+            .expireAfterWrite(60, TimeUnit.SECONDS)
+            .forceInMemory()
+            .withMaximumSize(orZeroInTestRun(1)));
+  }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
@@ -169,7 +169,6 @@ class DataStatisticsServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testGetSystemStatisticsSummary() {
-    dataStatisticsService.clearSystemStatisticsSummaryCache();
     DataSummary summary = dataStatisticsService.getSystemStatisticsSummary();
 
     assertAll(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
@@ -169,6 +169,7 @@ class DataStatisticsServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testGetSystemStatisticsSummary() {
+    dataStatisticsService.clearSystemStatisticsSummaryCache();
     DataSummary summary = dataStatisticsService.getSystemStatisticsSummary();
 
     assertAll(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSummaryControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSummaryControllerTest.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Date;
-import org.hisp.dhis.datastatistics.DataStatisticsService;
 import org.hisp.dhis.http.HttpClientAdapter;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonMixed;
@@ -47,14 +46,6 @@ import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 
 class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
-
-  @org.springframework.beans.factory.annotation.Autowired
-  private DataStatisticsService dataStatisticsService;
-
-  @org.junit.jupiter.api.BeforeEach
-  void clearSummaryCache() {
-    dataStatisticsService.clearSystemStatisticsSummaryCache();
-  }
 
   @Test
   void canGetPrometheusMetrics() {
@@ -297,7 +288,6 @@ class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
     // Delete the data element
     assertStatus(HttpStatus.OK, DELETE("/dataElements/" + dataElementId));
     // Get object counts after deleting the data element
-    dataStatisticsService.clearSystemStatisticsSummaryCache();
     HttpResponse responseAfterDelete = GET("/api/dataSummary");
     JsonMixed contentAfterDelete = responseAfterDelete.content();
     int dataElementCountAfterDelete;
@@ -359,8 +349,6 @@ class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
     assertTrue(dashboardCountBeforeDelete > 0, "Dashboard count should be greater than zero");
     // Delete the dashboard
     assertStatus(HttpStatus.OK, DELETE("/dashboards/" + dashboardId));
-    // Get object counts after deleting the dashboard
-    dataStatisticsService.clearSystemStatisticsSummaryCache();
     HttpResponse responseAfterDelete = GET("/api/dataSummary");
     JsonMixed contentAfterDelete = responseAfterDelete.content();
     int dashboardCountAfterDelete;
@@ -423,7 +411,6 @@ class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
     // Delete the data element group
     assertStatus(HttpStatus.OK, DELETE("/dataElementGroups/" + dataElementGroupId));
     // Get object counts after deleting the data element group
-    dataStatisticsService.clearSystemStatisticsSummaryCache();
     HttpResponse responseAfterDelete = GET("/api/dataSummary");
     JsonMixed contentAfterDelete = responseAfterDelete.content();
     int dataElementGroupCountAfterDelete;
@@ -499,8 +486,6 @@ class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
     b.setLastLogin(twoDaysAgo);
     userService.addUser(b);
 
-    // Get object counts after creating a user
-    dataStatisticsService.clearSystemStatisticsSummaryCache();
     HttpResponse responseAfter = GET("/api/dataSummary");
     JsonMixed contentAfter = responseAfter.content();
     int loginsOneHourAgoCountAfter;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSummaryControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSummaryControllerTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Date;
+import org.hisp.dhis.datastatistics.DataStatisticsService;
 import org.hisp.dhis.http.HttpClientAdapter;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonMixed;
@@ -46,6 +47,14 @@ import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 
 class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
+
+  @org.springframework.beans.factory.annotation.Autowired
+  private DataStatisticsService dataStatisticsService;
+
+  @org.junit.jupiter.api.BeforeEach
+  void clearSummaryCache() {
+    dataStatisticsService.clearSystemStatisticsSummaryCache();
+  }
 
   @Test
   void canGetPrometheusMetrics() {
@@ -267,6 +276,7 @@ class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
     // Delete the data element
     assertStatus(HttpStatus.OK, DELETE("/dataElements/" + dataElementId));
     // Get object counts after deleting the data element
+    dataStatisticsService.clearSystemStatisticsSummaryCache();
     HttpResponse responseAfterDelete = GET("/api/dataSummary");
     JsonMixed contentAfterDelete = responseAfterDelete.content();
     int dataElementCountAfterDelete;
@@ -329,6 +339,7 @@ class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
     // Delete the dashboard
     assertStatus(HttpStatus.OK, DELETE("/dashboards/" + dashboardId));
     // Get object counts after deleting the dashboard
+    dataStatisticsService.clearSystemStatisticsSummaryCache();
     HttpResponse responseAfterDelete = GET("/api/dataSummary");
     JsonMixed contentAfterDelete = responseAfterDelete.content();
     int dashboardCountAfterDelete;
@@ -391,6 +402,7 @@ class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
     // Delete the data element group
     assertStatus(HttpStatus.OK, DELETE("/dataElementGroups/" + dataElementGroupId));
     // Get object counts after deleting the data element group
+    dataStatisticsService.clearSystemStatisticsSummaryCache();
     HttpResponse responseAfterDelete = GET("/api/dataSummary");
     JsonMixed contentAfterDelete = responseAfterDelete.content();
     int dataElementGroupCountAfterDelete;
@@ -467,6 +479,7 @@ class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
     userService.addUser(b);
 
     // Get object counts after creating a user
+    dataStatisticsService.clearSystemStatisticsSummaryCache();
     HttpResponse responseAfter = GET("/api/dataSummary");
     JsonMixed contentAfter = responseAfter.content();
     int loginsOneHourAgoCountAfter;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSummaryControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSummaryControllerTest.java
@@ -87,34 +87,22 @@ class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
     assertTrue(
         content.lines().anyMatch(line -> line.startsWith("data_summary_object_counts")),
         "Object counts metric is missing");
-    assertTrue(
-        content.contains("# HELP data_summary_data_value_count"),
-        "Data value count help text is missing");
-    assertTrue(
+    // Expensive windowed data counts are only exposed on /metrics/data
+    assertFalse(
         content.lines().anyMatch(line -> line.startsWith("data_summary_data_value_count")),
-        "Data value count metric is missing");
-    assertTrue(
-        content.contains("# HELP data_summary_event_count"), "Event count help text is missing");
-    assertTrue(
+        "Data value count should not be on /metrics");
+    assertFalse(
         content.lines().anyMatch(line -> line.startsWith("data_summary_event_count")),
-        "Event count metric is missing");
-    // Single event count
-    assertTrue(
-        content.contains("# HELP data_summary_single_event_count"),
-        "Single event count help text is missing");
-    assertTrue(
-        content.lines().anyMatch(line -> line.startsWith("data_summary_single_event_count")),
-        "Single event count metric is missing");
-    // Tracker event count
-    assertTrue(
-        content.contains("# HELP data_summary_tracker_event_count"),
-        "Tracker event count help text is missing");
-    assertTrue(
+        "Event count should not be on /metrics");
+    assertFalse(
         content.lines().anyMatch(line -> line.startsWith("data_summary_tracker_event_count")),
-        "Tracker event count metric is missing");
-    assertTrue(
+        "Tracker event count should not be on /metrics");
+    assertFalse(
+        content.lines().anyMatch(line -> line.startsWith("data_summary_single_event_count")),
+        "Single event count should not be on /metrics");
+    assertFalse(
         content.lines().anyMatch(line -> line.startsWith("data_summary_enrollment_count")),
-        "Enrollment count metric is missing");
+        "Enrollment count should not be on /metrics");
     // Logins
     assertTrue(content.contains("# HELP data_summary_logins"), "Logins help text is missing");
     assertTrue(
@@ -137,6 +125,39 @@ class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
     assertTrue(
         content.lines().anyMatch(line -> line.matches("data_summary_system_id\\{.*\\} 1")),
         "System ID metric should be a static value of 1");
+  }
+
+  @Test
+  void canGetPrometheusDataMetrics() {
+    HttpResponse response =
+        GET("/api/dataSummary/metrics/data", HttpClientAdapter.Accept("text/plain"));
+    assertEquals(HttpStatus.OK, response.status());
+    String content = response.content("text/plain");
+    assertFalse(content.isEmpty(), "Response content should not be empty");
+    assertTrue(
+        content.contains("# HELP data_summary_data_value_count"),
+        "Data value count help text is missing");
+    assertTrue(
+        content.lines().anyMatch(line -> line.startsWith("data_summary_data_value_count")),
+        "Data value count metric is missing");
+    assertTrue(
+        content.lines().anyMatch(line -> line.startsWith("data_summary_event_count")),
+        "Event count metric is missing");
+    assertTrue(
+        content.lines().anyMatch(line -> line.startsWith("data_summary_tracker_event_count")),
+        "Tracker event count metric is missing");
+    assertTrue(
+        content.lines().anyMatch(line -> line.startsWith("data_summary_single_event_count")),
+        "Single event count metric is missing");
+    assertTrue(
+        content.lines().anyMatch(line -> line.startsWith("data_summary_enrollment_count")),
+        "Enrollment count metric is missing");
+    assertFalse(
+        content.lines().anyMatch(line -> line.startsWith("data_summary_active_users")),
+        "Active users should not be on /metrics/data");
+    assertFalse(
+        content.lines().anyMatch(line -> line.startsWith("data_summary_logins")),
+        "Logins should not be on /metrics/data");
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSummaryControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSummaryControllerTest.java
@@ -63,6 +63,16 @@ class DataSummaryControllerTest extends PostgresControllerIntegrationTestBase {
         "Active users metric should have days label and integer value");
 
     assertTrue(
+        content.contains("# HELP data_summary_active_sessions"),
+        "Active sessions help text is missing");
+    assertTrue(
+        content.lines().anyMatch(line -> line.matches("^data_summary_active_sessions \\d+")),
+        "Active sessions gauge should have an integer value");
+    assertTrue(
+        content.lines().anyMatch(line -> line.matches("^data_summary_active_session_users \\d+")),
+        "Active session users gauge should have an integer value");
+
+    assertTrue(
         content.contains("# HELP data_summary_object_counts"),
         "Object counts help text is missing");
     assertTrue(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/SessionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/SessionControllerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.common.HashUtils;
+import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.user.UserDetails;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.session.SessionInformation;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Tests the structured {@code /api/sessions} response and per-user session invalidation.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@Transactional
+class SessionControllerTest extends H2ControllerIntegrationTestBase {
+
+  private static final String SESSION_ID = "session-controller-test-1";
+
+  @Autowired private SessionRegistry sessionRegistry;
+
+  @AfterEach
+  void tearDown() {
+    sessionRegistry.removeSessionInformation(SESSION_ID);
+  }
+
+  @Test
+  void listSessionsReturnsStructuredSessionInfo() {
+    UserDetails principal = userService.createUserDetails(getAdminUser());
+    sessionRegistry.registerNewSession(SESSION_ID, principal);
+
+    JsonArray sessions = GET("/api/sessions").content(HttpStatus.OK).as(JsonArray.class);
+
+    JsonObject match =
+        sessions.asList(JsonObject.class).stream()
+            .filter(s -> "admin".equals(s.getString("username").string()))
+            .filter(
+                s -> HashUtils.hashSHA1(SESSION_ID.getBytes()).equals(s.getString("id").string()))
+            .findFirst()
+            .orElseThrow();
+
+    assertEquals(HashUtils.hashSHA1(SESSION_ID.getBytes()), match.getString("id").string());
+    assertEquals("admin", match.getString("username").string());
+    assertFalse(match.getBoolean("expired").booleanValue());
+    assertNotNull(match.get("lastRequest").node());
+    assertFalse(match.get("lastRequest").isNull());
+  }
+
+  @Test
+  void deleteUsernameExpiresRegisteredSession() {
+    UserDetails principal = userService.createUserDetails(getAdminUser());
+    sessionRegistry.registerNewSession(SESSION_ID, principal);
+    assertFalse(sessionRegistry.getAllSessions(principal, false).isEmpty());
+
+    assertEquals(HttpStatus.OK, DELETE("/api/sessions/admin").status());
+
+    assertTrue(sessionRegistry.getAllSessions(principal, false).isEmpty());
+    SessionInformation expired = sessionRegistry.getSessionInformation(SESSION_ID);
+    assertNotNull(expired);
+    assertTrue(expired.isExpired());
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datasummary/DataSummaryController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datasummary/DataSummaryController.java
@@ -123,10 +123,15 @@ public class DataSummaryController {
     }
   }
 
+  /**
+   * Prometheus metrics for the cheap system statistics: object counts, logins, active users, user
+   * invitations, sessions and build info. Safe to scrape frequently. The expensive windowed data
+   * counts are exposed separately on {@link #getPrometheusDataMetrics()}.
+   */
   @GetMapping(value = "/metrics", produces = TEXT_PLAIN_VALUE)
   @RequiresAuthority(anyOf = F_PERFORM_MAINTENANCE)
   public @ResponseBody String getPrometheusMetrics() {
-    DataSummary summary = dataStatisticsService.getSystemStatisticsSummary();
+    DataSummary summary = dataStatisticsService.getSystemStatisticsOverview();
 
     PrometheusTextBuilder metrics = new PrometheusTextBuilder();
 
@@ -150,6 +155,25 @@ public class DataSummaryController {
         "data_summary_user_invitations",
         "type",
         "Count of user invitations");
+
+    appendSessionMetrics(metrics);
+
+    appendSystemInfoMetrics(metrics, summary.getSystem());
+    return metrics.getMetrics();
+  }
+
+  /**
+   * Prometheus metrics for the expensive system statistics: exact, windowed count queries over the
+   * largest tables (data values, tracker events, single events, enrollments). Served from a
+   * separate, longer-lived cache; scrape this endpoint at a lower frequency than {@link
+   * #getPrometheusMetrics()}.
+   */
+  @GetMapping(value = "/metrics/data", produces = TEXT_PLAIN_VALUE)
+  @RequiresAuthority(anyOf = F_PERFORM_MAINTENANCE)
+  public @ResponseBody String getPrometheusDataMetrics() {
+    DataSummary summary = dataStatisticsService.getSystemStatisticsDataCounts();
+
+    PrometheusTextBuilder metrics = new PrometheusTextBuilder();
 
     metrics.addMetrics(
         summary.getDataValueCount(),
@@ -181,9 +205,6 @@ public class DataSummaryController {
         "days",
         "Count of updated enrollments by day");
 
-    appendSessionMetrics(metrics);
-
-    appendSystemInfoMetrics(metrics, summary.getSystem());
     return metrics.getMetrics();
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datasummary/DataSummaryController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datasummary/DataSummaryController.java
@@ -34,12 +34,10 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.cache.SimpleCacheBuilder;
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.common.Dhis2Info;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.cache.Region;
 import org.hisp.dhis.datastatistics.DataStatisticsService;
 import org.hisp.dhis.datasummary.DataSummary;
 import org.hisp.dhis.security.RequiresAuthority;
@@ -70,13 +68,7 @@ public class DataSummaryController {
    * is O(number of users) with a Redis-backed session registry and Prometheus scrapes on a fixed
    * interval.
    */
-  private static final Cache<SessionGauges> SESSION_GAUGE_CACHE =
-      new SimpleCacheBuilder<SessionGauges>()
-          .forRegion(Region.dataSummarySessionGauges.name())
-          .expireAfterWrite(60, TimeUnit.SECONDS)
-          .withInitialCapacity(1)
-          .withMaximumSize(1)
-          .build();
+  private final Cache<SessionGauges> sessionGaugeCache;
 
   private record SessionGauges(long sessions, long users) {}
 
@@ -86,9 +78,12 @@ public class DataSummaryController {
 
   @Autowired
   public DataSummaryController(
-      DataStatisticsService dataStatisticsService, UserService userService) {
+      DataStatisticsService dataStatisticsService,
+      UserService userService,
+      CacheProvider cacheProvider) {
     this.dataStatisticsService = dataStatisticsService;
     this.userService = userService;
+    this.sessionGaugeCache = cacheProvider.createDataSummarySessionGaugesCache();
   }
 
   @GetMapping(produces = APPLICATION_JSON_VALUE)
@@ -215,7 +210,7 @@ public class DataSummaryController {
    * endpoints instead.
    */
   private void appendSessionMetrics(PrometheusTextBuilder metrics) {
-    SessionGauges gauges = SESSION_GAUGE_CACHE.get("gauges", key -> computeSessionGauges());
+    SessionGauges gauges = sessionGaugeCache.get("gauges", key -> computeSessionGauges());
 
     metrics.addHelp("data_summary_active_sessions", "Number of active HTTP sessions");
     metrics.addType("data_summary_active_sessions");

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datasummary/DataSummaryController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datasummary/DataSummaryController.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.SimpleCacheBuilder;
 import org.hisp.dhis.common.Dhis2Info;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.cache.Region;
 import org.hisp.dhis.datastatistics.DataStatisticsService;
 import org.hisp.dhis.datasummary.DataSummary;
 import org.hisp.dhis.security.RequiresAuthority;
@@ -71,7 +72,7 @@ public class DataSummaryController {
    */
   private static final Cache<SessionGauges> SESSION_GAUGE_CACHE =
       new SimpleCacheBuilder<SessionGauges>()
-          .forRegion("dataSummarySessionGauges")
+          .forRegion(Region.dataSummarySessionGauges.name())
           .expireAfterWrite(60, TimeUnit.SECONDS)
           .withInitialCapacity(1)
           .withMaximumSize(1)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datasummary/DataSummaryController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datasummary/DataSummaryController.java
@@ -33,13 +33,20 @@ import static org.hisp.dhis.security.Authorities.F_PERFORM_MAINTENANCE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.SimpleCacheBuilder;
 import org.hisp.dhis.common.Dhis2Info;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.datastatistics.DataStatisticsService;
 import org.hisp.dhis.datasummary.DataSummary;
 import org.hisp.dhis.security.RequiresAuthority;
+import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.utils.PrometheusTextBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.session.SessionInformation;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -57,11 +64,30 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @RequestMapping("/api/dataSummary")
 public class DataSummaryController {
 
+  /**
+   * Session gauge values for the Prometheus endpoint, cached briefly because enumerating sessions
+   * is O(number of users) with a Redis-backed session registry and Prometheus scrapes on a fixed
+   * interval.
+   */
+  private static final Cache<SessionGauges> SESSION_GAUGE_CACHE =
+      new SimpleCacheBuilder<SessionGauges>()
+          .forRegion("dataSummarySessionGauges")
+          .expireAfterWrite(60, TimeUnit.SECONDS)
+          .withInitialCapacity(1)
+          .withMaximumSize(1)
+          .build();
+
+  private record SessionGauges(long sessions, long users) {}
+
   private final DataStatisticsService dataStatisticsService;
 
+  private final UserService userService;
+
   @Autowired
-  public DataSummaryController(DataStatisticsService dataStatisticsService) {
+  public DataSummaryController(
+      DataStatisticsService dataStatisticsService, UserService userService) {
     this.dataStatisticsService = dataStatisticsService;
+    this.userService = userService;
   }
 
   @GetMapping(produces = APPLICATION_JSON_VALUE)
@@ -154,7 +180,48 @@ public class DataSummaryController {
         "days",
         "Count of updated enrollments by day");
 
+    appendSessionMetrics(metrics);
+
     appendSystemInfoMetrics(metrics, summary.getSystem());
     return metrics.getMetrics();
+  }
+
+  /**
+   * Appends gauges for currently active HTTP sessions and the number of distinct users holding
+   * them. Values are cached for one minute, see {@link #SESSION_GAUGE_CACHE}. Sessions only exist
+   * for browser clients; PAT/basic/JWT clients are session-less and covered by the user statistics
+   * endpoints instead.
+   */
+  private void appendSessionMetrics(PrometheusTextBuilder metrics) {
+    SessionGauges gauges = SESSION_GAUGE_CACHE.get("gauges", key -> computeSessionGauges());
+
+    metrics.addHelp("data_summary_active_sessions", "Number of active HTTP sessions");
+    metrics.addType("data_summary_active_sessions");
+    metrics.append(String.format("data_summary_active_sessions %d%n", gauges.sessions()));
+
+    metrics.addHelp(
+        "data_summary_active_session_users", "Number of distinct users with an active session");
+    metrics.addType("data_summary_active_session_users");
+    metrics.append(String.format("data_summary_active_session_users %d%n", gauges.users()));
+  }
+
+  private SessionGauges computeSessionGauges() {
+    List<SessionInformation> sessions = userService.listAllSessions();
+    long active = sessions.stream().filter(s -> !s.isExpired()).count();
+    long users =
+        sessions.stream()
+            .filter(s -> !s.isExpired())
+            .map(DataSummaryController::sessionUsername)
+            .distinct()
+            .count();
+    return new SessionGauges(active, users);
+  }
+
+  /** The registry holds UserDetails principals in-memory but plain usernames under Redis. */
+  private static String sessionUsername(SessionInformation session) {
+    Object principal = session.getPrincipal();
+    return principal instanceof UserDetails userDetails
+        ? userDetails.getUsername()
+        : String.valueOf(principal);
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/SessionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/SessionController.java
@@ -32,10 +32,10 @@ package org.hisp.dhis.webapi.controller.security;
 import static org.hisp.dhis.security.Authorities.ALL;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import java.util.ArrayList;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import javax.annotation.CheckForNull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.HashUtils;
 import org.hisp.dhis.common.OpenApi;
@@ -43,8 +43,9 @@ import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.webapi.security.session.SessionCreationTimeProvider;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.security.core.session.SessionInformation;
-import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -62,51 +63,64 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class SessionController {
 
-  private final SessionRegistry sessionRegistry;
   private final UserService userService;
+  private final ObjectProvider<SessionCreationTimeProvider> sessionCreationTimeProvider;
+
+  /**
+   * Structured view of a single HTTP session for the sessions API.
+   *
+   * @param id SHA-1 hash of the raw session id
+   * @param username session owner username
+   * @param created session creation time when available, otherwise null
+   * @param lastRequest last request time from the session registry
+   * @param expired whether the session has been expired
+   */
+  public record UserSessionInfo(
+      @JsonProperty String id,
+      @JsonProperty String username,
+      @JsonProperty @CheckForNull Date created,
+      @JsonProperty Date lastRequest,
+      @JsonProperty boolean expired) {}
 
   @GetMapping(produces = APPLICATION_JSON_VALUE)
   @RequiresAuthority(anyOf = ALL)
-  public Map<String, String> listAllSessions() {
-    return listAllUserSessions().stream()
-        .collect(
-            Collectors.toMap(
-                s -> HashUtils.hashSHA1(s.getSessionId().getBytes()),
-                s ->
-                    ((UserDetails) s.getPrincipal()).getUsername()
-                        + (s.isExpired() ? ", (inactive)" : ", (active)")));
-  }
-
-  private List<SessionInformation> listAllUserSessions() {
-    List<SessionInformation> allSessions = new ArrayList<>();
-    List<User> allUsers = userService.getAllUsers();
-    for (User user : allUsers) {
-      allSessions.addAll(sessionRegistry.getAllSessions(userService.createUserDetails(user), true));
-    }
-    return allSessions;
+  public List<UserSessionInfo> listAllSessions() {
+    SessionCreationTimeProvider creationTimes = sessionCreationTimeProvider.getIfAvailable();
+    return userService.listAllSessions().stream()
+        .map(session -> toUserSessionInfo(session, creationTimes))
+        .toList();
   }
 
   @DeleteMapping(value = "/{username}")
   @RequiresAuthority(anyOf = ALL)
   public void invalidateSessions(@PathVariable("username") String username) {
-    User user = userService.getUserByUsername(username);
-    UserDetails userDetails = userService.createUserDetails(user);
-    if (userDetails != null) {
-      List<SessionInformation> allSessions = sessionRegistry.getAllSessions(userDetails, false);
-      allSessions.forEach(SessionInformation::expireNow);
-    }
+    userService.invalidateUserSessions(username);
   }
 
   @DeleteMapping
   @RequiresAuthority(anyOf = ALL)
   public void invalidateAllSessions() {
-    List<User> allUsers = userService.getAllUsers();
-    for (User user : allUsers) {
-      UserDetails userDetails = userService.createUserDetails(user);
-      if (userDetails != null) {
-        List<SessionInformation> allSessions = sessionRegistry.getAllSessions(userDetails, false);
-        allSessions.forEach(SessionInformation::expireNow);
+    for (SessionInformation session : userService.listAllSessions()) {
+      if (!session.isExpired()) {
+        session.expireNow();
       }
     }
+  }
+
+  private static UserSessionInfo toUserSessionInfo(
+      SessionInformation session, @CheckForNull SessionCreationTimeProvider creationTimes) {
+    Object principal = session.getPrincipal();
+    String username =
+        principal instanceof UserDetails userDetails
+            ? userDetails.getUsername()
+            : String.valueOf(principal);
+    Date created =
+        creationTimes != null ? creationTimes.getCreationTime(session.getSessionId()) : null;
+    return new UserSessionInfo(
+        HashUtils.hashSHA1(session.getSessionId().getBytes()),
+        username,
+        created,
+        session.getLastRequest(),
+        session.isExpired());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/SessionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/SessionController.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.webapi.controller.security;
 
 import static org.hisp.dhis.security.Authorities.ALL;
+import static org.hisp.dhis.security.Authorities.F_PERFORM_MAINTENANCE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -83,7 +84,7 @@ public class SessionController {
       @JsonProperty boolean expired) {}
 
   @GetMapping(produces = APPLICATION_JSON_VALUE)
-  @RequiresAuthority(anyOf = ALL)
+  @RequiresAuthority(anyOf = F_PERFORM_MAINTENANCE)
   public List<UserSessionInfo> listAllSessions() {
     SessionCreationTimeProvider creationTimes = sessionCreationTimeProvider.getIfAvailable();
     return userService.listAllSessions().stream()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/InMemorySessionCreationTimeProvider.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/InMemorySessionCreationTimeProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.session;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.CheckForNull;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.web.session.HttpSessionCreatedEvent;
+import org.springframework.security.web.session.HttpSessionDestroyedEvent;
+
+/**
+ * Map-backed {@link SessionCreationTimeProvider} for the in-memory (non-Redis) session stack.
+ * Creation times are recorded from {@link HttpSessionCreatedEvent} and removed on {@link
+ * HttpSessionDestroyedEvent}.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public class InMemorySessionCreationTimeProvider implements SessionCreationTimeProvider {
+
+  private final Map<String, Date> creationTimes = new ConcurrentHashMap<>();
+
+  @Override
+  @CheckForNull
+  public Date getCreationTime(String sessionId) {
+    if (sessionId == null) {
+      return null;
+    }
+    return creationTimes.get(sessionId);
+  }
+
+  @EventListener
+  public void sessionCreated(HttpSessionCreatedEvent event) {
+    creationTimes.put(event.getSession().getId(), new Date(event.getSession().getCreationTime()));
+  }
+
+  @EventListener
+  public void sessionDestroyed(HttpSessionDestroyedEvent event) {
+    creationTimes.remove(event.getSession().getId());
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/NonRedisSessionConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/NonRedisSessionConfig.java
@@ -74,6 +74,11 @@ public class NonRedisSessionConfig {
   }
 
   @Bean
+  public SessionCreationTimeProvider sessionCreationTimeProvider() {
+    return new InMemorySessionCreationTimeProvider();
+  }
+
+  @Bean
   public Filter springSessionRepositoryFilter() {
     return new CharacterEncodingFilter();
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/RedisSessionCreationTimeProvider.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/RedisSessionCreationTimeProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.session;
+
+import java.util.Date;
+import javax.annotation.CheckForNull;
+import org.springframework.session.Session;
+import org.springframework.session.data.redis.RedisIndexedSessionRepository;
+
+/**
+ * Redis-backed {@link SessionCreationTimeProvider} that reads creation time from {@link
+ * RedisIndexedSessionRepository}.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public class RedisSessionCreationTimeProvider implements SessionCreationTimeProvider {
+
+  private final RedisIndexedSessionRepository sessionRepository;
+
+  public RedisSessionCreationTimeProvider(RedisIndexedSessionRepository sessionRepository) {
+    this.sessionRepository = sessionRepository;
+  }
+
+  @Override
+  @CheckForNull
+  public Date getCreationTime(String sessionId) {
+    if (sessionId == null) {
+      return null;
+    }
+    Session session = sessionRepository.findById(sessionId);
+    if (session == null) {
+      return null;
+    }
+    return Date.from(session.getCreationTime());
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/RedisSpringSessionConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/RedisSpringSessionConfig.java
@@ -87,6 +87,12 @@ public class RedisSpringSessionConfig {
   }
 
   @Bean
+  public SessionCreationTimeProvider sessionCreationTimeProvider(
+      RedisIndexedSessionRepository sessionRepository) {
+    return new RedisSessionCreationTimeProvider(sessionRepository);
+  }
+
+  @Bean
   public static ConfigureRedisAction configureRedisAction() {
     return ConfigureRedisAction.NO_OP;
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/SessionCreationTimeProvider.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/SessionCreationTimeProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.session;
+
+import java.util.Date;
+import javax.annotation.CheckForNull;
+
+/**
+ * Provides the creation time of an HTTP session by id.
+ *
+ * <p>Two implementations exist, one per session backend:
+ *
+ * <ul>
+ *   <li>In-memory (non-Redis): records creation times from {@code HttpSessionCreatedEvent} into a
+ *       map and clears them on {@code HttpSessionDestroyedEvent}.
+ *   <li>Redis-backed Spring Session: looks up the session via {@code
+ *       RedisIndexedSessionRepository#findById(String)} and returns its creation time.
+ * </ul>
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public interface SessionCreationTimeProvider {
+
+  /**
+   * Returns the creation time of the session with the given id, or {@code null} when the session is
+   * unknown or creation time is unavailable.
+   *
+   * @param sessionId the raw session id (not the hashed value exposed by the API)
+   * @return creation time, or null
+   */
+  @CheckForNull
+  Date getCreationTime(String sessionId);
+}


### PR DESCRIPTION
## Summary

Improves the user statistics plumbing behind `/api/dataSummary` and `/api/sessions`. [DHIS2-21930](https://dhis2.atlassian.net/browse/DHIS2-21930)

- `dataSummary.logins`: 5 count queries over `userinfo.lastlogin` collapsed into one `count(*) filter (where ...)` query.
- `dataSummary.activeUsers`: 15 queries against `datastatisticsevent` (14 results discarded) collapsed into one `count(distinct username) filter (where ...)` query. JSON output unchanged for both.
- `GET /api/sessions`: returns structured JSON (`id`, `username`, `created`, `lastRequest`, `expired`) instead of a string map, and no longer loads every user + full `UserDetails` hydration to probe the session registry.
- New `SessionCreationTimeProvider` supplies session creation time (Redis: `Session.getCreationTime()`; in-memory: `HttpSessionCreatedEvent` listener).
- Fixes two latent bugs under Redis-backed session registries: `(UserDetails)` cast on String principals in `SessionController`, and `UnsupportedOperationException` from `getAllPrincipals()` in `DefaultUserService.invalidateAllSessions()`.

## Testing

- `DataSummaryControllerTest` (Postgres) covers the login/activeUsers windows, including `canVerifyLoginsOneHourAgo`.
- New `SessionControllerTest` covers the structured GET shape and DELETE-by-username session expiry.
- `DataStatisticsServiceTest` covers `getSystemStatisticsSummary` against the new SQL.


## Updates

- `GET /api/sessions` authority relaxed to `F_PERFORM_MAINTENANCE`.
- Prometheus gauges added to `/api/dataSummary/metrics`: `data_summary_active_sessions` and `data_summary_active_session_users` (values cached 60s; session enumeration is O(users) on Redis-backed registries), so monitoring never needs to scrape the sessions JSON.
- System statistics split into two cached parts: a cheap overview (object counts, logins, active users, invitations, system info; 5 min cache) and the expensive windowed data value/event/enrollment counts (exact `count(*)` over the largest tables; 30 min cache), both with single-flight loading.
- `/api/dataSummary/metrics` now exposes only the cheap overview (plus session gauges and build info), making it safe to scrape frequently. The expensive data counts moved to a new `GET /api/dataSummary/metrics/data` endpoint intended for low-frequency scraping. The `/api/dataSummary` JSON response is unchanged and composes both parts.

AI Assisted


[DHIS2-21930]: https://dhis2.atlassian.net/browse/DHIS2-21930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
