### PR TITLE
fix: Propogate L2 cache disabling and enable hikari mbeans

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -176,6 +176,8 @@ public class HibernateConfig {
       if (!configFile.isBlank()) {
         properties.put(ConfigSettings.CONFIG_URI, configFile);
       }
+    } else {
+      properties.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, "false");
     }
 
     properties.put(AvailableSettings.HBM2DDL_AUTO, Action.VALIDATE.getExternalHbm2ddlName());

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/datasource/DatabasePoolUtils.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/datasource/DatabasePoolUtils.java
@@ -249,6 +249,7 @@ public final class DatabasePoolUtils {
     hc.addDataSourceProperty("cachePrepStmts", "true");
     hc.addDataSourceProperty("prepStmtCacheSize", "250");
     hc.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+    hc.setRegisterMbeans(true);
     hc.setConnectionTestQuery(connectionTestQuery);
     final String leakThresholdStr =
         dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_WARN_MAX_AGE));


### PR DESCRIPTION
Setting hibernate.use_second_level_cache to false explicitly sets the config to false rather than relying on "defaults"
Hikari connection pools status can be viewed in glowroot with mbeans registered.