### PR TITLE
fix: do not create HTTP session in SessionIdFilter for stateless requests

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/filter/SessionIdFilterTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/filter/SessionIdFilterTest.java
@@ -35,6 +35,8 @@ import static org.hisp.dhis.webapi.filter.SessionIdFilter.hashToBase64;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.servlet.FilterChain;
@@ -42,8 +44,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -70,6 +74,11 @@ class SessionIdFilterTest {
     MDC.clear();
   }
 
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
   @Test
   void testIsDisabled() throws Exception {
     init(false);
@@ -80,34 +89,56 @@ class SessionIdFilterTest {
 
   @Test
   void testIsEnabled() throws Exception {
+    authenticate();
 
+    init(true);
+    AtomicReference<String> inChain =
+        doFilter(
+            request -> {
+              HttpSession session = mock(HttpSession.class);
+              when(request.getSession(false)).thenReturn(session);
+              when(session.getId()).thenReturn("ABCDEFGHILMNO");
+            });
+
+    assertEquals("ID" + hashToBase64("ABCDEFGHILMNO"), inChain.get());
+    assertNull(MDC.get(MDC_SESSION_ID), "session ID must be removed from MDC after the request");
+  }
+
+  @Test
+  void testDoesNotCreateSessionWhenNoneExists() throws Exception {
+    authenticate();
+
+    init(true);
+    AtomicReference<String> inChain =
+        doFilter(request -> when(request.getSession(false)).thenReturn(null));
+
+    assertNull(inChain.get());
+    assertNull(MDC.get(MDC_SESSION_ID));
+  }
+
+  private void authenticate() {
     Authentication authentication =
         new UsernamePasswordAuthenticationToken(
             "admin", "admin", List.of((GrantedAuthority) () -> "ALL"));
     SecurityContext context = SecurityContextHolder.createEmptyContext();
     context.setAuthentication(authentication);
-
     SecurityContextHolder.setContext(context);
-
-    init(true);
-    doFilter(
-        request -> {
-          HttpSession session = mock(HttpSession.class);
-          when(request.getSession()).thenReturn(session);
-          when(session.getId()).thenReturn("ABCDEFGHILMNO");
-        });
-
-    assertEquals("ID" + hashToBase64("ABCDEFGHILMNO"), MDC.get(MDC_SESSION_ID));
   }
 
-  private void doFilter(Consumer<HttpServletRequest> withRequest) throws Exception {
+  private AtomicReference<String> doFilter(Consumer<HttpServletRequest> withRequest)
+      throws Exception {
     HttpServletRequest req = mock(HttpServletRequest.class);
     HttpServletResponse res = mock(HttpServletResponse.class);
-    FilterChain filterChain = mock(FilterChain.class);
+    AtomicReference<String> inChain = new AtomicReference<>();
+    FilterChain filterChain = (request, response) -> inChain.set(MDC.get(MDC_SESSION_ID));
 
     withRequest.accept(req);
 
     subject.doFilter(req, res, filterChain);
+
+    verify(req, never()).getSession();
+    verify(req, never()).getSession(true);
+    return inChain;
   }
 
   private void init(boolean enabled) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/SessionIdFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/SessionIdFilter.java
@@ -36,6 +36,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -54,7 +55,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * via {@code %X{sessionId}} in log4j2 pattern layouts.
  *
  * <p>The session ID is hashed using SHA-256 and base64-encoded for security. Only enabled when
- * {@code logging.session_id} is true.
+ * {@code logging.session_id} is true. The filter never creates a session; requests without an
+ * existing session (e.g. PAT or other stateless authentication) are left untouched.
  *
  * @author Luciano Fiandesio
  * @see <a href="https://logback.qos.ch/manual/mdc.html">MDC Documentation</a>
@@ -87,14 +89,21 @@ public class SessionIdFilter extends OncePerRequestFilter {
             && authentication.isAuthenticated()
             && !authentication.getPrincipal().equals("anonymousUser")) {
 
-          MDC.put(MDC_SESSION_ID, IDENTIFIER_PREFIX + hashToBase64(req.getSession().getId()));
+          HttpSession session = req.getSession(false);
+          if (session != null) {
+            MDC.put(MDC_SESSION_ID, IDENTIFIER_PREFIX + hashToBase64(session.getId()));
+          }
         }
       } catch (NoSuchAlgorithmException e) {
         log.error(String.format("Invalid Hash algorithm provided (%s)", HASH_ALGO), e);
       }
     }
 
-    chain.doFilter(req, res);
+    try {
+      chain.doFilter(req, res);
+    } finally {
+      MDC.remove(MDC_SESSION_ID);
+    }
   }
 
   static String hashToBase64(String sessionId) throws NoSuchAlgorithmException {


### PR DESCRIPTION
## Problem

With `logging.session_id` enabled, `SessionIdFilter` called `req.getSession().getId()`, which implicitly creates an HTTP session when none exists. Since the filter runs on every request, all authenticated stateless requests (PAT, basic auth API clients) silently got an unwanted server-side session.

The filter also never removed the `sessionId` MDC key, so the hashed session ID could leak into log lines of the next request served by the same pooled thread.

## Fix

- Use `req.getSession(false)` with a null guard: no existing session means no MDC entry and no session creation.
- Remove `MDC_SESSION_ID` in a `finally` around `chain.doFilter` (same pattern as `RequestIdFilter`).

## Tests

`SessionIdFilterTest` updated: asserts the MDC value inside the filter chain (it is cleared after the request now), and a new test verifies no MDC entry and that `getSession()`/`getSession(true)` are never invoked when no session exists.

AI Assisted