### PR TITLE
perf: evaluate the rowContext subqueries once, in one lateral join

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -1187,6 +1187,11 @@ public abstract class AbstractJdbcEventAnalyticsManager {
 
     sql += getFromClause(params);
 
+    // Required, not merely an optimisation: getSelectClause may have emitted columns that read from
+    // these joins, and without them the inner select references tables that do not exist. Any
+    // assembly that calls getSelectClause has to append this too.
+    sql += getRowContextJoinClause(params);
+
     String whereClause = getWhereClause(params);
     String filterWhereClause = getQueryItemsAndFiltersWhereClause(params, new SqlHelper());
     sql += SqlConditionJoiner.joinSqlConditions(whereClause, filterWhereClause);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -167,6 +167,9 @@ public abstract class AbstractJdbcEventAnalyticsManager {
 
   private static final String LIMIT = "limit";
 
+  /** Alias prefix for the lateral joins that serve the row-context columns. */
+  private static final String ROW_CONTEXT_TABLE_ALIAS_PREFIX = "rowcontext_";
+
   private static final Collector<CharSequence, ?, String> OR_JOINER = joining(OR, "(", ")");
 
   private static final Collector<CharSequence, ?, String> AND_JOINER = joining(AND);
@@ -432,14 +435,40 @@ public abstract class AbstractJdbcEventAnalyticsManager {
       EventQueryParams params,
       boolean isGroupByClause,
       boolean isAggregated) {
-    for (QueryItem queryItem : params.getItems()) {
+    boolean lateralsApply = rowContextLateralsApply(isGroupByClause, isAggregated);
+
+    for (int index = 0; index < params.getItems().size(); index++) {
+      QueryItem queryItem = params.getItems().get(index);
       ColumnAndAlias columnAndAlias =
           getColumnAndAlias(queryItem, params, isGroupByClause, isAggregated);
 
+      // asked for row context if allowed and needed based on column and its alias
+      boolean rowContext =
+          rowContextAllowedAndNeeded(params, queryItem) && !isEmpty(columnAndAlias.alias);
+
+      Optional<RowContextLateral> lateral =
+          rowContext && lateralsApply
+              ? asRowContextLateral(columnAndAlias.column, index)
+              : Optional.empty();
+
+      if (lateral.isPresent()) {
+        String table = quote(lateral.get().tableAlias());
+        columns.add(
+            ColumnAndAlias.ofColumnAndAlias(table + ".value", columnAndAlias.alias).asSql());
+        columns.add(
+            ColumnAndAlias.ofColumnAndAlias(
+                    "coalesce(" + table + ".found, false)", columnAndAlias.alias + ".exists")
+                .asSql());
+        columns.add(
+            ColumnAndAlias.ofColumnAndAlias(
+                    table + ".eventstatus", columnAndAlias.alias + ".status")
+                .asSql());
+        continue;
+      }
+
       columns.add(columnAndAlias.asSql());
 
-      // asked for row context if allowed and needed based on column and its alias
-      if (rowContextAllowedAndNeeded(params, queryItem) && !isEmpty(columnAndAlias.alias)) {
+      if (rowContext) {
         String columnForExists = " exists (" + columnAndAlias.column + ")";
         String aliasForExists = columnAndAlias.alias + ".exists";
         columns.add((new ColumnAndAlias(columnForExists, aliasForExists)).asSql());
@@ -449,6 +478,128 @@ public abstract class AbstractJdbcEventAnalyticsManager {
         columns.add((new ColumnAndAlias(columnForStatus, aliasForStatus)).asSql());
       }
     }
+  }
+
+  /**
+   * A lateral join that evaluates a repeatable-stage subquery once and exposes the three things the
+   * row-context response needs from it: the value, whether a matching event was found at all, and
+   * that event's status.
+   *
+   * @param tableAlias the alias the join is given, and through which the select list reads it.
+   * @param joinSql the {@code left join lateral (...) on true} fragment.
+   */
+  protected record RowContextLateral(String tableAlias, String joinSql) {}
+
+  /**
+   * The row-context columns can only be served from a lateral join on the query shape that has one
+   * - the plain enrollment select. A group-by or aggregated select does not get the join appended,
+   * so it must keep emitting the three correlated subqueries.
+   */
+  private static boolean rowContextLateralsApply(boolean isGroupByClause, boolean isAggregated) {
+    return !isGroupByClause && !isAggregated;
+  }
+
+  /**
+   * Returns the {@code left join lateral} fragments for the row-context items of the given query,
+   * in item order.
+   *
+   * <p>This is derived from {@code params} alone and from the same {@code getColumnAndAlias} calls
+   * {@link #addItemSelectColumns} makes, so the two agree on which items get a lateral and on the
+   * alias each one is given. Nothing is threaded between them.
+   */
+  protected String getRowContextJoinClause(EventQueryParams params) {
+    if (!params.isRowContext()) {
+      return EMPTY;
+    }
+
+    StringBuilder joins = new StringBuilder();
+
+    for (int index = 0; index < params.getItems().size(); index++) {
+      QueryItem queryItem = params.getItems().get(index);
+
+      if (!rowContextAllowedAndNeeded(params, queryItem)) {
+        continue;
+      }
+
+      ColumnAndAlias columnAndAlias = getColumnAndAlias(queryItem, params, false, false);
+
+      if (isEmpty(columnAndAlias.alias)) {
+        continue;
+      }
+
+      asRowContextLateral(columnAndAlias.column, index)
+          .ifPresent(lateral -> joins.append(lateral.joinSql()));
+    }
+
+    return joins.toString();
+  }
+
+  /**
+   * Turns a repeatable-stage scalar subquery into a lateral join that evaluates it once.
+   *
+   * <p>With {@code rowContext=true} each repeatable-stage data element used to emit the same
+   * correlated subquery three times - once for the value, once wrapped in {@code exists (...)}, and
+   * once with the selected column textually replaced by {@code eventstatus}. The planner sees three
+   * independent nodes, each with its own {@code order by occurreddate desc, created desc limit 1},
+   * so an enrollment line list with 18 such dimensions generated 54 subselects. A lateral evaluates
+   * the subquery once and all three columns read from its single row.
+   *
+   * <p>Deliberately driven off the already-built subquery text rather than rebuilt from its parts:
+   * the shapes {@code getColumn} can produce are several - {@code nullif}-wrapped, coordinate,
+   * organisation-unit-with-suffix - and only the plain {@code (select <one expression> from ...
+   * limit 1)} form can be rewritten this way. Anything else returns empty and keeps the three
+   * subqueries, so this is strictly an optimisation of the recognised shape.
+   *
+   * <p>Equivalence of the three columns:
+   *
+   * <ul>
+   *   <li>{@code value} is the same expression over the same row, so the same value.
+   *   <li>{@code exists ((select ... limit 1))} is true exactly when the subquery returned a row,
+   *       which is exactly when the lateral produced one, which is what {@code found} records.
+   *   <li>{@code .status} was the same subquery selecting {@code eventstatus} instead, so it is
+   *       that row's status - the row the lateral already has.
+   * </ul>
+   */
+  private Optional<RowContextLateral> asRowContextLateral(String subquery, int index) {
+    String trimmed = StringUtils.trimToEmpty(subquery);
+
+    if (!trimmed.startsWith("(select ") || !trimmed.endsWith(")")) {
+      return Optional.empty();
+    }
+
+    String body = trimmed.substring(1, trimmed.length() - 1).trim();
+    int fromIndex = body.indexOf(" from ");
+
+    if (fromIndex < 0) {
+      return Optional.empty();
+    }
+
+    String selectList = body.substring("select".length(), fromIndex).trim();
+    String rest = body.substring(fromIndex);
+
+    // One unaliased expression, and a query that references eventstatus - which the
+    // repeatable-stage
+    // subquery does, in its "eventstatus != 'SCHEDULE'" filter. Anything else is a shape this
+    // cannot
+    // safely rewrite.
+    if (selectList.isEmpty()
+        || selectList.contains(",")
+        || selectList.contains(" as ")
+        || !rest.contains("eventstatus")) {
+      return Optional.empty();
+    }
+
+    String tableAlias = ROW_CONTEXT_TABLE_ALIAS_PREFIX + index;
+    String joinSql =
+        " left join lateral (select "
+            + selectList
+            + " as value, eventstatus, true as found"
+            + rest
+            + ") as "
+            + quote(tableAlias)
+            + " on true ";
+
+    return Optional.of(new RowContextLateral(tableAlias, joinSql));
   }
 
   /**
@@ -1010,6 +1161,10 @@ public abstract class AbstractJdbcEventAnalyticsManager {
     String sql = getSelectClause(params);
 
     sql += getFromClause(params);
+
+    // Must sit between the from and where clauses: the laterals reference the base table's
+    // enrollment column, and the where clause may reference the laterals' own columns.
+    sql += getRowContextJoinClause(params);
 
     sql += getWhereClause(params);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -76,6 +76,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -169,6 +170,9 @@ public abstract class AbstractJdbcEventAnalyticsManager {
 
   /** Alias prefix for the lateral joins that serve the row-context columns. */
   private static final String ROW_CONTEXT_TABLE_ALIAS_PREFIX = "rowcontext_";
+
+  /** Name prefix for the per-item value columns a row-context lateral join returns. */
+  private static final String ROW_CONTEXT_VALUE_COLUMN_PREFIX = "v";
 
   private static final Collector<CharSequence, ?, String> OR_JOINER = joining(OR, "(", ")");
 
@@ -435,10 +439,14 @@ public abstract class AbstractJdbcEventAnalyticsManager {
       EventQueryParams params,
       boolean isGroupByClause,
       boolean isAggregated) {
-    boolean lateralsApply = rowContextLateralsApply(isGroupByClause, isAggregated);
+    // Only consulted on the shape that gets the joins appended, which is also the shape
+    // getRowContextLaterals builds its columns for - so both sides pass the same flags.
+    Map<String, RowContextRef> lateralRefs =
+        params.isRowContext() && rowContextLateralsApply(isGroupByClause, isAggregated)
+            ? getRowContextLaterals(params).refs()
+            : Map.of();
 
-    for (int index = 0; index < params.getItems().size(); index++) {
-      QueryItem queryItem = params.getItems().get(index);
+    for (QueryItem queryItem : params.getItems()) {
       ColumnAndAlias columnAndAlias =
           getColumnAndAlias(queryItem, params, isGroupByClause, isAggregated);
 
@@ -446,15 +454,14 @@ public abstract class AbstractJdbcEventAnalyticsManager {
       boolean rowContext =
           rowContextAllowedAndNeeded(params, queryItem) && !isEmpty(columnAndAlias.alias);
 
-      Optional<RowContextLateral> lateral =
-          rowContext && lateralsApply
-              ? asRowContextLateral(columnAndAlias.column, index)
-              : Optional.empty();
+      RowContextRef ref = rowContext ? lateralRefs.get(columnAndAlias.alias) : null;
 
-      if (lateral.isPresent()) {
-        String table = quote(lateral.get().tableAlias());
+      if (ref != null) {
+        String table = quote(ref.tableAlias());
         columns.add(
-            ColumnAndAlias.ofColumnAndAlias(table + ".value", columnAndAlias.alias).asSql());
+            ColumnAndAlias.ofColumnAndAlias(
+                    table + "." + quote(ref.valueColumn()), columnAndAlias.alias)
+                .asSql());
         columns.add(
             ColumnAndAlias.ofColumnAndAlias(
                     "coalesce(" + table + ".found, false)", columnAndAlias.alias + ".exists")
@@ -481,14 +488,26 @@ public abstract class AbstractJdbcEventAnalyticsManager {
   }
 
   /**
-   * A lateral join that evaluates a repeatable-stage subquery once and exposes the three things the
-   * row-context response needs from it: the value, whether a matching event was found at all, and
-   * that event's status.
-   *
-   * @param tableAlias the alias the join is given, and through which the select list reads it.
-   * @param joinSql the {@code left join lateral (...) on true} fragment.
+   * Where one item's three row-context columns are read from: the lateral join that evaluated its
+   * subquery, and the column in that join holding this item's value. {@code found} and {@code
+   * eventstatus} are shared by every item on the join, so they need no per-item name.
    */
-  protected record RowContextLateral(String tableAlias, String joinSql) {}
+  private record RowContextRef(String tableAlias, String valueColumn) {}
+
+  /**
+   * One lateral join under construction: its alias, the subquery text from {@code from} onwards -
+   * which is the grouping key - and the expression each member item selects.
+   */
+  private record RowContextLateral(String tableAlias, String rest, List<String> valueExpressions) {}
+
+  /**
+   * The row-context laterals of a query: the joins to append, and where each item reads from them.
+   *
+   * @param joinClause the {@code left join lateral (...) on true} fragments, one per subquery
+   *     shape.
+   * @param refs where each row-context item's columns are read from, keyed by the item's alias.
+   */
+  private record RowContextLaterals(String joinClause, Map<String, RowContextRef> refs) {}
 
   /**
    * The row-context columns can only be served from a lateral join on the query shape that has one
@@ -499,56 +518,44 @@ public abstract class AbstractJdbcEventAnalyticsManager {
     return !isGroupByClause && !isAggregated;
   }
 
-  /**
-   * Returns the {@code left join lateral} fragments for the row-context items of the given query,
-   * in item order.
-   *
-   * <p>This is derived from {@code params} alone and from the same {@code getColumnAndAlias} calls
-   * {@link #addItemSelectColumns} makes, so the two agree on which items get a lateral and on the
-   * alias each one is given. Nothing is threaded between them.
-   */
+  /** Returns the {@code left join lateral} fragments for the row-context items of the query. */
   protected String getRowContextJoinClause(EventQueryParams params) {
-    if (!params.isRowContext()) {
-      return EMPTY;
-    }
-
-    StringBuilder joins = new StringBuilder();
-
-    for (int index = 0; index < params.getItems().size(); index++) {
-      QueryItem queryItem = params.getItems().get(index);
-
-      if (!rowContextAllowedAndNeeded(params, queryItem)) {
-        continue;
-      }
-
-      ColumnAndAlias columnAndAlias = getColumnAndAlias(queryItem, params, false, false);
-
-      if (isEmpty(columnAndAlias.alias)) {
-        continue;
-      }
-
-      asRowContextLateral(columnAndAlias.column, index)
-          .ifPresent(lateral -> joins.append(lateral.joinSql()));
-    }
-
-    return joins.toString();
+    return params.isRowContext() ? getRowContextLaterals(params).joinClause() : EMPTY;
   }
 
   /**
-   * Turns a repeatable-stage scalar subquery into a lateral join that evaluates it once.
+   * Rewrites the repeatable-stage scalar subqueries of a row-context query into lateral joins, one
+   * per distinct subquery, and says where each item reads its columns back from.
    *
    * <p>With {@code rowContext=true} each repeatable-stage data element used to emit the same
    * correlated subquery three times - once for the value, once wrapped in {@code exists (...)}, and
    * once with the selected column textually replaced by {@code eventstatus}. The planner sees three
    * independent nodes, each with its own {@code order by occurreddate desc, created desc limit 1},
-   * so an enrollment line list with 18 such dimensions generated 54 subselects. A lateral evaluates
-   * the subquery once and all three columns read from its single row.
+   * so an enrollment line list with 18 such dimensions generated 54 subselects.
+   *
+   * <p>Two reductions, and the second is the larger one:
+   *
+   * <ul>
+   *   <li>A lateral evaluates the subquery once and all three columns read from its single row: 54
+   *       subselects become 18 joins.
+   *   <li>Every data element on the same repeatable stage produces the <em>same</em> {@code from
+   *       ... where ... order by ... limit 1}, differing only in the expression selected - so they
+   *       are grouped onto one join that returns one value column each: 18 joins become 1.
+   * </ul>
+   *
+   * <p>That matters because the cost is the planner's, not the executor's. Each subquery expands to
+   * an {@code Append} over every year partition of the event table plus the inheritance parent, and
+   * planning is paid per relation reference: on Uganda's instance 54 subselects x 22 relations =
+   * 1,188 references cost 15.1 s to plan and 30 ms to execute. One join is 22 references.
    *
    * <p>Deliberately driven off the already-built subquery text rather than rebuilt from its parts:
    * the shapes {@code getColumn} can produce are several - {@code nullif}-wrapped, coordinate,
    * organisation-unit-with-suffix - and only the plain {@code (select <one expression> from ...
-   * limit 1)} form can be rewritten this way. Anything else returns empty and keeps the three
-   * subqueries, so this is strictly an optimisation of the recognised shape.
+   * limit 1)} form can be rewritten this way. Anything else is left out of the grouping and keeps
+   * its three subqueries, so this is strictly an optimisation of the recognised shape. Grouping on
+   * the subquery text, rather than on the program stage, is safe for the same reason: two items
+   * share a join only when everything but the selected expression is character-for-character equal,
+   * which is what makes them one evaluation.
    *
    * <p>Equivalence of the three columns:
    *
@@ -559,8 +566,82 @@ public abstract class AbstractJdbcEventAnalyticsManager {
    *   <li>{@code .status} was the same subquery selecting {@code eventstatus} instead, so it is
    *       that row's status - the row the lateral already has.
    * </ul>
+   *
+   * <p>Derived from {@code params} alone, so {@link #addItemSelectColumns} and {@link
+   * #getRowContextJoinClause} agree on the grouping and on every alias without threading anything
+   * between them.
    */
-  private Optional<RowContextLateral> asRowContextLateral(String subquery, int index) {
+  private RowContextLaterals getRowContextLaterals(EventQueryParams params) {
+    Map<String, RowContextLateral> laterals = new LinkedHashMap<>();
+    Map<String, RowContextRef> refs = new LinkedHashMap<>();
+
+    for (QueryItem queryItem : params.getItems()) {
+      if (!rowContextAllowedAndNeeded(params, queryItem)) {
+        continue;
+      }
+
+      ColumnAndAlias columnAndAlias = getColumnAndAlias(queryItem, params, false, false);
+
+      if (isEmpty(columnAndAlias.alias)) {
+        continue;
+      }
+
+      Optional<String[]> parts = splitRowContextSubquery(columnAndAlias.column);
+
+      if (parts.isEmpty()) {
+        continue;
+      }
+
+      String selectExpression = parts.get()[0];
+      String rest = parts.get()[1];
+
+      // Computed outside computeIfAbsent so the mapping function does not read the map it is
+      // populating: laterals are numbered in the order their subquery is first seen.
+      String tableAlias = ROW_CONTEXT_TABLE_ALIAS_PREFIX + laterals.size();
+
+      RowContextLateral lateral =
+          laterals.computeIfAbsent(
+              rest, key -> new RowContextLateral(tableAlias, key, new ArrayList<>()));
+
+      refs.put(
+          columnAndAlias.alias,
+          new RowContextRef(
+              lateral.tableAlias(),
+              ROW_CONTEXT_VALUE_COLUMN_PREFIX + lateral.valueExpressions().size()));
+      lateral.valueExpressions().add(selectExpression);
+    }
+
+    StringBuilder joins = new StringBuilder();
+
+    for (RowContextLateral lateral : laterals.values()) {
+      joins.append(" left join lateral (select ");
+
+      for (int ordinal = 0; ordinal < lateral.valueExpressions().size(); ordinal++) {
+        joins
+            .append(lateral.valueExpressions().get(ordinal))
+            .append(" as ")
+            .append(quote(ROW_CONTEXT_VALUE_COLUMN_PREFIX + ordinal))
+            .append(", ");
+      }
+
+      joins
+          .append("eventstatus, true as found")
+          .append(lateral.rest())
+          .append(") as ")
+          .append(quote(lateral.tableAlias()))
+          .append(" on true ");
+    }
+
+    return new RowContextLaterals(joins.toString(), refs);
+  }
+
+  /**
+   * Splits a repeatable-stage scalar subquery into the one expression it selects and everything
+   * from its {@code from} keyword onwards, or empty if it is not that shape.
+   *
+   * @return {@code [selected expression, rest]}, where {@code rest} is the grouping key.
+   */
+  private Optional<String[]> splitRowContextSubquery(String subquery) {
     String trimmed = StringUtils.trimToEmpty(subquery);
 
     if (!trimmed.startsWith("(select ") || !trimmed.endsWith(")")) {
@@ -578,28 +659,22 @@ public abstract class AbstractJdbcEventAnalyticsManager {
     String rest = body.substring(fromIndex);
 
     // One unaliased expression, and a query that references eventstatus - which the
-    // repeatable-stage
-    // subquery does, in its "eventstatus != 'SCHEDULE'" filter. Anything else is a shape this
-    // cannot
-    // safely rewrite.
+    // repeatable-stage subquery does, in its "eventstatus != 'SCHEDULE'" filter. Anything else is
+    // a shape this cannot safely rewrite.
+    //
+    // Balanced parentheses matter as more than tidiness: " from " is also a token inside
+    // expressions such as "extract(year from occurreddate)", and splitting on the first one would
+    // leave a half expression on each side. Requiring the select list to close every bracket it
+    // opens rejects that shape instead of emitting SQL that does not parse.
     if (selectList.isEmpty()
         || selectList.contains(",")
         || selectList.contains(" as ")
-        || !rest.contains("eventstatus")) {
+        || !rest.contains("eventstatus")
+        || StringUtils.countMatches(selectList, '(') != StringUtils.countMatches(selectList, ')')) {
       return Optional.empty();
     }
 
-    String tableAlias = ROW_CONTEXT_TABLE_ALIAS_PREFIX + index;
-    String joinSql =
-        " left join lateral (select "
-            + selectList
-            + " as value, eventstatus, true as found"
-            + rest
-            + ") as "
-            + quote(tableAlias)
-            + " on true ";
-
-    return Optional.of(new RowContextLateral(tableAlias, joinSql));
+    return Optional.of(new String[] {selectList, rest});
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -72,6 +72,7 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.RepeatableStageParams;
+import org.hisp.dhis.common.RequestTypeAware;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.db.sql.PostgreSqlAnalyticsSqlBuilder;
 import org.hisp.dhis.db.sql.PostgreSqlBuilder;
@@ -225,6 +226,37 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
   @Test
   void verifyWithRepeatableProgramStageAndTextDataElement() {
     verifyWithRepeatableProgramStageAndDataElement(ValueType.TEXT);
+  }
+
+  /**
+   * The aggregated-enrollments query wraps its own select clause in an outer count, and that select
+   * clause goes through the same row-context handling. Every assembly that emits columns reading
+   * from a lateral join has to emit the join as well - otherwise the SQL references a table that is
+   * not in the query. This asserts they stay in step.
+   */
+  @Test
+  void verifyAggregatedEnrollmentsWithRowContextEmitsTheLateralItReadsFrom() {
+    EventQueryParams params =
+        new EventQueryParams.Builder(createRequestParams(repeatableProgramStage, ValueType.TEXT))
+            .withEndpointAction(RequestTypeAware.EndpointAction.AGGREGATE)
+            .withEndpointItem(RequestTypeAware.EndpointItem.ENROLLMENT)
+            .build();
+
+    subject.getEnrollments(params, new ListGrid(), 100);
+
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generated = sql.getValue();
+
+    // The select list reads three columns off the lateral; the lateral must be declared once.
+    assertEquals(
+        3,
+        StringUtils.countMatches(generated, "\"rowcontext_0\"."),
+        "expected value, exists and status to read from the lateral: " + generated);
+    assertEquals(
+        1,
+        StringUtils.countMatches(generated, "as \"rowcontext_0\" on true"),
+        "the lateral the select list reads from must be joined in: " + generated);
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -59,6 +59,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.function.Consumer;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.event.EventQueryParams;
@@ -283,64 +284,51 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
 
     String dataElementUid = dataElementA.getUid();
 
+    // rowContext=true used to emit this subquery three times - the value, the same subquery wrapped
+    // in exists(...), and the same subquery with the column textually replaced by eventstatus - so
+    // 18 data elements produced 54 correlated subselects. It is now evaluated once in a lateral
+    // join
+    // and all three columns read from that one row.
+    String columnAlias = programStageUid + "[-1]." + dataElementUid;
+
     String expected =
         "select enrollment,trackedentity,enrollmentdate,occurreddate,storedby,createdbydisplayname,lastupdatedbydisplayname,lastupdated,ST_AsGeoJSON(enrollmentgeometry),longitude,latitude,"
             + "ouname,ounamehierarchy,oucode,enrollmentstatus,ax.\"quarterly\",ax.\"ou\","
-            + "(select \""
-            + dataElementUid
-            + "\" from analytics_event_"
-            + programUid
-            + " where analytics_event_"
-            + programUid
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programUid
-            + ".enrollment = ax.enrollment and ps = '"
-            + repeatableProgramStage.getUid()
-            + "' order by occurreddate desc, created desc offset 1 limit 1 ) "
-            + "as \""
-            + programStageUid
-            + "[-1]."
-            + dataElementUid
-            + "\", exists ((select \""
-            + dataElementUid
-            + "\" "
-            + "from analytics_event_"
-            + programUid
-            + " where analytics_event_"
-            + programUid
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programUid
-            + ".enrollment = ax.enrollment and ps = '"
-            + programStageUid
-            + "' order by occurreddate desc, created desc offset 1 limit 1 )) "
-            + "as \""
-            + programStageUid
-            + "[-1]."
-            + dataElementUid
-            + ".exists\""
-            + ",(select eventstatus "
-            + "from analytics_event_"
-            + programUid
-            + " where analytics_event_"
-            + programUid
-            + ".eventstatus != 'SCHEDULE' and analytics_event_"
-            + programUid
-            + ".enrollment = ax.enrollment and ps = '"
-            + programStageUid
-            + "' order by occurreddate desc, created desc offset 1 limit 1 ) "
-            + "as \""
-            + programStageUid
-            + "[-1]."
-            + dataElementUid
+            + "\"rowcontext_0\".value as \""
+            + columnAlias
+            + "\","
+            + "coalesce(\"rowcontext_0\".found, false) as \""
+            + columnAlias
+            + ".exists\","
+            + "\"rowcontext_0\".eventstatus as \""
+            + columnAlias
             + ".status\"  "
             + "from analytics_enrollment_"
             + programUid
-            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) "
+            + " as ax "
+            + " left join lateral (select \""
+            + dataElementUid
+            + "\" as value, eventstatus, true as found from analytics_event_"
+            + programUid
+            + " where analytics_event_"
+            + programUid
+            + ".eventstatus != 'SCHEDULE' and analytics_event_"
+            + programUid
+            + ".enrollment = ax.enrollment and ps = '"
+            + programStageUid
+            + "' order by occurreddate desc, created desc offset 1 limit 1) as \"rowcontext_0\" on true "
+            + "where (ax.\"quarterly\" in ('2000Q1') ) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) "
             + "and ps = '"
             + programStageUid
             + "' limit 101";
 
     assertEquals(expected, sql.getValue());
+
+    // The point of the change, asserted as a count rather than left implicit in the string above:
+    // the subquery is written once, and neither of the two duplicates survives.
+    assertEquals(1, StringUtils.countMatches(sql.getValue(), "left join lateral"));
+    assertEquals(1, StringUtils.countMatches(sql.getValue(), "order by occurreddate desc"));
+    assertEquals(0, StringUtils.countMatches(sql.getValue(), "exists (("));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -259,6 +259,70 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
         "the lateral the select list reads from must be joined in: " + generated);
   }
 
+  /**
+   * The point of the grouping. Every data element on the same repeatable stage generates the same
+   * subquery apart from the expression it selects, so they share one lateral and one evaluation of
+   * it: Uganda's traced request has 18 of them and used to emit 54 correlated subselects, then 18
+   * joins, and now emits one. Goes red if the grouping is removed - each item would take its own
+   * {@code rowcontext_<n>} and its own join.
+   */
+  @Test
+  void verifyRepeatableStageDataElementsShareOneLateral() {
+    EventQueryParams params =
+        new EventQueryParams.Builder(createRequestParams(repeatableProgramStage, ValueType.TEXT))
+            .addItem(repeatableStageItem("bBk3nGGkNbF"))
+            .addItem(repeatableStageItem("cCk3nGGkNbG"))
+            .build();
+
+    subject.getEnrollments(params, new ListGrid(), 100);
+
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generated = sql.getValue();
+
+    assertEquals(
+        1,
+        StringUtils.countMatches(generated, "left join lateral"),
+        "three data elements on one stage must share one lateral: " + generated);
+    assertEquals(
+        1,
+        StringUtils.countMatches(generated, "order by occurreddate desc"),
+        "the subquery must be evaluated once: " + generated);
+    assertEquals(
+        0,
+        StringUtils.countMatches(generated, "rowcontext_1"),
+        "a second lateral means the grouping did not happen: " + generated);
+
+    // One value column per item on the single join, and each read exactly once by the select list.
+    for (int ordinal = 0; ordinal < 3; ordinal++) {
+      assertEquals(
+          1,
+          StringUtils.countMatches(generated, "as \"v" + ordinal + "\""),
+          "expected a value column v" + ordinal + ": " + generated);
+      assertEquals(
+          1,
+          StringUtils.countMatches(generated, "\"rowcontext_0\".\"v" + ordinal + "\""),
+          "expected the select list to read v" + ordinal + ": " + generated);
+    }
+  }
+
+  /**
+   * A repeatable-stage query item for the given data element, on {@code repeatableProgramStage}.
+   */
+  private QueryItem repeatableStageItem(String dataElementUid) {
+    QueryItem item = new QueryItem(new BaseDimensionalItemObject(dataElementUid));
+    item.setProgram(programA);
+    item.setProgramStage(repeatableProgramStage);
+    item.setValueType(ValueType.TEXT);
+
+    RepeatableStageParams repeatableStageParams = new RepeatableStageParams();
+    repeatableStageParams.setDimension(repeatableProgramStage.getUid() + "[-1]." + dataElementUid);
+    repeatableStageParams.setIndex(-1);
+    item.setRepeatableStageParams(repeatableStageParams);
+
+    return item;
+  }
+
   @Test
   void verifyWithProgramStageAndTextDataElement() {
     verifyWithProgramStageAndDataElement(ValueType.TEXT);
@@ -326,7 +390,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     String expected =
         "select enrollment,trackedentity,enrollmentdate,occurreddate,storedby,createdbydisplayname,lastupdatedbydisplayname,lastupdated,ST_AsGeoJSON(enrollmentgeometry),longitude,latitude,"
             + "ouname,ounamehierarchy,oucode,enrollmentstatus,ax.\"quarterly\",ax.\"ou\","
-            + "\"rowcontext_0\".value as \""
+            + "\"rowcontext_0\".\"v0\" as \""
             + columnAlias
             + "\","
             + "coalesce(\"rowcontext_0\".found, false) as \""
@@ -340,7 +404,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + " as ax "
             + " left join lateral (select \""
             + dataElementUid
-            + "\" as value, eventstatus, true as found from analytics_event_"
+            + "\" as \"v0\", eventstatus, true as found from analytics_event_"
             + programUid
             + " where analytics_event_"
             + programUid


### PR DESCRIPTION
## The problem

An enrolment line list with repeatable-stage data elements takes 15 seconds to return one row. With
`rowContext=true` each data element emits its correlated subquery three times — value, `.exists`,
`.status` — so eighteen of them become 54 subselects.

Almost none of it is spent running the query. Each subselect expands to an `Append` over 22
relations — 21 event year-partitions plus the inheritance parent — none prunable, because the subquery
correlates on `enrollment`, not on the partition key. Planning is paid per relation reference, and the
statement has 1,188.

## The solution

Data elements on one repeatable stage generate the same subquery apart from the expression selected,
so they are grouped onto **one** `left join lateral` returning a value column each plus the
`eventstatus` and `found` marker they share. 54 subselects become 1 lateral, 1,188 range-table
entries become 22.

A second commit fixes a defect it exposed: `getAggregatedEnrollmentsSql` emitted columns
reading from the lateral alias without joining it in.

Only the plain `(select <one expression> from … limit 1)` shape is rewritten; anything else keeps its
three subqueries, and `rowContext=false` is untouched.

## Why this is a good solution

```
                                    range-table entries   planning    execution
54 correlated subselects (today)                  1,188   893.4 ms     234.8 ms
18 laterals, one per data element                   396   271.4 ms      34.9 ms
 1 grouped lateral                                   22    52.6 ms       2.2 ms
```

**17× less planning.** On a production instance the same statement plans in 15,120 ms and executes
in 30 ms — the 54 × 22 entries of the first row.

Output is byte-identical across the three variants over 101 rows whose enrolments have several events
each, exercising the `order by occurreddate desc, created desc limit 1` tie-break. 1,022
module tests pass; one pins the lateral count at 1 and fails without the grouping.

The times come from a fixture with the same partition count, index count and statement shape rather
than from a served request, so the ratios transfer and the absolute times do not.