### PR TITLE
fix: remove duplicate HttpSessionCreatedEvent publish on login

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
@@ -40,6 +40,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Calendar;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.security.twofa.TwoFactorAuthService;
@@ -57,8 +59,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.web.session.HttpSessionCreatedEvent;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
@@ -68,6 +76,7 @@ class AuthenticationControllerTest extends AuthenticationApiTestBase {
 
   @Autowired private SystemSettingsService settingsService;
   @Autowired private SessionRegistry sessionRegistry;
+  @Autowired private ConfigurableApplicationContext applicationContext;
 
   @AfterEach
   void tearDown() {
@@ -87,6 +96,38 @@ class AuthenticationControllerTest extends AuthenticationApiTestBase {
 
     assertEquals("SUCCESS", response.getLoginStatus());
     assertEquals("/", response.getRedirectUrl());
+  }
+
+  @Test
+  void testLoginPublishesNoDuplicateSessionCreatedEvent() {
+    // HttpSessionEventPublisher is registered as a servlet container listener in
+    // DhisWebApiWebAppInitializer, which already publishes HttpSessionCreatedEvent when the
+    // container creates the login session. In this MockMvc setup no container listener exists,
+    // so any HttpSessionCreatedEvent observed during login can only come from a manual publish
+    // in the login code path, which would make session lifecycle consumers count logins twice.
+    List<ApplicationEvent> sessionCreatedEvents = new CopyOnWriteArrayList<>();
+    ApplicationListener<ApplicationEvent> listener =
+        event -> {
+          if (event instanceof HttpSessionCreatedEvent) {
+            sessionCreatedEvents.add(event);
+          }
+        };
+    ApplicationEventMulticaster multicaster =
+        applicationContext.getBean(
+            AbstractApplicationContext.APPLICATION_EVENT_MULTICASTER_BEAN_NAME,
+            ApplicationEventMulticaster.class);
+    multicaster.addApplicationListener(listener);
+    try {
+      POST("/auth/login", "{'username':'admin','password':'district'}").content(HttpStatus.OK);
+
+      assertEquals(
+          0,
+          sessionCreatedEvents.size(),
+          "login must not manually publish HttpSessionCreatedEvent; the container listener"
+              + " already publishes it, a manual publish means sessions get counted twice");
+    } finally {
+      multicaster.removeApplicationListener(listener);
+    }
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
@@ -32,8 +32,6 @@ package org.hisp.dhis.webapi.controller.security;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
-import jakarta.servlet.http.HttpSessionEvent;
 import java.util.List;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.external.conf.ConfigurationKey;
@@ -74,7 +72,6 @@ import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.security.web.savedrequest.DefaultSavedRequest;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.security.web.savedrequest.SavedRequest;
-import org.springframework.security.web.session.HttpSessionEventPublisher;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -110,7 +107,6 @@ public class AuthenticationController {
   @Autowired private UserService userService;
 
   @Autowired protected ApplicationEventPublisher eventPublisher;
-  @Autowired private HttpSessionEventPublisher httpSessionEventPublisher;
 
   private SessionAuthenticationStrategy sessionStrategy = new NullAuthenticatedSessionStrategy();
 
@@ -226,9 +222,6 @@ public class AuthenticationController {
 
     this.securityContextHolderStrategy.setContext(context);
     this.securityContextRepository.saveContext(context, request, response);
-
-    HttpSession session = request.getSession(true);
-    httpSessionEventPublisher.sessionCreated(new HttpSessionEvent(session));
   }
 
   private String getRedirectUrl(


### PR DESCRIPTION
## Problem

Sessions created via `/api/auth/login` are announced twice to session lifecycle consumers (discovered on a 2.42.5.1 deployment measuring session stats via #24750).

`DhisWebApiWebAppInitializer` registers `HttpSessionEventPublisher` as a servlet context listener, so the container already publishes `HttpSessionCreatedEvent` when the login session is created (by `RegisterSessionAuthenticationStrategy` / `HttpSessionSecurityContextRepository.saveContext`).

`AuthenticationController.saveContext()` then published a **second** event for the same session via a manual `httpSessionEventPublisher.sessionCreated(...)` call. The manual call does not create the session (it already exists at that point); it only re-announces it, so anything counting session lifecycle events counts every login session twice. On stock master the only consumer is the session timeout setter in `NonRedisSessionConfig` (applied twice, harmless), but any lifecycle-based metric double-counts.

## Fix

Remove the manual publish (and the now-unused `request.getSession(true)`, the session is guaranteed to exist by the session authentication strategy and the security context repository).

## Tests

New regression test `testLoginPublishesNoDuplicateSessionCreatedEvent`: MockMvc has no servlet container listener, so any `HttpSessionCreatedEvent` seen during login must come from a manual publish; the test asserts zero. Verified it fails against the previous code (1 event) and passes with the fix. Existing `AuthenticationControllerTest` (incl. session registry assertions) all green.

AI Assisted