### PR TITLE
fix: invalidate template cache and use live template when sending notifications [DHIS2-21836]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationTemplateService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationTemplateService.java
@@ -48,6 +48,14 @@ public interface ProgramNotificationTemplateService {
    */
   ProgramNotificationTemplate getByUidCached(String uid);
 
+  /**
+   * Evicts the given template from the {@link #getByUidCached(String)} cache. Must be called
+   * whenever a template is modified outside of {@link #save}/{@link #update}/{@link #delete} (e.g.
+   * through the metadata import pipeline), otherwise stale templates keep being used when sending
+   * notifications.
+   */
+  void invalidateCache(String uid);
+
   void save(ProgramNotificationTemplate programNotificationTemplate);
 
   void update(ProgramNotificationTemplate programNotificationTemplate);

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationTemplateService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationTemplateService.java
@@ -53,6 +53,11 @@ public interface ProgramNotificationTemplateService {
    * whenever a template is modified outside of {@link #save}/{@link #update}/{@link #delete} (e.g.
    * through the metadata import pipeline), otherwise stale templates keep being used when sending
    * notifications.
+   *
+   * <p>When called within an active transaction the eviction is deferred until after that
+   * transaction commits, so it never runs before the write is visible to other connections. This
+   * avoids re-caching a stale template that a concurrent reader could otherwise fetch during the
+   * eviction-inside-transaction window. Outside a transaction the eviction happens immediately.
    */
   void invalidateCache(String uid);
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/template/NotificationTemplateMapper.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/template/NotificationTemplateMapper.java
@@ -112,7 +112,7 @@ public class NotificationTemplateMapper {
                         template.getRecipientDataElement(),
                         IdentifiableObjectSnapshot::new,
                         Collections.emptyList())),
-            t -> t.setSendRepeatable(t.isSendRepeatable()),
+            t -> t.setSendRepeatable(template.isSendRepeatable()),
             t -> t.setRecipientUserGroup(toUserGroupSnapshot(template.getRecipientUserGroup()))));
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramNotificationTemplateService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramNotificationTemplateService.java
@@ -41,6 +41,8 @@ import org.hisp.dhis.program.notification.ProgramNotificationTemplateService;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplateStore;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * @author Zubair Asghar
@@ -99,7 +101,22 @@ public class DefaultProgramNotificationTemplateService
 
   @Override
   public void invalidateCache(String uid) {
-    templateCache.invalidate(uid);
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      // Defer eviction until the surrounding transaction commits. Evicting mid-transaction, before
+      // the write is visible to other connections (PostgreSQL defaults to READ COMMITTED), lets a
+      // concurrent reader miss, re-read the still-committed pre-edit row, and re-cache the stale
+      // template until TTL. Evicting only after commit means a reader has to arrive already-missing
+      // to re-cache a stale value, a much narrower race.
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              templateCache.invalidate(uid);
+            }
+          });
+    } else {
+      templateCache.invalidate(uid);
+    }
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramNotificationTemplateService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramNotificationTemplateService.java
@@ -98,24 +98,29 @@ public class DefaultProgramNotificationTemplateService
   }
 
   @Override
+  public void invalidateCache(String uid) {
+    templateCache.invalidate(uid);
+  }
+
+  @Override
   @Transactional
   public void save(ProgramNotificationTemplate programNotificationTemplate) {
     store.save(programNotificationTemplate);
-    templateCache.invalidate(programNotificationTemplate.getUid());
+    invalidateCache(programNotificationTemplate.getUid());
   }
 
   @Override
   @Transactional
   public void update(ProgramNotificationTemplate programNotificationTemplate) {
     store.update(programNotificationTemplate);
-    templateCache.invalidate(programNotificationTemplate.getUid());
+    invalidateCache(programNotificationTemplate.getUid());
   }
 
   @Override
   @Transactional
   public void delete(ProgramNotificationTemplate programNotificationTemplate) {
     store.delete(programNotificationTemplate);
-    templateCache.invalidate(programNotificationTemplate.getUid());
+    invalidateCache(programNotificationTemplate.getUid());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/DefaultProgramNotificationTemplateServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/DefaultProgramNotificationTemplateServiceTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.program;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
+import org.hisp.dhis.program.notification.ProgramNotificationTemplateOperationParamsMapper;
+import org.hisp.dhis.program.notification.ProgramNotificationTemplateStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultProgramNotificationTemplateServiceTest {
+  private static final String UID = "PNT_UID_1";
+
+  @Mock private ProgramNotificationTemplateStore store;
+
+  @Mock private ProgramNotificationTemplateOperationParamsMapper paramsMapper;
+
+  @Mock private CacheProvider cacheProvider;
+
+  @Mock private Cache<ProgramNotificationTemplate> templateCache;
+
+  private DefaultProgramNotificationTemplateService service;
+
+  @BeforeEach
+  void setUp() {
+    doReturn(templateCache).when(cacheProvider).createNotificationTemplateCache();
+    service = new DefaultProgramNotificationTemplateService(store, paramsMapper, cacheProvider);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
+
+  @Test
+  void shouldEvictImmediatelyWhenNoTransactionIsActive() {
+    service.invalidateCache(UID);
+
+    verify(templateCache).invalidate(UID);
+  }
+
+  @Test
+  void shouldDeferEvictionUntilAfterCommitWhenTransactionIsActive() {
+    TransactionSynchronizationManager.initSynchronization();
+
+    service.invalidateCache(UID);
+
+    // Eviction must not happen while the transaction is still open: the write is not yet visible to
+    // other connections, so evicting now would let a concurrent reader re-cache the stale template.
+    verify(templateCache, never()).invalidate(UID);
+
+    List<TransactionSynchronization> synchronizations =
+        TransactionSynchronizationManager.getSynchronizations();
+    assertEquals(1, synchronizations.size());
+
+    synchronizations.get(0).afterCommit();
+
+    verify(templateCache).invalidate(UID);
+  }
+
+  @Test
+  void shouldNotEvictWhenTransactionRollsBack() {
+    TransactionSynchronizationManager.initSynchronization();
+
+    service.invalidateCache(UID);
+
+    List<TransactionSynchronization> synchronizations =
+        TransactionSynchronizationManager.getSynchronizations();
+    synchronizations.get(0).afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+    // The write was rolled back, so the cached template is still valid and must not be evicted.
+    verify(templateCache, never()).invalidate(UID);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramNotificationTemplateObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramNotificationTemplateObjectBundleHook.java
@@ -33,19 +33,24 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.DeliveryChannel;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.program.notification.ProgramNotificationRecipient;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
+import org.hisp.dhis.program.notification.ProgramNotificationTemplateService;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Halvdan Hoem Grelland
  */
 @Component
+@AllArgsConstructor
 public class ProgramNotificationTemplateObjectBundleHook
     extends AbstractObjectBundleHook<ProgramNotificationTemplate> {
+  private final ProgramNotificationTemplateService programNotificationTemplateService;
+
   private static final Map<
           ProgramNotificationRecipient, Function<ProgramNotificationTemplate, ValueType>>
       RECIPIENT_TO_VALUETYPE_RESOLVER =
@@ -79,11 +84,23 @@ public class ProgramNotificationTemplateObjectBundleHook
   @Override
   public void postCreate(ProgramNotificationTemplate template, ObjectBundle bundle) {
     postProcess(template);
+    // Evict any stale entry (e.g. a template deleted then re-created with the same uid) so the
+    // cached-template send path picks up the newly persisted delivery channels.
+    programNotificationTemplateService.invalidateCache(template.getUid());
   }
 
   @Override
   public void postUpdate(ProgramNotificationTemplate template, ObjectBundle bundle) {
     postProcess(template);
+    // The metadata import pipeline persists directly through the store and bypasses
+    // ProgramNotificationTemplateService, so the getByUidCached cache would otherwise keep serving
+    // the pre-edit template (e.g. still delivering email after the channel was deselected).
+    programNotificationTemplateService.invalidateCache(template.getUid());
+  }
+
+  @Override
+  public void preDelete(ProgramNotificationTemplate template, ObjectBundle bundle) {
+    programNotificationTemplateService.invalidateCache(template.getUid());
   }
 
   /** Removes any non-valid combinations of properties on the template object. */

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramNotificationTemplateObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramNotificationTemplateObjectBundleHookTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
+
+import static org.mockito.Mockito.verify;
+
+import org.hisp.dhis.program.notification.ProgramNotificationRecipient;
+import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
+import org.hisp.dhis.program.notification.ProgramNotificationTemplateService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProgramNotificationTemplateObjectBundleHookTest {
+  private static final String TEMPLATE_UID = "abcdefghij0";
+
+  @Mock private ProgramNotificationTemplateService programNotificationTemplateService;
+
+  private ProgramNotificationTemplateObjectBundleHook hook;
+
+  @BeforeEach
+  void setUp() {
+    hook = new ProgramNotificationTemplateObjectBundleHook(programNotificationTemplateService);
+  }
+
+  @Test
+  void shouldInvalidateCacheOnPostUpdate() {
+    hook.postUpdate(template(), null);
+
+    verify(programNotificationTemplateService).invalidateCache(TEMPLATE_UID);
+  }
+
+  @Test
+  void shouldInvalidateCacheOnPostCreate() {
+    hook.postCreate(template(), null);
+
+    verify(programNotificationTemplateService).invalidateCache(TEMPLATE_UID);
+  }
+
+  @Test
+  void shouldInvalidateCacheOnPreDelete() {
+    hook.preDelete(template(), null);
+
+    verify(programNotificationTemplateService).invalidateCache(TEMPLATE_UID);
+  }
+
+  private ProgramNotificationTemplate template() {
+    ProgramNotificationTemplate template = new ProgramNotificationTemplate();
+    template.setUid(TEMPLATE_UID);
+    template.setNotificationRecipient(ProgramNotificationRecipient.TRACKED_ENTITY_INSTANCE);
+    return template;
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/DefaultProgramNotificationService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/DefaultProgramNotificationService.java
@@ -294,26 +294,39 @@ public class DefaultProgramNotificationService extends HibernateGenericStore<Tra
 
   private ProgramNotificationTemplate getApplicableTemplate(
       ProgramNotificationInstance programNotificationInstance) {
-    return Optional.of(programNotificationInstance)
-        .map(ProgramNotificationInstance::getProgramNotificationTemplateSnapshot)
-        .map(NotificationTemplateMapper::toProgramNotificationTemplate)
-        .orElseGet(() -> this.getDatabaseTemplate(programNotificationInstance));
+    // Prefer the live template so edits made after the notification was scheduled (e.g. removing a
+    // delivery channel) take effect. The frozen jsonb snapshot is only a fallback for when the
+    // template has since been deleted, so the notification can still be sent.
+    ProgramNotificationTemplate databaseTemplate = getDatabaseTemplate(programNotificationInstance);
+    if (databaseTemplate != null) {
+      return databaseTemplate;
+    }
+    return getSnapshotTemplate(programNotificationInstance);
   }
 
   private ProgramNotificationTemplate getDatabaseTemplate(
       ProgramNotificationInstance programNotificationInstance) {
-    log.warn("Couldn't use template from jsonb column, using the one from database if possible");
-    if (Objects.nonNull(programNotificationInstance.getProgramNotificationTemplateId())) {
-      ProgramNotificationTemplate programNotificationTemplate =
-          notificationTemplateService.get(
-              programNotificationInstance.getProgramNotificationTemplateId());
-      if (Objects.isNull(programNotificationTemplate)) {
-        log.warn(
-            "Unable to load program notification template from database, because it might have been deleted.");
-      }
-      return programNotificationTemplate;
+    if (Objects.isNull(programNotificationInstance.getProgramNotificationTemplateId())) {
+      return null;
     }
-    return null;
+    return notificationTemplateService.get(
+        programNotificationInstance.getProgramNotificationTemplateId());
+  }
+
+  private ProgramNotificationTemplate getSnapshotTemplate(
+      ProgramNotificationInstance programNotificationInstance) {
+    ProgramNotificationTemplate snapshotTemplate =
+        Optional.of(programNotificationInstance)
+            .map(ProgramNotificationInstance::getProgramNotificationTemplateSnapshot)
+            .map(NotificationTemplateMapper::toProgramNotificationTemplate)
+            .orElse(null);
+    if (snapshotTemplate == null) {
+      log.warn(
+          "Unable to resolve a program notification template for instance with id: {}. The template "
+              + "may have been deleted and no snapshot is available.",
+          programNotificationInstance.getId());
+    }
+    return snapshotTemplate;
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/program/notification/ProgramNotificationServiceTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/program/notification/ProgramNotificationServiceTest.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.tracker.program.notification;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
@@ -515,6 +516,82 @@ class ProgramNotificationServiceTest extends TrackerTestBase {
     when(programNotificationInstanceService.getProgramNotificationInstances(any()))
         .thenReturn(Collections.singletonList(programNotificationInstaceForToday));
 
+    when(programNotificationRenderer.render(any(Enrollment.class), any(NotificationTemplate.class)))
+        .thenReturn(notificationMessage);
+
+    programNotificationService.sendScheduledNotifications(JobProgress.noop());
+
+    assertEquals(1, sentProgramMessages.size());
+  }
+
+  @Test
+  void shouldUseLiveTemplateInsteadOfStaleSnapshotWhenTemplateStillExists() {
+    sentProgramMessages.clear();
+
+    // Snapshot was frozen when the template still delivered on EMAIL...
+    ProgramNotificationTemplate staleTemplate =
+        createProgramNotificationTemplate(
+            TEMPLATE_NAME,
+            0,
+            NotificationTrigger.PROGRAM_RULE,
+            ProgramNotificationRecipient.PROGRAM_ATTRIBUTE);
+    staleTemplate.setUid(notificationTemplate);
+    staleTemplate.setRecipientProgramAttribute(trackedEntityAttribute);
+    staleTemplate.setDeliveryChannels(Sets.newHashSet(DeliveryChannel.EMAIL));
+    programNotificationInstaceForToday.setProgramNotificationTemplateSnapshot(
+        NotificationTemplateMapper.toProgramNotificationTemplateSnapshot(staleTemplate));
+
+    // ...but the template was later edited to deliver on SMS only.
+    long templateId = 999L;
+    programNotificationInstaceForToday.setProgramNotificationTemplateId(templateId);
+    ProgramNotificationTemplate liveTemplate =
+        createProgramNotificationTemplate(
+            TEMPLATE_NAME,
+            0,
+            NotificationTrigger.PROGRAM_RULE,
+            ProgramNotificationRecipient.PROGRAM_ATTRIBUTE);
+    liveTemplate.setUid(notificationTemplate);
+    liveTemplate.setRecipientProgramAttribute(trackedEntityAttribute);
+    liveTemplate.setDeliveryChannels(Sets.newHashSet(DeliveryChannel.SMS));
+    when(notificationTemplateService.get(templateId)).thenReturn(liveTemplate);
+
+    when(programNotificationInstanceService.getProgramNotificationInstances(any()))
+        .thenReturn(Collections.singletonList(programNotificationInstaceForToday));
+    when(programMessageService.sendMessages(anyList()))
+        .thenAnswer(
+            invocation -> {
+              sentProgramMessages.addAll((List<ProgramMessage>) invocation.getArguments()[0]);
+              return new BatchResponseStatus(Collections.emptyList());
+            });
+    when(programNotificationRenderer.render(any(Enrollment.class), any(NotificationTemplate.class)))
+        .thenReturn(notificationMessage);
+
+    programNotificationService.sendScheduledNotifications(JobProgress.noop());
+
+    assertEquals(1, sentProgramMessages.size());
+    ProgramMessage programMessage = sentProgramMessages.iterator().next();
+    // The edited (live) template wins: SMS is used and EMAIL is no longer delivered.
+    assertTrue(programMessage.getDeliveryChannels().contains(DeliveryChannel.SMS));
+    assertFalse(programMessage.getDeliveryChannels().contains(DeliveryChannel.EMAIL));
+    assertTrue(programMessage.getRecipients().getPhoneNumbers().contains(ATT_PHONE_NUMBER));
+    assertTrue(programMessage.getRecipients().getEmailAddresses().isEmpty());
+  }
+
+  @Test
+  void shouldFallBackToSnapshotWhenTemplateWasDeleted() {
+    sentProgramMessages.clear();
+
+    // No live template id -> template deleted; the snapshot must still be usable.
+    programNotificationInstaceForToday.setProgramNotificationTemplateId(null);
+
+    when(programNotificationInstanceService.getProgramNotificationInstances(any()))
+        .thenReturn(Collections.singletonList(programNotificationInstaceForToday));
+    when(programMessageService.sendMessages(anyList()))
+        .thenAnswer(
+            invocation -> {
+              sentProgramMessages.addAll((List<ProgramMessage>) invocation.getArguments()[0]);
+              return new BatchResponseStatus(Collections.emptyList());
+            });
     when(programNotificationRenderer.render(any(Enrollment.class), any(NotificationTemplate.class)))
         .thenReturn(notificationMessage);
 


### PR DESCRIPTION
## Summary

Fixes [DHIS2-21836]: after editing a program notification template to deselect the email delivery channel, users still received emails (even with no channel or only SMS selected), and clearing the cache did not help. The template was being read from an in-memory cache that the metadata edit path never invalidated, and scheduled program-rule notifications were reading a frozen template snapshot instead of the current template. Both are now fixed so channel edits take effect immediately.

## Changes

- **Cache invalidation on the real edit path** (`ProgramNotificationTemplateObjectBundleHook.java`): template edits go through the metadata/ObjectBundle pipeline, which bypasses `ProgramNotificationTemplateService.save/update/delete` — the only place the `getByUidCached` cache was invalidated. The hook now evicts the cache in `postCreate`, `postUpdate`, and `preDelete`, so a deselected channel is honored on the next notification instead of serving the stale pre-edit template.
- **Service cache API** (`ProgramNotificationTemplateService.java`, `DefaultProgramNotificationTemplateService.java`): adds `invalidateCache(String uid)` to the interface and implementation, and routes the existing save/update/delete invalidations through it.
- **Prefer live template over snapshot** (`DefaultProgramNotificationService.java`): `getApplicableTemplate` now uses the live database template and only falls back to the frozen JSONB snapshot when the template has been deleted. This makes edits take effect on already-scheduled program-rule notifications while preserving the snapshot's purpose of surviving template deletion. The misleading `log.warn` now fires only when no template can be resolved at all.
- **Snapshot mapping fix** (`NotificationTemplateMapper.java`): corrects `setSendRepeatable(t.isSendRepeatable())`, which read from the snapshot being built instead of the source template, so `sendRepeatable` is now captured.
- **Tests**: `ProgramNotificationTemplateObjectBundleHookTest` verifies the cache is invalidated on create/update/delete; `ProgramNotificationServiceTest` adds cases proving the live template wins over a stale snapshot and that the snapshot is still used when the template was deleted.


[DHIS2-21836]: https://dhis2.atlassian.net/browse/DHIS2-21836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ