### PR TITLE
perf: evaluate the rowContext subquery once, in a lateral join

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -1187,6 +1187,11 @@ public abstract class AbstractJdbcEventAnalyticsManager {
 
     sql += getFromClause(params);
 
+    // Required, not merely an optimisation: getSelectClause may have emitted columns that read from
+    // these joins, and without them the inner select references tables that do not exist. Any
+    // assembly that calls getSelectClause has to append this too.
+    sql += getRowContextJoinClause(params);
+
     String whereClause = getWhereClause(params);
     String filterWhereClause = getQueryItemsAndFiltersWhereClause(params, new SqlHelper());
     sql += SqlConditionJoiner.joinSqlConditions(whereClause, filterWhereClause);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -167,6 +167,9 @@ public abstract class AbstractJdbcEventAnalyticsManager {
 
   private static final String LIMIT = "limit";
 
+  /** Alias prefix for the lateral joins that serve the row-context columns. */
+  private static final String ROW_CONTEXT_TABLE_ALIAS_PREFIX = "rowcontext_";
+
   private static final Collector<CharSequence, ?, String> OR_JOINER = joining(OR, "(", ")");
 
   private static final Collector<CharSequence, ?, String> AND_JOINER = joining(AND);
@@ -432,14 +435,40 @@ public abstract class AbstractJdbcEventAnalyticsManager {
       EventQueryParams params,
       boolean isGroupByClause,
       boolean isAggregated) {
-    for (QueryItem queryItem : params.getItems()) {
+    boolean lateralsApply = rowContextLateralsApply(isGroupByClause, isAggregated);
+
+    for (int index = 0; index < params.getItems().size(); index++) {
+      QueryItem queryItem = params.getItems().get(index);
       ColumnAndAlias columnAndAlias =
           getColumnAndAlias(queryItem, params, isGroupByClause, isAggregated);
 
+      // asked for row context if allowed and needed based on column and its alias
+      boolean rowContext =
+          rowContextAllowedAndNeeded(params, queryItem) && !isEmpty(columnAndAlias.alias);
+
+      Optional<RowContextLateral> lateral =
+          rowContext && lateralsApply
+              ? asRowContextLateral(columnAndAlias.column, index)
+              : Optional.empty();
+
+      if (lateral.isPresent()) {
+        String table = quote(lateral.get().tableAlias());
+        columns.add(
+            ColumnAndAlias.ofColumnAndAlias(table + ".value", columnAndAlias.alias).asSql());
+        columns.add(
+            ColumnAndAlias.ofColumnAndAlias(
+                    "coalesce(" + table + ".found, false)", columnAndAlias.alias + ".exists")
+                .asSql());
+        columns.add(
+            ColumnAndAlias.ofColumnAndAlias(
+                    table + ".eventstatus", columnAndAlias.alias + ".status")
+                .asSql());
+        continue;
+      }
+
       columns.add(columnAndAlias.asSql());
 
-      // asked for row context if allowed and needed based on column and its alias
-      if (rowContextAllowedAndNeeded(params, queryItem) && !isEmpty(columnAndAlias.alias)) {
+      if (rowContext) {
         String columnForExists = " exists (" + columnAndAlias.column + ")";
         String aliasForExists = columnAndAlias.alias + ".exists";
         columns.add((new ColumnAndAlias(columnForExists, aliasForExists)).asSql());
@@ -449,6 +478,128 @@ public abstract class AbstractJdbcEventAnalyticsManager {
         columns.add((new ColumnAndAlias(columnForStatus, aliasForStatus)).asSql());
       }
     }
+  }
+
+  /**
+   * A lateral join that evaluates a repeatable-stage subquery once and exposes the three things the
+   * row-context response needs from it: the value, whether a matching event was found at all, and
+   * that event's status.
+   *
+   * @param tableAlias the alias the join is given, and through which the select list reads it.
+   * @param joinSql the {@code left join lateral (...) on true} fragment.
+   */
+  protected record RowContextLateral(String tableAlias, String joinSql) {}
+
+  /**
+   * The row-context columns can only be served from a lateral join on the query shape that has one
+   * - the plain enrollment select. A group-by or aggregated select does not get the join appended,
+   * so it must keep emitting the three correlated subqueries.
+   */
+  private static boolean rowContextLateralsApply(boolean isGroupByClause, boolean isAggregated) {
+    return !isGroupByClause && !isAggregated;
+  }
+
+  /**
+   * Returns the {@code left join lateral} fragments for the row-context items of the given query,
+   * in item order.
+   *
+   * <p>This is derived from {@code params} alone and from the same {@code getColumnAndAlias} calls
+   * {@link #addItemSelectColumns} makes, so the two agree on which items get a lateral and on the
+   * alias each one is given. Nothing is threaded between them.
+   */
+  protected String getRowContextJoinClause(EventQueryParams params) {
+    if (!params.isRowContext()) {
+      return EMPTY;
+    }
+
+    StringBuilder joins = new StringBuilder();
+
+    for (int index = 0; index < params.getItems().size(); index++) {
+      QueryItem queryItem = params.getItems().get(index);
+
+      if (!rowContextAllowedAndNeeded(params, queryItem)) {
+        continue;
+      }
+
+      ColumnAndAlias columnAndAlias = getColumnAndAlias(queryItem, params, false, false);
+
+      if (isEmpty(columnAndAlias.alias)) {
+        continue;
+      }
+
+      asRowContextLateral(columnAndAlias.column, index)
+          .ifPresent(lateral -> joins.append(lateral.joinSql()));
+    }
+
+    return joins.toString();
+  }
+
+  /**
+   * Turns a repeatable-stage scalar subquery into a lateral join that evaluates it once.
+   *
+   * <p>With {@code rowContext=true} each repeatable-stage data element used to emit the same
+   * correlated subquery three times - once for the value, once wrapped in {@code exists (...)}, and
+   * once with the selected column textually replaced by {@code eventstatus}. The planner sees three
+   * independent nodes, each with its own {@code order by occurreddate desc, created desc limit 1},
+   * so an enrollment line list with 18 such dimensions generated 54 subselects. A lateral evaluates
+   * the subquery once and all three columns read from its single row.
+   *
+   * <p>Deliberately driven off the already-built subquery text rather than rebuilt from its parts:
+   * the shapes {@code getColumn} can produce are several - {@code nullif}-wrapped, coordinate,
+   * organisation-unit-with-suffix - and only the plain {@code (select <one expression> from ...
+   * limit 1)} form can be rewritten this way. Anything else returns empty and keeps the three
+   * subqueries, so this is strictly an optimisation of the recognised shape.
+   *
+   * <p>Equivalence of the three columns:
+   *
+   * <ul>
+   *   <li>{@code value} is the same expression over the same row, so the same value.
+   *   <li>{@code exists ((select ... limit 1))} is true exactly when the subquery returned a row,
+   *       which is exactly when the lateral produced one, which is what {@code found} records.
+   *   <li>{@code .status} was the same subquery selecting {@code eventstatus} instead, so it is
+   *       that row's status - the row the lateral already has.
+   * </ul>
+   */
+  private Optional<RowContextLateral> asRowContextLateral(String subquery, int index) {
+    String trimmed = StringUtils.trimToEmpty(subquery);
+
+    if (!trimmed.startsWith("(select ") || !trimmed.endsWith(")")) {
+      return Optional.empty();
+    }
+
+    String body = trimmed.substring(1, trimmed.length() - 1).trim();
+    int fromIndex = body.indexOf(" from ");
+
+    if (fromIndex < 0) {
+      return Optional.empty();
+    }
+
+    String selectList = body.substring("select".length(), fromIndex).trim();
+    String rest = body.substring(fromIndex);
+
+    // One unaliased expression, and a query that references eventstatus - which the
+    // repeatable-stage
+    // subquery does, in its "eventstatus != 'SCHEDULE'" filter. Anything else is a shape this
+    // cannot
+    // safely rewrite.
+    if (selectList.isEmpty()
+        || selectList.contains(",")
+        || selectList.contains(" as ")
+        || !rest.contains("eventstatus")) {
+      return Optional.empty();
+    }
+
+    String tableAlias = ROW_CONTEXT_TABLE_ALIAS_PREFIX + index;
+    String joinSql =
+        " left join lateral (select "
+            + selectList
+            + " as value, eventstatus, true as found"
+            + rest
+            + ") as "
+            + quote(tableAlias)
+            + " on true ";
+
+    return Optional.of(new RowContextLateral(tableAlias, joinSql));
   }
 
   /**
@@ -1010,6 +1161,10 @@ public abstract class AbstractJdbcEventAnalyticsManager {
     String sql = getSelectClause(params);
 
     sql += getFromClause(params);
+
+    // Must sit between the from and where clauses: the laterals reference the base table's
+    // enrollment column, and the where clause may reference the laterals' own columns.
+    sql += getRowContextJoinClause(params);
 
     sql += getWhereClause(params);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -72,6 +72,7 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.RepeatableStageParams;
+import org.hisp.dhis.common.RequestTypeAware;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.PostgreSqlBuilder;
@@ -225,6 +226,37 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
   @Test
   void verifyWithRepeatableProgramStageAndTextDataElement() {
     verifyWithRepeatableProgramStageAndDataElement(ValueType.TEXT);
+  }
+
+  /**
+   * The aggregated-enrollments query wraps its own select clause in an outer count, and that select
+   * clause goes through the same row-context handling. Every assembly that emits columns reading
+   * from a lateral join has to emit the join as well - otherwise the SQL references a table that is
+   * not in the query. This asserts they stay in step.
+   */
+  @Test
+  void verifyAggregatedEnrollmentsWithRowContextEmitsTheLateralItReadsFrom() {
+    EventQueryParams params =
+        new EventQueryParams.Builder(createRequestParams(repeatableProgramStage, ValueType.TEXT))
+            .withEndpointAction(RequestTypeAware.EndpointAction.AGGREGATE)
+            .withEndpointItem(RequestTypeAware.EndpointItem.ENROLLMENT)
+            .build();
+
+    subject.getEnrollments(params, new ListGrid(), 100);
+
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generated = sql.getValue();
+
+    // The select list reads three columns off the lateral; the lateral must be declared once.
+    assertEquals(
+        3,
+        StringUtils.countMatches(generated, "\"rowcontext_0\"."),
+        "expected value, exists and status to read from the lateral: " + generated);
+    assertEquals(
+        1,
+        StringUtils.countMatches(generated, "as \"rowcontext_0\" on true"),
+        "the lateral the select list reads from must be joined in: " + generated);
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -59,6 +59,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.function.Consumer;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.event.EventQueryParams;
@@ -283,64 +284,51 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
 
     String dataElementUid = dataElementA.getUid();
 
+    // rowContext=true used to emit this subquery three times - the value, the same subquery wrapped
+    // in exists(...), and the same subquery with the column textually replaced by eventstatus - so
+    // 18 data elements produced 54 correlated subselects. It is now evaluated once in a lateral
+    // join
+    // and all three columns read from that one row.
+    String columnAlias = programStageUid + "[-1]." + dataElementUid;
+
     String expected =
         "select enrollment,trackedentity,enrollmentdate,occurreddate,storedby,createdbydisplayname,lastupdatedbydisplayname,lastupdated,ST_AsGeoJSON(enrollmentgeometry),longitude,latitude,"
             + "ouname,ounamehierarchy,oucode,enrollmentstatus,ax.\"quarterly\",ax.\"ou\","
-            + "(select \""
-            + dataElementUid
-            + "\" from analytics_event_"
-            + programUid
-            + " where analytics_event_"
-            + programUid
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programUid
-            + ".enrollment = ax.enrollment and ps = '"
-            + repeatableProgramStage.getUid()
-            + "' order by occurreddate desc, created desc offset 1 limit 1 ) "
-            + "as \""
-            + programStageUid
-            + "[-1]."
-            + dataElementUid
-            + "\", exists ((select \""
-            + dataElementUid
-            + "\" "
-            + "from analytics_event_"
-            + programUid
-            + " where analytics_event_"
-            + programUid
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programUid
-            + ".enrollment = ax.enrollment and ps = '"
-            + programStageUid
-            + "' order by occurreddate desc, created desc offset 1 limit 1 )) "
-            + "as \""
-            + programStageUid
-            + "[-1]."
-            + dataElementUid
-            + ".exists\""
-            + ",(select eventstatus "
-            + "from analytics_event_"
-            + programUid
-            + " where analytics_event_"
-            + programUid
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programUid
-            + ".enrollment = ax.enrollment and ps = '"
-            + programStageUid
-            + "' order by occurreddate desc, created desc offset 1 limit 1 ) "
-            + "as \""
-            + programStageUid
-            + "[-1]."
-            + dataElementUid
+            + "\"rowcontext_0\".value as \""
+            + columnAlias
+            + "\","
+            + "coalesce(\"rowcontext_0\".found, false) as \""
+            + columnAlias
+            + ".exists\","
+            + "\"rowcontext_0\".eventstatus as \""
+            + columnAlias
             + ".status\"  "
             + "from analytics_enrollment_"
             + programUid
-            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) "
+            + " as ax "
+            + " left join lateral (select \""
+            + dataElementUid
+            + "\" as value, eventstatus, true as found from analytics_event_"
+            + programUid
+            + " where analytics_event_"
+            + programUid
+            + ".eventstatus != 'SCHEDULE' and analytics_event_"
+            + programUid
+            + ".enrollment = ax.enrollment and ps = '"
+            + programStageUid
+            + "' order by occurreddate desc, created desc offset 1 limit 1) as \"rowcontext_0\" on true "
+            + "where (ax.\"quarterly\" in ('2000Q1') ) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) "
             + "and ps = '"
             + programStageUid
             + "' limit 101";
 
     assertEquals(expected, sql.getValue());
+
+    // The point of the change, asserted as a count rather than left implicit in the string above:
+    // the subquery is written once, and neither of the two duplicates survives.
+    assertEquals(1, StringUtils.countMatches(sql.getValue(), "left join lateral"));
+    assertEquals(1, StringUtils.countMatches(sql.getValue(), "order by occurreddate desc"));
+    assertEquals(0, StringUtils.countMatches(sql.getValue(), "exists (("));
   }
 
   @Test


### PR DESCRIPTION
## The problem

With `rowContext=true`, each repeatable-stage data element emits its correlated subquery three
times — once for the value, once for `.exists` and once for `.status`. Eighteen data elements
become 54 correlated subselects, and Postgres does not collapse them.

## The solution

The subquery is emitted once, as a `left join lateral`. A second commit fixes a latent defect the
rewrite exposed: `getAggregatedEnrollmentsSql` builds its select clause through the same code, so
it emitted columns reading from the lateral alias without ever joining the lateral in — any
aggregate enrollment request with a repeatable stage generated SQL referencing a table that was not
in the query.

## Why this is a good solution

```
before   54 SubPlan nodes,  0 Nested Loop Left Join   planning 7.962 ms
after     0 SubPlan nodes, 18 Nested Loop Left Join   planning 1.846 ms
```

Replayed against a 200 000-row enrollment and 600 000-row event fixture: **28.1 ms → 17.8 ms,
1.54×**, with byte-identical output over 101 rows. `.exists` and `.status` semantics are unchanged,
including the `eventstatus != 'SCHEDULE'` handling, and the `rowContext=false` path generates
byte-identical SQL to today. The aggregate fix carries a test that fails when the join is removed
again.

**The 1.54× should not carry the merge decision.** On that fixture the base scan is still a third
of what remains after the fix, so the ceiling here is 3×, not 54/18×. On the instance that
motivated the change the cost is independent of rows returned — 1 row took 13.537 s and 101 rows
took 13.438 s — which is the signature of a base scan, not of a per-row subquery fan-out. If that
holds, this is a tidy-up and the real fix is a composite `(uidlevel*, enrollmentdate)` index. The
`EXPLAIN (ANALYZE, BUFFERS)` that would settle it has not been run.