### PR TITLE
canary: NONSTRICT_READ_WRITE for all L2 cache regions (experiment, not for merge)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/Category.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/Category.java
@@ -113,7 +113,7 @@ import org.hisp.dhis.user.sharing.Sharing;
 @Entity
 @Table(name = "category")
 @Setter
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JacksonXmlRootElement(localName = "category", namespace = DxfNamespaces.DXF_2_0)
 public class Category extends BaseMetadataObject
     implements DimensionalObject, SystemDefaultMetadataObject {
@@ -155,11 +155,11 @@ public class Category extends BaseMetadataObject
               name = "categoryoptionid",
               foreignKey = @ForeignKey(name = "fk_category_categoryoptionid")))
   @OrderColumn(name = "sort_order")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<CategoryOption> categoryOptions = new ArrayList<>();
 
   @ManyToMany(mappedBy = "categories", fetch = FetchType.LAZY)
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<CategoryCombo> categoryCombos = new HashSet<>();
 
   @Embedded private TranslationProperty translations = new TranslationProperty();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryCombo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryCombo.java
@@ -124,11 +124,11 @@ public class CategoryCombo extends BaseMetadataObject
               foreignKey = @ForeignKey(name = "fk_categorycombo_categoryid")))
   @OrderColumn(name = "sort_order")
   @ListIndexBase(1)
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<Category> categories = new ArrayList<>();
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "categoryCombo")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<CategoryOptionCombo> optionCombos = new HashSet<>();
 
   @Column(name = "datadimensiontype", nullable = false)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
@@ -112,7 +112,7 @@ import org.hisp.dhis.user.sharing.UserGroupAccess;
 @Entity
 @Table(name = "categoryoption")
 @Setter
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JacksonXmlRootElement(localName = "categoryOption", namespace = DXF_2_0)
 public class CategoryOption extends BaseMetadataObject
     implements DimensionalItemObject, SystemDefaultMetadataObject, Serializable {
@@ -159,21 +159,21 @@ public class CategoryOption extends BaseMetadataObject
       name = "categoryoption_organisationunits",
       joinColumns = @JoinColumn(name = "categoryoptionid"),
       inverseJoinColumns = @JoinColumn(name = "organisationunitid"))
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   @BatchSize(size = 100)
   private Set<OrganisationUnit> organisationUnits = new HashSet<>();
 
   @ManyToMany(mappedBy = "categoryOptions")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   @BatchSize(size = 100)
   private Set<Category> categories = new HashSet<>();
 
   @ManyToMany(mappedBy = "categoryOptions")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<CategoryOptionCombo> categoryOptionCombos = new HashSet<>();
 
   @ManyToMany(mappedBy = "members")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<CategoryOptionGroup> groups = new HashSet<>();
 
   @Type(type = "jsbObjectSharing")

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/Dashboard.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dashboard/Dashboard.java
@@ -93,7 +93,7 @@ import org.hisp.dhis.user.sharing.Sharing;
 @Entity
 @Table(name = "dashboard")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @NoArgsConstructor
 @JacksonXmlRootElement(localName = "dashboard", namespace = DxfNamespaces.DXF_2_0)
 public class Dashboard extends BaseMetadataObject implements IdentifiableObject, FavoritableObject {
@@ -123,7 +123,7 @@ public class Dashboard extends BaseMetadataObject implements IdentifiableObject,
               name = "dashboarditemid",
               foreignKey = @ForeignKey(name = "fk_dashboard_items_dashboarditemid")))
   @OrderColumn(name = "sort_order")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
   private List<DashboardItem> items = new ArrayList<>();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalLevel.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalLevel.java
@@ -78,7 +78,7 @@ import org.hisp.dhis.user.sharing.Sharing;
         @UniqueConstraint(
             name = "dataapprovallevel_orgunitlevel_categoryoptiongroupset_unique_key",
             columnNames = {"orgunitlevel", "categoryoptiongroupsetid"}))
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class DataApprovalLevel extends BaseMetadataObject implements IdentifiableObject {
   @Id
   @GeneratedValue(strategy = GenerationType.SEQUENCE)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -132,7 +132,7 @@ import org.hisp.dhis.user.sharing.UserGroupAccess;
 @Entity
 @Table(name = "dataelement")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JacksonXmlRootElement(localName = "dataElement", namespace = DxfNamespaces.DXF_2_0)
 public class DataElement extends BaseMetadataObject
     implements DimensionalItemObject,
@@ -213,12 +213,12 @@ public class DataElement extends BaseMetadataObject
 
   /** The data element groups which this data element is a member of. */
   @ManyToMany(mappedBy = "members")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<DataElementGroup> groups = new HashSet<>();
 
   /** The data sets which this data element is a member of. */
   @OneToMany(mappedBy = "dataElement")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<DataSetElement> dataSetElements = new HashSet<>();
 
   /** The lower organisation unit levels for aggregation. */
@@ -229,7 +229,7 @@ public class DataElement extends BaseMetadataObject
       foreignKey = @ForeignKey(name = "fk_dataelementaggregationlevels_dataelementid"))
   @Column(name = "aggregationlevel")
   @OrderColumn(name = "sort_order")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<Integer> aggregationLevels = new ArrayList<>();
 
   /** Indicates whether to store zero data values. */
@@ -258,7 +258,7 @@ public class DataElement extends BaseMetadataObject
               name = "legendsetid",
               foreignKey = @ForeignKey(name = "fk_dataelement_legendsetid")))
   @OrderColumn(name = "sort_order")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<LegendSet> legendSets = new ArrayList<>();
 
   @AuditAttribute

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSetElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSetElement.java
@@ -62,7 +62,7 @@ import org.hisp.dhis.dataelement.DataElement;
 @Entity
 @Table(name = "dataSetElement")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JacksonXmlRootElement(localName = "dataSetElement", namespace = DxfNamespaces.DXF_2_0)
 public class DataSetElement implements EmbeddedObject, Serializable {
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/Section.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/Section.java
@@ -106,7 +106,7 @@ import org.hisp.dhis.user.sharing.Sharing;
         @UniqueConstraint(
             name = "key_sectionnamedataset",
             columnNames = {"name", "datasetid"}))
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class Section extends BaseLinkableObject implements IdentifiableObject, MetadataObject {
 
   @Id
@@ -150,7 +150,7 @@ public class Section extends BaseLinkableObject implements IdentifiableObject, M
       inverseJoinColumns = @JoinColumn(name = "dataelementid"))
   @OrderColumn(name = "sort_order")
   @ListIndexBase(value = 1)
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<DataElement> dataElements = new ArrayList<>();
 
   @ManyToMany
@@ -160,7 +160,7 @@ public class Section extends BaseLinkableObject implements IdentifiableObject, M
       inverseJoinColumns = @JoinColumn(name = "indicatorid"))
   @OrderColumn(name = "sort_order")
   @ListIndexBase(value = 1)
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<Indicator> indicators = new ArrayList<>();
 
   @ManyToMany
@@ -173,7 +173,7 @@ public class Section extends BaseLinkableObject implements IdentifiableObject, M
       name = "sectiongreyedfields",
       joinColumns = @JoinColumn(name = "sectionid"),
       inverseJoinColumns = @JoinColumn(name = "dataelementoperandid"))
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<DataElementOperand> greyedFields = new HashSet<>();
 
   @Column(name = "sortorder", nullable = false)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroup.java
@@ -93,7 +93,7 @@ import org.hisp.dhis.user.sharing.Sharing;
 @Setter
 @Entity
 @Table(name = "indicatorgroup")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class IndicatorGroup extends BaseMetadataObject
     implements IdentifiableObject, MetadataObject {
   @Id
@@ -123,7 +123,7 @@ public class IndicatorGroup extends BaseMetadataObject
           @JoinColumn(
               name = "indicatorid",
               foreignKey = @ForeignKey(name = "fk_indicatorgroup_indicatorid")))
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<Indicator> members = new HashSet<>();
 
   @Type(type = "jsbAttributeValues")
@@ -135,7 +135,7 @@ public class IndicatorGroup extends BaseMetadataObject
   private Sharing sharing = new Sharing();
 
   @ManyToMany(mappedBy = "members", fetch = FetchType.LAZY)
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<IndicatorGroupSet> groupSets = new HashSet<>();
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSet.java
@@ -93,7 +93,7 @@ import org.hisp.dhis.user.sharing.Sharing;
 @Setter
 @Entity
 @Table(name = "indicatorgroupset")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class IndicatorGroupSet extends BaseMetadataObject
     implements IdentifiableObject, MetadataObject {
 
@@ -134,7 +134,7 @@ public class IndicatorGroupSet extends BaseMetadataObject
               foreignKey = @ForeignKey(name = "fk_indicatorgroupset_indicatorgroupid")))
   @OrderColumn(name = "sort_order", nullable = false)
   @ListIndexBase(1)
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<IndicatorGroup> members = new ArrayList<>();
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/legend/Legend.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/legend/Legend.java
@@ -90,7 +90,7 @@ import org.hisp.dhis.user.sharing.Sharing;
       @Index(name = "maplegend_endvalue", columnList = "endvalue")
     })
 @JacksonXmlRootElement(localName = "legend", namespace = DxfNamespaces.DXF_2_0)
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @Setter
 public class Legend implements IdentifiableObject, EmbeddedObject {
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/legend/LegendSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/legend/LegendSet.java
@@ -104,7 +104,7 @@ public class LegendSet extends BaseMetadataObject implements IdentifiableObject,
 
   @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn(name = "maplegendsetid")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<Legend> legends = new HashSet<>();
 
   public LegendSet() {}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
@@ -127,7 +127,7 @@ public class OptionSet extends BaseMetadataObject implements IdentifiableObject,
   @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   @JoinColumn(name = "optionsetid", foreignKey = @ForeignKey(name = "fk_optionset_optionid"))
   @OrderBy(value = "sortOrder ASC")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<Option> options = new ArrayList<>();
 
   @Type(type = "jsbAttributeValues")

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
@@ -126,7 +126,7 @@ import org.hisp.dhis.user.sharing.Sharing;
  */
 @Entity
 @Table(name = "program")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JacksonXmlRootElement(localName = "program", namespace = DxfNamespaces.DXF_2_0)
 public class Program extends BaseMetadataObject
     implements IdentifiableObject, NameableObject, VersionedObject {
@@ -218,7 +218,7 @@ public class Program extends BaseMetadataObject
       name = "program_organisationunits",
       joinColumns = @JoinColumn(name = "programid"),
       inverseJoinColumns = @JoinColumn(name = "organisationunitid"))
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<OrganisationUnit> organisationUnits = new HashSet<>();
 
   @OneToMany

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/analytics/hibernate/AnalyticsTableHook.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/analytics/hibernate/AnalyticsTableHook.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.analytics.AnalyticsTableHook" table="tablehook">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="analyticstablehookid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/attribute/hibernate/Attribute.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/attribute/hibernate/Attribute.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping package="org.hisp.dhis.attribute">
   <class name="Attribute" table="attribute">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="attributeid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/Category.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/Category.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.Category" table="category">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="categoryid">
       <generator class="native"/>
@@ -30,7 +30,7 @@
               not-null="true"/>
 
     <list name="categoryOptions" table="categories_categoryoptions">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="categoryid"
            foreign-key="fk_categories_categoryoptions_categoryid"/>
       <list-index column="sort_order" base="1"/>
@@ -40,7 +40,7 @@
     </list>
 
     <set name="categoryCombos" table="categorycombos_categories" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="categoryid" foreign-key="fk_categorycombo_categoryid" />
       <many-to-many class="org.hisp.dhis.category.CategoryCombo" column="categorycomboid"
         foreign-key="fk_categorycombos_categories_categorycomboid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryDimension.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryDimension.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.CategoryDimension" table="categorydimension">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="categorydimensionid">
       <generator class="native" />
@@ -16,7 +16,7 @@
       foreign-key="fk_categorydimension_category" />
     
     <list name="items" table="categorydimension_items">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="categorydimensionid" foreign-key="fk_categorydimension_items_categorydimensionid" />
       <list-index column="sort_order" />
       <many-to-many class="org.hisp.dhis.category.CategoryOption" column="categoryoptionid"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionCombo.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionCombo.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.CategoryOptionCombo" table="categoryoptioncombo">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="categoryoptioncomboid">
       <generator class="native" />
@@ -20,7 +20,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="categoryOptions" table="categoryoptioncombos_categoryoptions">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="categoryoptioncomboid" foreign-key="fk_categoryoptioncombos_categoryoptions_categoryoptioncomboid" />
       <many-to-many class="org.hisp.dhis.category.CategoryOption" column="categoryoptionid"
         foreign-key="fk_categoryoptioncombo_categoryoptionid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroup.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.CategoryOptionGroup" table="categoryoptiongroup">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="categoryoptiongroupid">
       <generator class="native" />
@@ -24,14 +24,14 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="members" table="categoryoptiongroupmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="categoryoptiongroupid" foreign-key="fk_categoryoptiongroupmembers_categoryoptionid" />
       <many-to-many class="org.hisp.dhis.category.CategoryOption" column="categoryoptionid"
         foreign-key="fk_categoryoptiongroupmembers_categoryoptiongroupid" />
     </set>
 
     <set name="groupSets" table="categoryoptiongroupsetmembers" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="categoryoptiongroupid" />
       <many-to-many class="org.hisp.dhis.category.CategoryOptionGroupSet" column="categoryoptiongroupsetid" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroupSet.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.CategoryOptionGroupSet" table="categoryoptiongroupset">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="categoryoptiongroupsetid">
       <generator class="native"/>
@@ -26,7 +26,7 @@
     <property name="dataDimension" column="datadimension" not-null="true"/>
 
     <list name="members" table="categoryoptiongroupsetmembers">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="categoryoptiongroupsetid"
            foreign-key="fk_categoryoptiongroupsetmembers_categoryoptiongroupsetid"/>
       <list-index column="sort_order" base="1"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroupSetDimension.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroupSetDimension.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.CategoryOptionGroupSetDimension" table="categoryoptiongroupsetdimension">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="categoryoptiongroupsetdimensionid">
       <generator class="native" />
@@ -16,7 +16,7 @@
       foreign-key="fk_dimension_categoryoptiongroupsetid" />
     
     <list name="items" table="categoryoptiongroupsetdimension_items">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="categoryoptiongroupsetdimensionid" foreign-key="fk_dimension_items_categoryoptiongroupsetdimensionid" />
       <list-index column="sort_order" />
       <many-to-many class="org.hisp.dhis.category.CategoryOptionGroup" column="categoryoptiongroupid"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/common.hibernate/DataDimensionItem.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/common.hibernate/DataDimensionItem.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.common.DataDimensionItem" table="datadimensionitem">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="datadimensionitemid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/configuration/hibernate/Configuration.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/configuration/hibernate/Configuration.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.configuration.Configuration" table="configuration">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="configurationid">
       <generator class="native" />
@@ -45,13 +45,13 @@
         column="facilityorgunitlevel" foreign-key="fk_configuration_facilityorgunitlevel" />
 
     <set name="corsWhitelist" table="configuration_corswhitelist" lazy="false">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="configurationid" foreign-key="fk_configuration_corswhitelist" />
       <element type="string" column="corswhitelist" />
     </set>
 
     <set name="dataOutputPeriodTypes" table="configuration_dataoutputperiodtype" lazy="false">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="configurationid" foreign-key="fk_configuration_dataoutputperiodtype_configurationid" not-null="true" />
       <many-to-many class="org.hisp.dhis.period.PeriodType" column="periodtypeid" foreign-key="fk_configuration_dataoutputperiodtype_periodtypeid" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/constant/hibernate/Constant.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/constant/hibernate/Constant.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.constant.Constant" table="constant">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="constantid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroup.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.dataelement.DataElementGroup" table="dataelementgroup">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="dataelementgroupid">
       <generator class="native" />
@@ -24,14 +24,14 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="members" table="dataelementgroupmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="dataelementgroupid" foreign-key="fk_dataelementgroupmembers_dataelementgroupid" />
       <many-to-many class="org.hisp.dhis.dataelement.DataElement" column="dataelementid"
         foreign-key="fk_dataelementgroup_dataelementid" />
     </set>
 
     <set name="groupSets" table="dataelementgroupsetmembers" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="dataelementgroupid" />
       <many-to-many class="org.hisp.dhis.dataelement.DataElementGroupSet" column="dataelementgroupsetid" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroupSet.hbm.xml
@@ -9,7 +9,7 @@
   <class name="org.hisp.dhis.dataelement.DataElementGroupSet"
          table="dataelementgroupset">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="dataelementgroupsetid">
       <generator class="native"/>
@@ -31,7 +31,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <list name="members" table="dataelementgroupsetmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="dataelementgroupsetid" foreign-key="fk_dataelementgroupsetmembers_dataelementgroupsetid" />
       <list-index column="sort_order" base="1" />
       <many-to-many class="org.hisp.dhis.dataelement.DataElementGroup" column="dataelementgroupid"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroupSetDimension.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroupSetDimension.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.dataelement.DataElementGroupSetDimension" table="dataelementgroupsetdimension">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="dataelementgroupsetdimensionid">
       <generator class="native" />
@@ -16,7 +16,7 @@
       foreign-key="fk_dimension_dataelementgroupsetid" />
     
     <list name="items" table="dataelementgroupsetdimension_items">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="dataelementgroupsetdimensionid" foreign-key="fk_dimension_items_dataelementgroupsetdimensionid" />
       <list-index column="sort_order" />
       <many-to-many class="org.hisp.dhis.dataelement.DataElementGroup" column="dataelementgroupid"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementOperand.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementOperand.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.dataelement.DataElementOperand" table="dataelementoperand">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="dataelementoperandid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataentryform/hibernate/DataEntryForm.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataentryform/hibernate/DataEntryForm.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.dataentryform.DataEntryForm" table="dataentryform">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="dataentryformid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataexchange/aggregate/hibernate/AggregateDataExchange.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataexchange/aggregate/hibernate/AggregateDataExchange.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.dataexchange.aggregate.AggregateDataExchange" table="aggregatedataexchange">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="aggregatedataexchangeid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/DataInputPeriod.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/DataInputPeriod.hbm.xml
@@ -5,7 +5,7 @@
   >
 <hibernate-mapping>
   <class name="org.hisp.dhis.dataset.DataInputPeriod" table="datainputperiod">
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="datainputperiodid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/DataSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/DataSet.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.dataset.DataSet" table="dataset">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="datasetid">
       <generator class="native" />
@@ -31,40 +31,40 @@
       not-null="true" foreign-key="fk_dataset_periodtypeid" />
 
     <set name="dataInputPeriods" table="datasetdatainputperiods" cascade="all-delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="datasetid" foreign-key="fk_datasetdatainputperiods_datasetid" />
       <one-to-many class="org.hisp.dhis.dataset.DataInputPeriod" />
     </set>
 
     <set name="dataSetElements" table="datasetelement" cascade="all-delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="datasetid" foreign-key="fk_datasetmembers_datasetid" />
       <one-to-many class="org.hisp.dhis.dataset.DataSetElement" />
     </set>
 
     <set name="indicators" table="datasetindicators">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="datasetid" foreign-key="fk_datasetindicators_datasetid" />
       <many-to-many class="org.hisp.dhis.indicator.Indicator" column="indicatorid"
         foreign-key="fk_dataset_indicatorid" />
     </set>
 
     <set name="compulsoryDataElementOperands" table="datasetoperands" cascade="all-delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="datasetid" foreign-key="fk_datasetoperands_datasetid" />
       <many-to-many class="org.hisp.dhis.dataelement.DataElementOperand" column="dataelementoperandid"
         foreign-key="fk_dataset_dataelementoperandid" />
     </set>
 
     <set name="sources" table="datasetsource">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="datasetid" foreign-key="fk_datasetsource_datasetid" />
       <many-to-many column="sourceid" class="org.hisp.dhis.organisationunit.OrganisationUnit"
         foreign-key="fk_dataset_organisationunit" />
     </set>
 
     <set name="sections" order-by="sortorder" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="datasetid" />
       <one-to-many class="org.hisp.dhis.dataset.Section" />
     </set>
@@ -121,7 +121,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <list name="legendSets" table="datasetlegendsets">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="datasetid" />
       <list-index column="sort_order" base="0" />
       <many-to-many class="org.hisp.dhis.legend.LegendSet" column="legendsetid" foreign-key="fk_dataset_legendsetid"></many-to-many>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/datastore/hibernate/DatastoreEntry.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/datastore/hibernate/DatastoreEntry.hbm.xml
@@ -7,7 +7,7 @@
 <hibernate-mapping>
     <class name="org.hisp.dhis.datastore.DatastoreEntry" table="keyjsonvalue">
 
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="keyjsonvalueid">
             <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/document/hibernate/Document.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/document/hibernate/Document.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.document.Document" table="document">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="documentid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchart/hibernate/EventChart.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchart/hibernate/EventChart.hbm.xml
@@ -6,7 +6,7 @@
         >
 <hibernate-mapping>
     <class name="org.hisp.dhis.eventchart.EventChart" table="eventvisualization">
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="eventvisualizationid">
             <generator class="native"/>
@@ -18,7 +18,7 @@
         <property name="description" type="text"/>
 
         <list name="organisationUnits" table="eventvisualization_organisationunits">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_eventvisualization_organisationunits_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="organisationunitid" class="org.hisp.dhis.organisationunit.OrganisationUnit"
@@ -26,7 +26,7 @@
         </list>
 
         <list name="persistedPeriods" table="eventvisualization_periods">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_periods_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="periodid" class="org.hisp.dhis.period.Period"
@@ -34,7 +34,7 @@
         </list>
 
         <list name="categoryDimensions" table="eventvisualization_categorydimensions" cascade="all-delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_categorydimensions_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="categorydimensionid" class="org.hisp.dhis.category.CategoryDimension"
@@ -43,7 +43,7 @@
 
         <list name="organisationUnitGroupSetDimensions" table="eventvisualization_orgunitgroupsetdimensions"
               cascade="all-delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid"
                  foreign-key="fk_evisualization_orgunitgroupsetdimensions_evisualizationid"/>
             <list-index column="sort_order"/>
@@ -54,7 +54,7 @@
 
         <list name="categoryOptionGroupSetDimensions" table="eventvisualization_categoryoptiongroupsetdimensions"
               cascade="all-delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid"
                  foreign-key="fk_evisualization_catoptiongroupsetdimensions_evisualizationid"/>
             <list-index column="sort_order"/>
@@ -64,14 +64,14 @@
         </list>
 
         <list name="organisationUnitLevels" table="eventvisualization_orgunitlevels">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_orgunitlevels_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <element column="orgunitlevel" type="integer"/>
         </list>
 
         <list name="itemOrganisationUnitGroups" table="eventvisualization_itemorgunitgroups">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_itemorgunitunitgroups_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="orgunitgroupid" class="org.hisp.dhis.organisationunit.OrganisationUnitGroup"
@@ -79,7 +79,7 @@
         </list>
 
         <list name="attributeDimensions" table="eventvisualization_attributedimensions" cascade="all, delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_attributedimensions_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="trackedentityattributedimensionid"
@@ -89,7 +89,7 @@
 
         <list name="dataElementDimensions" table="eventvisualization_dataelementdimensions"
               cascade="all, delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_dataelementdimensions_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="trackedentitydataelementdimensionid"
@@ -99,7 +99,7 @@
 
         <list name="programIndicatorDimensions" table="eventvisualization_programindicatordimensions"
               cascade="all, delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid"
                  foreign-key="fk_evisualization_programindicatordimensions_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
@@ -170,21 +170,21 @@
         </property>
 
         <list name="columnDimensions" table="eventvisualization_columns">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_columns_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <element type="string" column="dimension"/>
         </list>
 
         <list name="rowDimensions" table="eventvisualization_rows">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_rows_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <element type="string" column="dimension"/>
         </list>
 
         <list name="filterDimensions" table="eventvisualization_filters">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_filters_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <element type="string" column="dimension"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventhook/hibernate/EventHook.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventhook/hibernate/EventHook.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
     <class name="org.hisp.dhis.eventhook.EventHook" table="eventhook">
 
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="eventhookid">
             <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventreport/hibernate/EventReport.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventreport/hibernate/EventReport.hbm.xml
@@ -6,7 +6,7 @@
         >
 <hibernate-mapping>
     <class name="org.hisp.dhis.eventreport.EventReport" table="eventvisualization">
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="eventvisualizationid">
             <generator class="native"/>
@@ -18,7 +18,7 @@
         <property name="description" type="text"/>
 
         <list name="organisationUnits" table="eventvisualization_organisationunits">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_eventvisualization_organisationunits_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="organisationunitid" class="org.hisp.dhis.organisationunit.OrganisationUnit"
@@ -26,7 +26,7 @@
         </list>
 
         <list name="persistedPeriods" table="eventvisualization_periods">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_periods_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="periodid" class="org.hisp.dhis.period.Period"
@@ -34,7 +34,7 @@
         </list>
 
         <list name="categoryDimensions" table="eventvisualization_categorydimensions" cascade="all-delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_categorydimensions_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="categorydimensionid" class="org.hisp.dhis.category.CategoryDimension"
@@ -43,7 +43,7 @@
 
         <list name="organisationUnitGroupSetDimensions" table="eventvisualization_orgunitgroupsetdimensions"
               cascade="all-delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid"
                  foreign-key="fk_evisualization_orgunitgroupsetdimensions_evisualizationid"/>
             <list-index column="sort_order"/>
@@ -54,7 +54,7 @@
 
         <list name="categoryOptionGroupSetDimensions" table="eventvisualization_categoryoptiongroupsetdimensions"
               cascade="all-delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid"
                  foreign-key="fk_evisualization_catoptiongroupsetdimensions_evisualizationid"/>
             <list-index column="sort_order"/>
@@ -64,14 +64,14 @@
         </list>
 
         <list name="organisationUnitLevels" table="eventvisualization_orgunitlevels">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_orgunitlevels_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <element column="orgunitlevel" type="integer"/>
         </list>
 
         <list name="itemOrganisationUnitGroups" table="eventvisualization_itemorgunitgroups">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_itemorgunitunitgroups_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="orgunitgroupid" class="org.hisp.dhis.organisationunit.OrganisationUnitGroup"
@@ -79,7 +79,7 @@
         </list>
 
         <list name="attributeDimensions" table="eventvisualization_attributedimensions" cascade="all, delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_attributedimensions_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="trackedentityattributedimensionid"
@@ -89,7 +89,7 @@
 
         <list name="dataElementDimensions" table="eventvisualization_dataelementdimensions"
               cascade="all, delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_dataelementdimensions_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="trackedentitydataelementdimensionid"
@@ -99,7 +99,7 @@
 
         <list name="programIndicatorDimensions" table="eventvisualization_programindicatordimensions"
               cascade="all, delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid"
                  foreign-key="fk_evisualization_programindicatordimensions_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
@@ -170,21 +170,21 @@
         </property>
 
         <list name="columnDimensions" table="eventvisualization_columns">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_columns_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <element type="string" column="dimension"/>
         </list>
 
         <list name="rowDimensions" table="eventvisualization_rows">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_rows_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <element type="string" column="dimension"/>
         </list>
 
         <list name="filterDimensions" table="eventvisualization_filters">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_filters_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <element type="string" column="dimension"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventvisualization/hibernate/EventVisualization.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventvisualization/hibernate/EventVisualization.hbm.xml
@@ -7,7 +7,7 @@
         >
 <hibernate-mapping>
     <class name="org.hisp.dhis.eventvisualization.EventVisualization" table="eventvisualization">
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="eventvisualizationid">
             <generator class="native"/>
@@ -21,7 +21,7 @@
         <property name="rawPeriods" column="relativeperiods" type="jbList"/>
 
         <list name="organisationUnits" table="eventvisualization_organisationunits">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_eventvisualization_organisationunits_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="organisationunitid" class="org.hisp.dhis.organisationunit.OrganisationUnit"
@@ -29,7 +29,7 @@
         </list>
 
         <list name="persistedPeriods" table="eventvisualization_periods">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_periods_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="periodid" class="org.hisp.dhis.period.Period"
@@ -37,7 +37,7 @@
         </list>
 
         <list name="categoryDimensions" table="eventvisualization_categorydimensions" cascade="all-delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_categorydimensions_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="categorydimensionid" class="org.hisp.dhis.category.CategoryDimension"
@@ -46,7 +46,7 @@
 
         <list name="organisationUnitGroupSetDimensions" table="eventvisualization_orgunitgroupsetdimensions"
               cascade="all-delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_orgunitgroupsetdimensions_evisualizationid"/>
             <list-index column="sort_order"/>
             <many-to-many column="orgunitgroupsetdimensionid"
@@ -56,7 +56,7 @@
 
         <list name="categoryOptionGroupSetDimensions" table="eventvisualization_categoryoptiongroupsetdimensions"
               cascade="all-delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_catoptiongroupsetdimensions_evisualizationid"/>
             <list-index column="sort_order"/>
             <many-to-many column="categoryoptiongroupsetdimensionid"
@@ -65,14 +65,14 @@
         </list>
 
         <list name="organisationUnitLevels" table="eventvisualization_orgunitlevels">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_orgunitlevels_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <element column="orgunitlevel" type="integer"/>
         </list>
 
         <list name="itemOrganisationUnitGroups" table="eventvisualization_itemorgunitgroups">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_itemorgunitunitgroups_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="orgunitgroupid" class="org.hisp.dhis.organisationunit.OrganisationUnitGroup"
@@ -80,7 +80,7 @@
         </list>
 
         <list name="attributeDimensions" table="eventvisualization_attributedimensions" cascade="all, delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_attributedimensions_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="trackedentityattributedimensionid"
@@ -89,7 +89,7 @@
         </list>
 
         <list name="dataElementDimensions" table="eventvisualization_dataelementdimensions" cascade="all, delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_dataelementdimensions_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="trackedentitydataelementdimensionid"
@@ -99,7 +99,7 @@
 
         <list name="programIndicatorDimensions" table="eventvisualization_programindicatordimensions"
               cascade="all, delete-orphan">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_programindicatordimensions_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <many-to-many column="trackedentityprogramindicatordimensionid"
@@ -195,21 +195,21 @@
         </property>
 
         <list name="columnDimensions" table="eventvisualization_columns">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_columns_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <element type="string" column="dimension"/>
         </list>
 
         <list name="rowDimensions" table="eventvisualization_rows">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_rows_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <element type="string" column="dimension"/>
         </list>
 
         <list name="filterDimensions" table="eventvisualization_filters">
-            <cache usage="read-write"/>
+            <cache usage="nonstrict-read-write"/>
             <key column="eventvisualizationid" foreign-key="fk_evisualization_filters_evisualizationid"/>
             <list-index column="sort_order" base="0"/>
             <element type="string" column="dimension"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/expression/hibernate/Expression.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/expression/hibernate/Expression.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
     <class name="org.hisp.dhis.expression.Expression" table="expression">
 
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="expressionid">
             <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/expressiondimensionitem/hibernate/ExpressionDimensionItem.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/expressiondimensionitem/hibernate/ExpressionDimensionItem.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
     <class name="org.hisp.dhis.expressiondimensionitem.ExpressionDimensionItem" table="expressiondimensionitem">
 
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="expressiondimensionitemid">
             <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/fileresource/hibernate/FileResource.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/fileresource/hibernate/FileResource.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.fileresource.FileResource" table="fileresource">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="fileresourceid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/Indicator.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/Indicator.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.indicator.Indicator" table="indicator">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="indicatorid">
       <generator class="native" />
@@ -45,19 +45,19 @@
     <property name="style" type="jbObjectStyle" column="style" />
 
     <set name="groups" table="indicatorgroupmembers" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="indicatorid" />
       <many-to-many class="org.hisp.dhis.indicator.IndicatorGroup" column="indicatorgroupid" />
     </set>
 
     <set name="dataSets" table="datasetindicators" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="indicatorid" />
       <many-to-many class="org.hisp.dhis.dataset.DataSet" column="datasetid" />
     </set>
 
     <list name="legendSets" table="indicatorlegendsets">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="indicatorid" />
       <list-index column="sort_order" base="0" />
       <many-to-many class="org.hisp.dhis.legend.LegendSet" column="legendsetid" foreign-key="fk_indicator_legendsetid"></many-to-many>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorType.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorType.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.indicator.IndicatorType" table="indicatortype">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="indicatortypeid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/interpretation/hibernate/Interpretation.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/interpretation/hibernate/Interpretation.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.interpretation.Interpretation" table="interpretation">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
     
     <id name="id" column="interpretationid">
       <generator class="native" />
@@ -45,7 +45,7 @@
     <property name="created" not-null="true" type="timestamp" />
 
     <list name="comments" table="interpretation_comments" cascade="all,delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="interpretationid" foreign-key="fk_interpretation_comments_interpretationid" />
       <list-index column="sort_order" base="1" />
       <many-to-many class="org.hisp.dhis.interpretation.InterpretationComment" column="interpretationcommentid"
@@ -55,7 +55,7 @@
     <property name="likes" />
 
     <set name="likedBy" table="interpretation_likedby">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="interpretationid" foreign-key="fk_interpretation_likedby_interpretationid" />
       <many-to-many class="org.hisp.dhis.user.User" column="userid"
         foreign-key="fk_interpretation_likedby_userid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/Map.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/Map.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.mapping.Map" table="map">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="mapid">
       <generator class="native" />
@@ -34,7 +34,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <list name="mapViews" table="mapmapviews" cascade="all-delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapid" foreign-key="fk_mapmapview_mapid" />
       <list-index column="sort_order" base="0" />
       <many-to-many column="mapviewid" class="org.hisp.dhis.mapping.MapView"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/MapView.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/MapView.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.mapping.MapView" table="mapview">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="mapviewid">
       <generator class="native" />
@@ -24,7 +24,7 @@
     <!-- AnalyticalObject -->
 
     <list name="dataDimensionItems" table="mapview_datadimensionitems" cascade="all, delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapviewid" foreign-key="fk_mapview_datadimensionitems_mapviewid" />
       <list-index column="sort_order"/>
       <many-to-many column="datadimensionitemid" class="org.hisp.dhis.common.DataDimensionItem"
@@ -32,7 +32,7 @@
     </list>
 
     <list name="organisationUnits" table="mapview_organisationunits">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapviewid" foreign-key="fk_mapview_organisationunits_mapviewid" />
       <list-index column="sort_order" base="0" />
       <many-to-many column="organisationunitid" class="org.hisp.dhis.organisationunit.OrganisationUnit"
@@ -40,7 +40,7 @@
     </list>
 
     <list name="persistedPeriods" table="mapview_periods">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapviewid" foreign-key="fk_mapview_periods_mapviewid" />
       <list-index column="sort_order" base="0" />
       <many-to-many column="periodid" class="org.hisp.dhis.period.Period"
@@ -54,7 +54,7 @@
     <property name="rawPeriods" column="relativeperiods" type="jbList"/>
 
     <list name="categoryDimensions" table="mapview_categorydimensions" cascade="all-delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapviewid" foreign-key="fk_mapview_categorydimensions_mapviewid" />
       <list-index column="sort_order" base="0" />
       <many-to-many column="categorydimensionid" class="org.hisp.dhis.category.CategoryDimension"
@@ -62,7 +62,7 @@
     </list>
 
     <list name="organisationUnitGroupSetDimensions" table="mapview_orgunitgroupsetdimensions" cascade="all-delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapviewid" foreign-key="fk_mapview_orgunitgroupsetdimensions_mapviewid" />
       <list-index column="sort_order" />
       <many-to-many column="orgunitgroupsetdimensionid" class="org.hisp.dhis.organisationunit.OrganisationUnitGroupSetDimension"
@@ -70,7 +70,7 @@
     </list>
 
     <list name="categoryOptionGroupSetDimensions" table="mapview_categoryoptiongroupsetdimensions" cascade="all-delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapviewid" foreign-key="fk_mapview_catoptiongroupsetdimensions_mapviewid" />
       <list-index column="sort_order" />
       <many-to-many column="categoryoptiongroupsetdimensionid" class="org.hisp.dhis.category.CategoryOptionGroupSetDimension"
@@ -78,14 +78,14 @@
     </list>
 
     <list name="organisationUnitLevels" table="mapview_orgunitlevels">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapviewid" foreign-key="fk_mapview_orgunitlevels_mapviewid" />
       <list-index column="sort_order" base="0" />
       <element column="orgunitlevel" type="integer" />
     </list>
 
     <list name="itemOrganisationUnitGroups" table="mapview_itemorgunitgroups">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapviewid" foreign-key="fk_mapview_itemorgunitunitgroups_mapviewid" />
       <list-index column="sort_order" base="0" />
       <many-to-many column="orgunitgroupid" class="org.hisp.dhis.organisationunit.OrganisationUnitGroup"
@@ -95,7 +95,7 @@
     <!-- EventAnalyticalObject -->
 
     <list name="attributeDimensions" table="mapview_attributedimensions" cascade="all, delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapviewid" foreign-key="fk_mapview_attributedimensions_mapviewid" />
       <list-index column="sort_order" base="0" />
       <many-to-many column="trackedentityattributedimensionid" class="org.hisp.dhis.trackedentity.TrackedEntityAttributeDimension"
@@ -103,7 +103,7 @@
     </list>
 
     <list name="dataElementDimensions" table="mapview_dataelementdimensions" cascade="all, delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapviewid" foreign-key="fk_mapview_dataelementdimensions_mapviewid" />
       <list-index column="sort_order" base="0" />
       <many-to-many column="trackedentitydataelementdimensionid" class="org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension"
@@ -111,14 +111,14 @@
     </list>
 
     <list name="columnDimensions" table="mapview_columns">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapviewid" foreign-key="fk_mapview_columns_mapviewid" />
       <list-index column="sort_order" base="0" />
       <element type="string" column="dimension" />
     </list>
 
     <list name="filterDimensions" table="mapview_filters">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="mapviewid" foreign-key="fk_mapview_filters_mapviewid" />
       <list-index column="sort_order" base="0" />
       <element type="string" column="dimension" />    

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/Option.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/Option.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.option.Option" table="optionvalue">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="optionvalueid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionGroup.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.option.OptionGroup" table="optiongroup">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="optiongroupid">
       <generator class="native" />
@@ -24,7 +24,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="members" table="optiongroupmembers" cascade="all">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="optiongroupid" foreign-key="fk_optiongroupmembers_optionid" />
       <many-to-many class="org.hisp.dhis.option.Option" column="optionid"
         foreign-key="fk_optiongroupmembers_optiongroupid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionGroupSet.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.option.OptionGroupSet" table="optiongroupset">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="optiongroupsetid">
       <generator class="native" />
@@ -24,7 +24,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <list name="members" table="optiongroupsetmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="optiongroupsetid" foreign-key="fk_optiongroupsetmembers_optiongroupsetid" />
       <list-index column="sort_order" base="1" />
       <many-to-many class="org.hisp.dhis.option.OptionGroup" column="optiongroupid" unique="true"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnit.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnit.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.organisationunit.OrganisationUnit" table="organisationunit">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="organisationunitid">
       <generator class="native" />
@@ -20,7 +20,7 @@
     <property name="shortName" column="shortname" not-null="true" unique="false" length="50" />
 
     <set name="children" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="parentid" />
       <one-to-many class="org.hisp.dhis.organisationunit.OrganisationUnit" />
     </set>
@@ -47,31 +47,31 @@
     <property name="url" />
 
     <set name="dataSets" table="datasetsource" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="sourceid" />
       <many-to-many class="org.hisp.dhis.dataset.DataSet" column="datasetid" />
     </set>
 
     <set name="programs" table="program_organisationunits" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="organisationunitid" />
       <many-to-many class="org.hisp.dhis.program.Program" column="programid" />
     </set>
 
     <set name="groups" table="orgunitgroupmembers" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="organisationunitid" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnitGroup" column="orgunitgroupid" />
     </set>
 
     <set name="users" table="usermembership" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="organisationunitid" />
       <many-to-many class="org.hisp.dhis.user.User" column="userinfoid" />
     </set>
 
     <set name="categoryOptions" table="categoryoption_organisationunits" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="organisationunitid" />
       <many-to-many class="org.hisp.dhis.category.CategoryOption" column="categoryoptionid" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroup.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.organisationunit.OrganisationUnitGroup" table="orgunitgroup">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="orgunitgroupid">
       <generator class="native" />
@@ -28,14 +28,14 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="members" table="orgunitgroupmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="orgunitgroupid" foreign-key="fk_orgunitgroupmembers_orgunitgroupid" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnit" column="organisationunitid"
         foreign-key="fk_orgunitgroup_organisationunitid" />
     </set>
     
     <set name="groupSets" table="orgunitgroupsetmembers" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="orgunitgroupid" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnitGroupSet" column="orgunitgroupsetid" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroupSet.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.organisationunit.OrganisationUnitGroupSet" table="orgunitgroupset">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="orgunitgroupsetid">
       <generator class="native"/>
@@ -32,7 +32,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="organisationUnitGroups" table="orgunitgroupsetmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="orgunitgroupsetid" foreign-key="fk_orgunitgroupsetmembers_orgunitgroupsetid" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnitGroup" column="orgunitgroupid"
         foreign-key="fk_orgunitgroupset_orgunitgroupid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroupSetDimension.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroupSetDimension.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.organisationunit.OrganisationUnitGroupSetDimension" table="orgunitgroupsetdimension">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="orgunitgroupsetdimensionid">
       <generator class="native" />
@@ -16,7 +16,7 @@
       foreign-key="fk_dimension_orgunitgroupsetid" />
     
     <list name="items" table="orgunitgroupsetdimension_items">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="orgunitgroupsetdimensionid" foreign-key="fk_dimension_items_orgunitgroupsetdimensionid" />
       <list-index column="sort_order" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnitGroup" column="orgunitgroupid"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitLevel.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitLevel.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.organisationunit.OrganisationUnitLevel" table="orgunitlevel">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="orgunitlevelid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/period/hibernate/Period.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/period/hibernate/Period.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.period.Period" table="period" mutable="false">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="periodid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/period/hibernate/PeriodType.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/period/hibernate/PeriodType.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.period.PeriodType" table="periodtype">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="periodtypeid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/period/hibernate/RelativePeriods.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/period/hibernate/RelativePeriods.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.period.RelativePeriods" table="relativeperiods">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="relativeperiodsid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/PredictorGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/PredictorGroup.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.predictor.PredictorGroup" table="predictorgroup">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="predictorgroupid">
       <generator class="native" />
@@ -22,7 +22,7 @@
     <property name="description" type="text" />
 
     <set name="members" table="predictorgroupmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="predictorgroupid" foreign-key="fk_predictorgroupmembers_predictorgroupid" />
       <many-to-many class="org.hisp.dhis.predictor.Predictor" column="predictorid"
                     foreign-key="fk_predictorgroup_predictorid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/AnalyticsPeriodBoundary.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/AnalyticsPeriodBoundary.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.program.AnalyticsPeriodBoundary" table="periodboundary">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="periodboundaryid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramIndicator.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramIndicator.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.program.ProgramIndicator" table="programindicator">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="programindicatorid">
       <generator class="native" />
@@ -33,7 +33,7 @@
       column="programid" foreign-key="fk_programindicator_program" not-null="true" />
 
     <set name="groups" table="programindicatorgroupmembers" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="programindicatorid" />
       <many-to-many class="org.hisp.dhis.program.ProgramIndicatorGroup" column="programindicatorgroupid" />
     </set>
@@ -53,7 +53,7 @@
     <property name="decimals" />
 
     <list name="legendSets" table="programindicatorlegendsets">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="programindicatorid" />
       <list-index column="sort_order" base="0" />
       <many-to-many class="org.hisp.dhis.legend.LegendSet" column="legendsetid" foreign-key="fk_programindicator_legendsetid" />
@@ -84,7 +84,7 @@
     </property>
     
     <set name="analyticsPeriodBoundaries" cascade="all-delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="programindicatorid" />
       <one-to-many class="org.hisp.dhis.program.AnalyticsPeriodBoundary" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramIndicatorGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramIndicatorGroup.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.program.ProgramIndicatorGroup" table="programindicatorgroup">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="programindicatorgroupid">
       <generator class="native" />
@@ -20,7 +20,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="members" table="programindicatorgroupmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="programindicatorgroupid" foreign-key="fk_programindicatorgroupmembers_programindicatorgroupid" />
       <many-to-many class="org.hisp.dhis.program.ProgramIndicator" column="programindicatorid"
         foreign-key="fk_programindicatorgroup_programindicatorid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramSection.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramSection.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
     <class name="org.hisp.dhis.program.ProgramSection" table="programsection">
 
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="programsectionid">
             <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramStage.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramStage.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
     <class name="org.hisp.dhis.program.ProgramStage" table="programstage">
 
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="programstageid">
             <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramStageSection.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramStageSection.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.program.ProgramStageSection" table="programstagesection">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="programstagesectionid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.programrule.ProgramRule" table="programrule">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="programruleid">
       <generator class="native" />
@@ -28,7 +28,7 @@
       column="programstageid" foreign-key="fk_programrule_programstage" />
 
     <set name="programRuleActions" cascade="all-delete-orphan">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="programruleid" />
       <one-to-many class="org.hisp.dhis.programrule.ProgramRuleAction" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRuleAction.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRuleAction.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.programrule.ProgramRuleAction" table="programruleaction">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="programruleactionid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRuleVariable.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRuleVariable.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.programrule.ProgramRuleVariable" table="programrulevariable">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="programrulevariableid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programstagefilter/hibernate/EventFilter.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programstagefilter/hibernate/EventFilter.hbm.xml
@@ -7,7 +7,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.programstagefilter.EventFilter" table="eventfilter">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="eventfilterid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programstageworkinglist/hibernate/ProgramStageWorkingList.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programstageworkinglist/hibernate/ProgramStageWorkingList.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.programstageworkinglist.ProgramStageWorkingList" table="programstageworkinglist">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="programstageworkinglistid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/RelationshipConstraint.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/RelationshipConstraint.hbm.xml
@@ -6,7 +6,7 @@
 
 <hibernate-mapping>
     <class name="org.hisp.dhis.relationship.RelationshipConstraint" table="relationshipconstraint">
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="relationshipconstraintid">
             <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/RelationshipType.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/RelationshipType.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
     <class name="org.hisp.dhis.relationship.RelationshipType" table="relationshiptype">
 
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="relationshiptypeid">
             <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/report/hibernate/Report.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/report/hibernate/Report.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.report.Report" table="report">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="reportid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/route/hibernate/Route.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/route/hibernate/Route.hbm.xml
@@ -6,7 +6,7 @@
 
 <hibernate-mapping>
     <class name="org.hisp.dhis.route.Route" table="route">
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="routeid">
             <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/scheduling/hibernate/JobConfiguration.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/scheduling/hibernate/JobConfiguration.hbm.xml
@@ -7,7 +7,7 @@
 
 <hibernate-mapping>
     <class name="org.hisp.dhis.scheduling.JobConfiguration" table="jobconfiguration">
-        <cache usage="read-write" />
+        <cache usage="nonstrict-read-write" />
 
         <id name="id" column="jobconfigurationid">
             <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/security.hibernate/ApiToken.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/security.hibernate/ApiToken.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
     <class name="org.hisp.dhis.security.apikey.ApiToken" table="api_token">
 
-        <cache usage="read-write"/>
+        <cache usage="nonstrict-read-write"/>
 
         <id name="id" column="apiTokenId">
             <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/security.hibernate/oauth2/Dhis2OAuth2Authorization.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/security.hibernate/oauth2/Dhis2OAuth2Authorization.hbm.xml
@@ -9,7 +9,7 @@
   <class name="org.hisp.dhis.security.oauth2.authorization.Dhis2OAuth2Authorization"
     table="oauth2_authorization">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="id">
       <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/security.hibernate/oauth2/Dhis2OAuth2AuthorizationConsent.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/security.hibernate/oauth2/Dhis2OAuth2AuthorizationConsent.hbm.xml
@@ -9,7 +9,7 @@
   <class name="org.hisp.dhis.security.oauth2.consent.Dhis2OAuth2AuthorizationConsent"
     table="oauth2_authorization_consent">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="id">
       <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/security.hibernate/oauth2/Dhis2OAuth2Client.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/security.hibernate/oauth2/Dhis2OAuth2Client.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.security.oauth2.client.Dhis2OAuth2Client" table="oauth2_client">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="id">
       <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityAttribute.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityAttribute.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.trackedentity.TrackedEntityAttribute" table="trackedentityattribute">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="trackedentityattributeid">
       <generator class="native" />
@@ -43,7 +43,7 @@
       column="optionsetid" foreign-key="fk_trackedentityattribute_optionsetid" />
 
     <list name="legendSets" table="trackedentityattributelegendsets">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="trackedentityattributeid" />
       <list-index column="sort_order" base="0" />
       <many-to-many class="org.hisp.dhis.legend.LegendSet" column="legendsetid"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityType.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentity/hibernate/TrackedEntityType.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.trackedentity.TrackedEntityType" table="trackedentitytype">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="trackedentitytypeid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentityfilter/hibernate/TrackedEntityFilter.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/trackedentityfilter/hibernate/TrackedEntityFilter.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.trackedentityfilter.TrackedEntityFilter" table="trackedentityfilter">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="trackedentityfilterid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/User.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/User.hbm.xml
@@ -11,7 +11,7 @@
 
   <class name="org.hisp.dhis.user.User" lazy="false" table="userinfo">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="userinfoid">
       <generator class="native" />
@@ -76,27 +76,27 @@
     <many-to-one name="avatar" class="org.hisp.dhis.fileresource.FileResource" column="avatar" foreign-key="fk_user_fileresourceid" />
 
     <set name="groups" table="usergroupmembers" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="userid" />
       <many-to-many class="org.hisp.dhis.user.UserGroup" column="usergroupid" />
     </set>
 
     <set name="organisationUnits" table="usermembership">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="userinfoid" foreign-key="fk_usermembership_userinfoid" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnit" column="organisationunitid"
         foreign-key="fk_userinfo_organisationunitid" />
     </set>
 
     <set name="dataViewOrganisationUnits" table="userdatavieworgunits">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="userinfoid" foreign-key="fk_userdatavieworgunits_userinfoid" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnit" column="organisationunitid"
         foreign-key="fk_userdatavieworgunits_organisationunitid" />
     </set>
 
     <set name="teiSearchOrganisationUnits" table="userteisearchorgunits">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="userinfoid" foreign-key="fk_userteisearchorgunits_userinfoid" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnit" column="organisationunitid"
         foreign-key="fk_userteisearchorgunits_organisationunitid" />
@@ -109,7 +109,7 @@
     <property name="attributeValues" type="jsbAttributeValues"/>
 
     <list name="apps" table="userapps">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="userinfoid" foreign-key="fk_userapps_userinfoid" />
       <list-index column="sort_order" base="0" />
       <element type="string" column="app" />
@@ -142,7 +142,7 @@
     <property name="passwordLastUpdated" />
 
     <set name="userRoles" table="userrolemembers" cascade="save-update,persist,merge">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="userid" foreign-key="fk_userrolemembers_userid"/>
       <many-to-many column="userroleid" class="org.hisp.dhis.user.UserRole"/>
     </set>
@@ -154,14 +154,14 @@
     </list>
 
     <set name="cogsDimensionConstraints" table="users_cogsdimensionconstraints">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="userid" foreign-key="fk_users_cogsconstraints_userid" />
       <many-to-many column="categoryoptiongroupsetid" class="org.hisp.dhis.category.CategoryOptionGroupSet"
                     foreign-key="fk_fk_users_cogsconstraints_categoryoptiongroupsetid" />
     </set>
 
     <set name="catDimensionConstraints" table="users_catdimensionconstraints">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="userid" foreign-key="fk_users_catconstraints_userid" />
       <many-to-many column="dataelementcategoryid" class="org.hisp.dhis.category.Category"
                     foreign-key="fk_fk_users_catconstraints_dataelementcategoryid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/UserGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/UserGroup.hbm.xml
@@ -9,7 +9,7 @@
   <typedef class="org.hibernate.type.PostgresUUIDType" name="pg-uuid" />
   <class name="org.hisp.dhis.user.UserGroup" table="usergroup">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="usergroupid">
       <generator class="native" />
@@ -38,7 +38,7 @@
     </set>
 
     <set name="managedGroups" table="usergroupmanaged">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="managedbygroupid" />
       <many-to-many column="managedgroupid" class="org.hisp.dhis.user.UserGroup" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/UserRole.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/UserRole.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.user.UserRole" table="userrole">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="userroleid">
       <generator class="native" />
@@ -27,13 +27,13 @@
     </set>
 
     <set name="authorities" table="userroleauthorities">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="userroleid" foreign-key="fk_userroleauthorities_userroleid" />
       <element type="string" column="authority" />
     </set>
 
     <set name="restrictions" table="userrolerestrictions">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="userroleid" foreign-key="fk_userrolerestrictions_userroleid" />
       <element type="string" column="restriction" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/userdatastore/hibernate/UserDatastoreEntry.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/userdatastore/hibernate/UserDatastoreEntry.hbm.xml
@@ -8,7 +8,7 @@
 
   <class name="org.hisp.dhis.userdatastore.UserDatastoreEntry" table="userkeyjsonvalue">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="userkeyjsonvalueid">
       <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/version/hibernate/Version.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/version/hibernate/Version.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.version.Version" table="version">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="versionid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Axis.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Axis.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.visualization.Axis" table="axis">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="axisid">
       <generator class="native"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Visualization.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Visualization.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.visualization.Visualization" table="visualization">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="visualizationid">
       <generator class="native"/>
@@ -22,7 +22,7 @@
     <property name="cumulativeValues" column="cumulative" />
 
     <list name="dataElementGroupSetDimensions" table="visualization_dataelementgroupsetdimensions" cascade="all-delete-orphan">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_dataelementgroupsetdimensions_visualizationid"/>
       <list-index column="sort_order"/>
       <many-to-many column="dataelementgroupsetdimensionid"
@@ -31,7 +31,7 @@
     </list>
 
     <list name="organisationUnitGroupSetDimensions" table="visualization_orgunitgroupsetdimensions" cascade="all-delete-orphan">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_orgunitgroupsetdimensions_visualizationid"/>
       <list-index column="sort_order"/>
       <many-to-many column="orgunitgroupsetdimensionid"
@@ -40,21 +40,21 @@
     </list>
 
     <list name="columnDimensions" table="visualization_columns">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_columns_visualizationid"/>
       <list-index column="sort_order" base="0"/>
       <element type="string" column="dimension"/>
     </list>
 
     <list name="rowDimensions" table="visualization_rows">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_rows_visualizationid"/>
       <list-index column="sort_order" base="0"/>
       <element type="string" column="dimension"/>
     </list>
 
     <list name="filterDimensions" table="visualization_filters">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_filters_visualizationid"/>
       <list-index column="sort_order" base="0"/>
       <element type="string" column="dimension"/>
@@ -94,7 +94,7 @@
     </property>
 
     <list name="optionalAxes" table="visualization_axis" cascade="all, delete-orphan">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="visualizationid" foreign-key="fk_visualization_axis_visualizationid" />
       <list-index column="sort_order" base="0" />
       <many-to-many column="axisid" class="org.hisp.dhis.visualization.Axis"
@@ -102,7 +102,7 @@
     </list>
 
     <list name="yearlySeries" table="visualization_yearlyseries">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_yearlyseries_visualizationid"/>
       <list-index column="sort_order" base="0"/>
       <element type="string" column="yearlyseries"/>
@@ -119,7 +119,7 @@
     <property name="series" type="jbSeries"/>
 
     <list name="dataDimensionItems" table="visualization_datadimensionitems" cascade="all, delete-orphan">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_datadimensionitems_visualizationid"/>
       <list-index column="sort_order" base="0"/>
       <many-to-many column="datadimensionitemid" class="org.hisp.dhis.common.DataDimensionItem"
@@ -127,7 +127,7 @@
     </list>
 
     <list name="organisationUnits" table="visualization_organisationunits">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_organisationunits_visualizationid"/>
       <list-index column="sort_order" base="0"/>
       <many-to-many column="organisationunitid" class="org.hisp.dhis.organisationunit.OrganisationUnit"
@@ -135,7 +135,7 @@
     </list>
 
     <list name="categoryOptionGroupSetDimensions" table="visualization_categoryoptiongroupsetdimensions" cascade="all-delete-orphan">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_catoptiongroupsetdimensions_visualizationid"/>
       <list-index column="sort_order"/>
       <many-to-many column="categoryoptiongroupsetdimensionid"
@@ -144,14 +144,14 @@
     </list>
 
     <list name="organisationUnitLevels" table="visualization_orgunitlevels">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_orgunitlevels_visualizationid"/>
       <list-index column="sort_order" base="0"/>
       <element column="orgunitlevel" type="integer"/>
     </list>
 
     <list name="itemOrganisationUnitGroups" table="visualization_itemorgunitgroups">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_itemorgunitunitgroups_visualizationid"/>
       <list-index column="sort_order" base="0"/>
       <many-to-many column="orgunitgroupid" class="org.hisp.dhis.organisationunit.OrganisationUnitGroup"
@@ -174,7 +174,7 @@
     </set>
 
     <list name="categoryDimensions" table="visualization_categorydimensions" cascade="all-delete-orphan">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_categorydimensions_visualizationid"/>
       <list-index column="sort_order" base="0"/>
       <many-to-many column="categorydimensionid" class="org.hisp.dhis.category.CategoryDimension"
@@ -200,7 +200,7 @@
     </property>
 
     <list name="persistedPeriods" table="visualization_periods">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="visualizationid" foreign-key="fk_visualization_periods_visualizationid"/>
       <list-index column="sort_order" base="0"/>
       <many-to-many column="periodid" class="org.hisp.dhis.period.Period"

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationRule.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationRule.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.validation.ValidationRule" table="validationrule">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="validationruleid">
       <generator class="native" />
@@ -51,7 +51,7 @@
     </set>
 
     <set name="notificationTemplates" table="validationnotificationtemplatevalidationrules" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="validationruleid" foreign-key="fk_validationrule_validationnotificationtemplateid" />
       <many-to-many class="org.hisp.dhis.validation.notification.ValidationNotificationTemplate"
         column="validationnotificationtemplateid" />
@@ -61,7 +61,7 @@
       foreign-key="fk_validationrule_periodtypeid" not-null="true" />
 
     <set name="organisationUnitLevels" table="validationruleorganisationunitlevels">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="validationruleid" foreign-key="fk_organisationunitlevel_validationtuleid" />
       <element column="organisationunitlevel" type="int" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationRuleGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/resources/org/hisp/dhis/validation/hibernate/ValidationRuleGroup.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.validation.ValidationRuleGroup" table="validationrulegroup">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="validationrulegroupid">
       <generator class="native" />
@@ -22,7 +22,7 @@
     <property name="description" type="text" />
 
     <set name="members" table="validationrulegroupmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="validationgroupid" foreign-key="fk_validationrulegroupmembers_validationrulegroupid" />
       <many-to-many class="org.hisp.dhis.validation.ValidationRule" column="validationruleid"
         foreign-key="fk_validationrulegroup_validationruleid" />


### PR DESCRIPTION
## Do not merge

This is a canary/experiment, opened to get CI, API/integration tests, and (via the `deploy`
label) a live e2e instance to run against a repo-wide change, not a change intended to land.

## Summary

Field reports indicate that disabling the Hibernate L2 cache entirely gives a large performance
improvement on highly-loaded instances. Every cached entity in DHIS2 currently uses
`CacheConcurrencyStrategy.READ_WRITE` (verified: 14 `@Cache`-annotated classes in `dhis-api`,
plus 71 more classes across 77 `.hbm.xml` mappings in `dhis-service-core`/`dhis-service-validation`,
~202 collection-level `<cache>` declarations total — `nonstrict-read-write` is used nowhere).

`READ_WRITE`'s soft lock is held on a cached entity from write until the *surrounding
transaction's* commit/rollback callback fires, not just for the write itself. A transaction that
goes idle-in-transaction under load (Postgres connection graphs from a production instance show
exactly this pattern, correlated with L2 cache being enabled) can force cache misses for every
concurrent reader of that entity, system-wide, for as long as it stays open — a feedback loop
under load, not a fixed cost.

This PR mechanically flips every `read-write` declaration to `nonstrict-read-write` (91 files,
235 lines changed each direction) to see:
- Whether anything in the existing test suite depends on `READ_WRITE`'s stricter consistency
  guarantee (a representative local slice — `CategoryControllerTest`, `DataElementControllerTest`,
  `UserLookupControllerTest` — passed 31/31 against a fresh reactor build off master).
- What CI (`run-tests.yml`, `run-api-tests.yml`) and a live e2e instance (`deploy` label) show
  under the full test matrix.

## Test plan

- [x] Compiles clean (`dhis-api`, `dhis-service-core`, `dhis-service-validation`)
- [x] Local representative controller test slice: 31/31 passing
- [ ] Full CI (`run-tests.yml`, `run-api-tests.yml`)
- [ ] Live e2e instance (`deploy` label)