### PR TITLE
fix: Set L2 cache based on dhis.conf [DHIS2-21935]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -167,8 +167,9 @@ public class HibernateConfig {
         // import).
         "org.springframework.orm.jpa.hibernate.SpringSessionContext");
 
-    if ("true".equals(dhisConfig.getProperty(USE_SECOND_LEVEL_CACHE))) {
-      properties.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, "true");
+    boolean useSecondLevelCache = "true".equals(dhisConfig.getProperty(USE_SECOND_LEVEL_CACHE));
+    properties.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, String.valueOf(useSecondLevelCache));
+    if (useSecondLevelCache) {
       properties.put(AvailableSettings.CACHE_REGION_FACTORY, JCacheRegionFactory.class.getName());
       properties.put(AvailableSettings.USE_QUERY_CACHE, dhisConfig.getProperty(USE_QUERY_CACHE));
       properties.put(

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/HibernateConfigTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/HibernateConfigTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.config;
+
+import static org.hisp.dhis.external.conf.ConfigurationKey.CACHE_EHCACHE_CONFIG_FILE;
+import static org.hisp.dhis.external.conf.ConfigurationKey.USE_QUERY_CACHE;
+import static org.hisp.dhis.external.conf.ConfigurationKey.USE_SECOND_LEVEL_CACHE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+import org.hibernate.cache.jcache.internal.JCacheRegionFactory;
+import org.hibernate.cfg.AvailableSettings;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HibernateConfigTest {
+
+  @Mock private DhisConfigurationProvider config;
+
+  @Test
+  void shouldEnableSecondLevelCacheWhenTrueInConf() {
+    when(config.getProperty(USE_SECOND_LEVEL_CACHE)).thenReturn("true");
+    when(config.getProperty(USE_QUERY_CACHE)).thenReturn("true");
+    when(config.getProperty(CACHE_EHCACHE_CONFIG_FILE)).thenReturn("");
+
+    Properties properties = HibernateConfig.getAdditionalProperties(config);
+
+    assertEquals("true", properties.get(AvailableSettings.USE_SECOND_LEVEL_CACHE));
+    assertEquals(
+        JCacheRegionFactory.class.getName(),
+        properties.get(AvailableSettings.CACHE_REGION_FACTORY));
+  }
+
+  @Test
+  void shouldDisableSecondLevelCacheWhenFalseInConf() {
+    when(config.getProperty(USE_SECOND_LEVEL_CACHE)).thenReturn("false");
+
+    Properties properties = HibernateConfig.getAdditionalProperties(config);
+
+    assertEquals("false", properties.get(AvailableSettings.USE_SECOND_LEVEL_CACHE));
+    assertNull(properties.get(AvailableSettings.CACHE_REGION_FACTORY));
+  }
+
+  @Test
+  void shouldEnableSecondLevelCacheWhenNotPresentInConf() {
+    when(config.getProperty(USE_SECOND_LEVEL_CACHE))
+        .thenReturn(USE_SECOND_LEVEL_CACHE.getDefaultValue());
+    when(config.getProperty(USE_QUERY_CACHE)).thenReturn(USE_QUERY_CACHE.getDefaultValue());
+    when(config.getProperty(CACHE_EHCACHE_CONFIG_FILE))
+        .thenReturn(CACHE_EHCACHE_CONFIG_FILE.getDefaultValue());
+
+    Properties properties = HibernateConfig.getAdditionalProperties(config);
+
+    assertEquals("true", properties.get(AvailableSettings.USE_SECOND_LEVEL_CACHE));
+    assertEquals(
+        JCacheRegionFactory.class.getName(),
+        properties.get(AvailableSettings.CACHE_REGION_FACTORY));
+  }
+}


### PR DESCRIPTION
We were setting the Hibernate second level cache property only when the `dhis.conf` property was set to `true`. Setting it to `false` in the conf had no effect. Now we explicitly set it in both cases.

Verified that it works by:
* Running `curl -H "Accept: text/plain" -u admin:district http://localhost:8080/api/metrics | grep hibernate_cache_l2`
  When the cache is enabled, the statistics show how many times an entity is read from or written to the L2 cache. When the cache is disabled, the statistics show 0 in both cases.

* Query log
  When running a request like `GET /api/organisationUnits/{uid}.json` multiple times, if the L2 cache is enabled, the logs show the request only once. If the L2 cache is disabled, the request shows up every time.
