### PR TITLE
fix(i18n): correct outdated account-restore email translations (2.40) [DHIS2-19912]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global_es.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global_es.properties
@@ -1768,7 +1768,7 @@ respond_to_this_message=Responder a este mensaje
 email_restore_subject=Confirmaci\u00f3n de restauraci\u00f3n de cuenta de usuario en
 email_restore_1_1st_paragraph_before_application_title=Alguien, probablemente usted, nos ha pedido que
 email_restore_1_1st_paragraph_after_application_title=Cuenta de usuario
-email_restore_1_2nd_paragraph=Te han enviado dos correos-e, donde este es el primero. Por favor, siga el siguiente enlace. En el paso siguiente, se le pedir\u00e1 que ingrese un c\u00f3digo que le ha sido enviado en el otro correo-e.
+email_restore_1_2nd_paragraph=Por favor, siga el siguiente enlace para restaurar su cuenta.
 email_restore_1_3rd_paragraph=Debe completar el proceso de restauraci\u00f3n en 1 hora. Si no realiza ninguna acci\u00f3n, su cuenta no se restaurar\u00e1. Si no solicit\u00f3 esta restauraci\u00f3n, omita este mensaje.
 
 #-- Invite emails -------------------------------------------------------------#


### PR DESCRIPTION
Related: [DHIS2-19912](https://dhis2.atlassian.net/browse/DHIS2-19912)

Same issue as #24710/#24711, for 2.40: Spanish restore-account email still referenced "two e-mails" (`email_restore_1_2nd_paragraph`).

Unlike 2.41/2.42, this branch IS synced with Transifex, and the `2-40--i18n-global-properties` resource still held the old Spanish translation. That has been fixed directly in Transifex (round-trip verified with `tx pull`), so this PR and the next nightly sync converge on the same value — the sync will not revert it.

AI Assisted

[DHIS2-19912]: https://dhis2.atlassian.net/browse/DHIS2-19912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ