### PR TITLE
test: pin the per-flow SQL cost of second level cache hits

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
@@ -150,6 +150,11 @@
       <version>3.3.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Other -->
 
@@ -262,7 +267,12 @@
             <ignoredUnusedDeclaredDependency>com.google.code.java-allocation-instrumenter:java-allocation-instrumenter</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.glassfish.jaxb:jaxb-runtime</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.ehcache:ehcache</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>com.h2database:h2</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
+          <ignoredNonTestScopedDependencies combine.children="append">
+            <ignoredNonTestScopedDependency>org.ehcache:ehcache</ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>javax.cache:cache-api</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -180,7 +180,7 @@ public class HibernateConfig {
       // Specify the location of the Ehcache 3 configuration file
       String configFile = dhisConfig.getProperty(CACHE_EHCACHE_CONFIG_FILE);
       if (!configFile.isBlank()) {
-        properties.put(ConfigSettings.CONFIG_URI, configFile);
+        properties.put(ConfigSettings.CONFIG_URI, normalizeEhcacheConfigLocation(configFile));
       }
     } else {
       // Explicitly disable both caches. Without this, Hibernate auto-enables the second level
@@ -196,5 +196,26 @@ public class HibernateConfig {
     properties.put(AvailableSettings.HBM2DDL_AUTO, Action.VALIDATE.getExternalHbm2ddlName());
 
     return properties;
+  }
+
+  /**
+   * Normalizes the {@code cache.ehcache.config.file} value so Hibernate can resolve it.
+   *
+   * <p>Hibernate's ClassLoaderService only understands the nonstandard {@code classpath://} scheme:
+   * it strips that exact prefix and resolves the rest against the classpath, while the common
+   * {@code classpath:} spelling (also the ConfigurationKey default) is passed to the classloader
+   * verbatim, never resolves, and fails the SessionFactory boot with "Couldn't load URI". Both
+   * spellings are therefore stripped here; a bare resource name resolves fine. Other values ({@code
+   * file:} URLs, absolute paths) are passed through untouched.
+   */
+  static String normalizeEhcacheConfigLocation(String location) {
+    String value = location.strip();
+    if (value.regionMatches(true, 0, "classpath://", 0, 12)) {
+      return value.substring(12);
+    }
+    if (value.regionMatches(true, 0, "classpath:", 0, 10)) {
+      return value.substring(10);
+    }
+    return value;
   }
 }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
@@ -7,9 +7,11 @@
             http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.10.xsd
             http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.10.xsd">
 
-  <!-- Service definition to specify the default template for JSR-107 created caches -->
+  <!-- Service definition to specify the default template for JSR-107 created caches.
+       Statistics are enabled so per-region metrics can be exposed via the
+       monitoring.ehcache.enabled Micrometer binding (see EhCacheMetricsConfig). -->
   <service>
-    <jsr107:defaults default-template="defaultCacheTemplate"/>
+    <jsr107:defaults default-template="defaultCacheTemplate" enable-statistics="true"/>
   </service>
 
   <!-- Cache template definition (referenced by jsr107:defaults and potentially explicit caches) -->

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/CachedParentTestEntity.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/CachedParentTestEntity.java
@@ -44,10 +44,10 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 /**
- * Minimal cached entity owning a cached collection, used to observe the real SQL cost of
- * collection cache hits. It is mapped exactly like the production entities: READ_WRITE concurrency
- * on both the entity and the lazy collection, which is the only strategy used in DHIS2 (see the
- * {@code <cache usage="read-write"/>} tags on collections in the hbm.xml mappings).
+ * Minimal cached entity owning a cached collection, used to observe the real SQL cost of collection
+ * cache hits. It is mapped exactly like the production entities: READ_WRITE concurrency on both the
+ * entity and the lazy collection, which is the only strategy used in DHIS2 (see the {@code <cache
+ * usage="read-write"/>} tags on collections in the hbm.xml mappings).
  *
  * @author Morten Svanæs
  */

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/CachedParentTestEntity.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/CachedParentTestEntity.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.config;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+/**
+ * Minimal cached entity owning a cached collection, used to observe the real SQL cost of
+ * collection cache hits. It is mapped exactly like the production entities: READ_WRITE concurrency
+ * on both the entity and the lazy collection, which is the only strategy used in DHIS2 (see the
+ * {@code <cache usage="read-write"/>} tags on collections in the hbm.xml mappings).
+ *
+ * @author Morten Svanæs
+ */
+@Entity
+@Table(name = "cached_parent_test_entity")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+public class CachedParentTestEntity {
+
+  @Id private Long id;
+
+  @Column private String name;
+
+  @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @JoinColumn(name = "parent_id")
+  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  private Set<CachedTestEntity> children = new HashSet<>();
+
+  public CachedParentTestEntity() {}
+
+  public CachedParentTestEntity(Long id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Set<CachedTestEntity> getChildren() {
+    return children;
+  }
+
+  public void setChildren(Set<CachedTestEntity> children) {
+    this.children = children;
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/CachedTestEntity.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/CachedTestEntity.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.config;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+/**
+ * Minimal cached entity used to observe real second level cache behavior at the SessionFactory
+ * level. It is annotated exactly like the production entities: READ_WRITE concurrency, which is the
+ * only strategy used in DHIS2.
+ *
+ * @author Morten Svanæs
+ */
+@Entity
+@Table(name = "cached_test_entity")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+public class CachedTestEntity {
+
+  @Id private Long id;
+
+  @Column private String name;
+
+  public CachedTestEntity() {}
+
+  public CachedTestEntity(Long id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/HibernateCacheEffectTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/HibernateCacheEffectTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.config;
+
+import static org.hisp.dhis.external.conf.ConfigurationKey.CACHE_EHCACHE_CONFIG_FILE;
+import static org.hisp.dhis.external.conf.ConfigurationKey.USE_QUERY_CACHE;
+import static org.hisp.dhis.external.conf.ConfigurationKey.USE_SECOND_LEVEL_CACHE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import org.ehcache.config.CacheRuntimeConfiguration;
+import org.ehcache.config.ResourceType;
+import org.ehcache.config.SizedResourcePool;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cache.internal.NoCachingRegionFactory;
+import org.hibernate.cache.jcache.internal.JCacheRegionFactory;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.stat.Statistics;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.hibernate.dialect.DhisH2Dialect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Effect tests for the second level cache and query cache configuration: instead of inspecting the
+ * JPA property map (see {@link HibernateConfigTest}), these tests build a real {@link
+ * SessionFactory} from {@link HibernateConfig#getAdditionalProperties(DhisConfigurationProvider)}
+ * and assert what Hibernate actually resolved:
+ *
+ * <ul>
+ *   <li>the resolved {@link RegionFactory} service ({@link NoCachingRegionFactory} when off, {@link
+ *       JCacheRegionFactory} when on),
+ *   <li>the actual cache region names created at boot,
+ *   <li>second level cache and query cache behavior via {@code hibernate.generate_statistics}
+ *       counters,
+ *   <li>that the {@code cache.ehcache.config.file} location resolves and the settings from
+ *       ehcache.xml (bounded heap sizes) are in effect on regions, so a silent fallback to
+ *       unbounded provider default caches becomes a test failure.
+ * </ul>
+ *
+ * @author Morten Svanæs
+ */
+class HibernateCacheEffectTest {
+
+  private static final String ENTITY_REGION = CachedTestEntity.class.getName();
+
+  private static final String QUERY_RESULTS_REGION = "default-query-results-region";
+
+  private static final String UPDATE_TIMESTAMPS_REGION = "default-update-timestamps-region";
+
+  /** Heap bound for the update timestamps region declared in ehcache.xml. */
+  private static final long EHCACHE_XML_TIMESTAMPS_HEAP_ENTRIES = 5_000;
+
+  /** Heap bound from the ehcache.xml default cache template (jsr107:defaults). */
+  private static final long EHCACHE_XML_TEMPLATE_HEAP_ENTRIES = 1_000_000;
+
+  private SessionFactory sessionFactory;
+
+  @AfterEach
+  void tearDown() {
+    if (sessionFactory != null) {
+      sessionFactory.close();
+      sessionFactory = null;
+    }
+  }
+
+  @Test
+  void secondLevelCacheOffResolvesNoCachingRegionFactory() {
+    sessionFactory = buildSessionFactory(dhisConfig("false", "true", ""));
+
+    assertInstanceOf(NoCachingRegionFactory.class, regionFactory());
+    Set<String> regions = regionNames();
+    // DisabledCaching in Hibernate 5.6 returns null instead of an empty set
+    assertTrue(
+        regions == null || regions.isEmpty(),
+        "no cache regions must exist when the cache is off: " + regions);
+  }
+
+  @Test
+  void secondLevelCacheOffNeverTouchesTheCache() {
+    sessionFactory = buildSessionFactory(dhisConfig("false", "true", ""));
+    persistEntity();
+
+    Statistics statistics = sessionFactory.getStatistics();
+    statistics.clear();
+    loadEntityInNewSession();
+    loadEntityInNewSession();
+
+    assertEquals(0, statistics.getSecondLevelCachePutCount());
+    assertEquals(0, statistics.getSecondLevelCacheHitCount());
+    assertEquals(0, statistics.getSecondLevelCacheMissCount());
+  }
+
+  @Test
+  void secondLevelCacheOnResolvesJCacheRegionFactoryAndCreatesRegions() {
+    sessionFactory = buildSessionFactory(dhisConfig("true", "false", ""));
+
+    assertInstanceOf(JCacheRegionFactory.class, regionFactory());
+    Set<String> regions = regionNames();
+    assertTrue(regions.contains(ENTITY_REGION), "entity region must exist: " + regions);
+    assertTrue(
+        regions.stream().noneMatch(QUERY_RESULTS_REGION::equals),
+        "query results region must not exist when the query cache is off: " + regions);
+  }
+
+  @Test
+  void secondLevelCacheOnServesSecondLoadFromCache() {
+    sessionFactory = buildSessionFactory(dhisConfig("true", "false", ""));
+    persistEntity();
+    sessionFactory.getCache().evictAllRegions();
+
+    Statistics statistics = sessionFactory.getStatistics();
+    statistics.clear();
+    loadEntityInNewSession();
+
+    assertEquals(1, statistics.getSecondLevelCacheMissCount(), "first load must miss");
+    assertEquals(1, statistics.getSecondLevelCachePutCount(), "first load must populate");
+
+    loadEntityInNewSession();
+
+    assertEquals(1, statistics.getSecondLevelCacheHitCount(), "second load must hit");
+    assertEquals(1, statistics.getSecondLevelCacheMissCount(), "second load must not miss");
+  }
+
+  @Test
+  void queryCacheOnServesRepeatedQueryFromCache() {
+    sessionFactory = buildSessionFactory(dhisConfig("true", "true", ""));
+    persistEntity();
+
+    assertTrue(
+        regionNames().contains(QUERY_RESULTS_REGION),
+        "query results region must exist when the query cache is on: " + regionNames());
+
+    Statistics statistics = sessionFactory.getStatistics();
+    statistics.clear();
+    queryEntitiesInNewSession();
+    queryEntitiesInNewSession();
+
+    assertEquals(1, statistics.getQueryCachePutCount(), "first query must populate");
+    assertEquals(1, statistics.getQueryCacheHitCount(), "second query must hit");
+    assertEquals(1, statistics.getQueryExecutionCount(), "second query must not hit the database");
+  }
+
+  @Test
+  void queryCacheOffIgnoresCacheableQueries() {
+    sessionFactory = buildSessionFactory(dhisConfig("true", "false", ""));
+    persistEntity();
+
+    Statistics statistics = sessionFactory.getStatistics();
+    statistics.clear();
+    queryEntitiesInNewSession();
+    queryEntitiesInNewSession();
+
+    assertEquals(0, statistics.getQueryCachePutCount());
+    assertEquals(0, statistics.getQueryCacheHitCount());
+    assertEquals(2, statistics.getQueryExecutionCount(), "both queries must hit the database");
+  }
+
+  @Test
+  void noEhcacheConfigFileFallsBackToUnboundedProviderDefaultCaches() {
+    sessionFactory = buildSessionFactory(dhisConfig("true", "true", ""));
+
+    CacheManager cacheManager = cacheManager();
+    assertEquals(Caching.getCachingProvider().getDefaultURI(), cacheManager.getURI());
+    assertEquals(
+        Long.MAX_VALUE,
+        heapEntries(cacheManager, ENTITY_REGION),
+        "provider default caches are unbounded");
+  }
+
+  /**
+   * Encodes the {@code cache.ehcache.config.file} default value bug: Hibernate's
+   * ClassLoaderServiceImpl only understands the nonstandard 'classpath://' scheme, so the
+   * documented 'classpath:' spelling (which is also the ConfigurationKey default) must be
+   * normalized before it is handed to Hibernate, otherwise the SessionFactory fails to boot. Both
+   * spellings must load ehcache.xml.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"classpath:ehcache.xml", "classpath://ehcache.xml"})
+  void ehcacheConfigFileLoadsForAllClasspathSpellings(String location) {
+    assertEhcacheXmlIsInEffect(location);
+  }
+
+  @Test
+  void ehcacheConfigFileDefaultValueLoads() {
+    assertEhcacheXmlIsInEffect(CACHE_EHCACHE_CONFIG_FILE.getDefaultValue());
+  }
+
+  @Test
+  void ehcacheConfigFileLoadsFromFileUrl(@TempDir Path tempDir) throws IOException {
+    Path file = tempDir.resolve("ehcache.xml");
+    try (InputStream in =
+        Objects.requireNonNull(
+            getClass().getClassLoader().getResourceAsStream("ehcache.xml"),
+            "ehcache.xml must be on the classpath")) {
+      Files.copy(in, file);
+    }
+
+    assertEhcacheXmlIsInEffect(file.toUri().toString());
+  }
+
+  private void assertEhcacheXmlIsInEffect(String location) {
+    sessionFactory = buildSessionFactory(dhisConfig("true", "true", location));
+
+    CacheManager cacheManager = cacheManager();
+    assertNotEquals(
+        Caching.getCachingProvider().getDefaultURI(),
+        cacheManager.getURI(),
+        "CacheManager must not run on the provider default configuration");
+    assertTrue(
+        cacheManager.getURI().toString().contains("ehcache.xml"),
+        "CacheManager must be configured from ehcache.xml: " + cacheManager.getURI());
+    assertEquals(
+        EHCACHE_XML_TIMESTAMPS_HEAP_ENTRIES,
+        heapEntries(cacheManager, UPDATE_TIMESTAMPS_REGION),
+        "update timestamps region must carry the heap bound declared in ehcache.xml");
+    assertEquals(
+        EHCACHE_XML_TEMPLATE_HEAP_ENTRIES,
+        heapEntries(cacheManager, ENTITY_REGION),
+        "entity region must carry the heap bound of the ehcache.xml default template");
+    assertEquals(
+        EHCACHE_XML_TEMPLATE_HEAP_ENTRIES,
+        heapEntries(cacheManager, QUERY_RESULTS_REGION),
+        "query results region must carry the heap bound declared in ehcache.xml");
+  }
+
+  // -------------------------------------------------------------------------
+  // Test plumbing
+  // -------------------------------------------------------------------------
+
+  private static DhisConfigurationProvider dhisConfig(
+      String secondLevelCache, String queryCache, String ehcacheConfigFile) {
+    DhisConfigurationProvider dhisConfig = mock(DhisConfigurationProvider.class);
+    when(dhisConfig.isEnabled(any())).thenCallRealMethod();
+    when(dhisConfig.getProperty(USE_SECOND_LEVEL_CACHE)).thenReturn(secondLevelCache);
+    when(dhisConfig.getProperty(USE_QUERY_CACHE)).thenReturn(queryCache);
+    when(dhisConfig.getProperty(CACHE_EHCACHE_CONFIG_FILE)).thenReturn(ehcacheConfigFile);
+    return dhisConfig;
+  }
+
+  private static SessionFactory buildSessionFactory(DhisConfigurationProvider dhisConfig) {
+    Properties properties = HibernateConfig.getAdditionalProperties(dhisConfig);
+
+    StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder();
+    properties.forEach((key, value) -> registryBuilder.applySetting((String) key, value));
+    registryBuilder.applySetting(AvailableSettings.DIALECT, DhisH2Dialect.class.getName());
+    registryBuilder.applySetting(AvailableSettings.DRIVER, "org.h2.Driver");
+    registryBuilder.applySetting(
+        AvailableSettings.URL,
+        "jdbc:h2:mem:cache-effect-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+    registryBuilder.applySetting(AvailableSettings.USER, "sa");
+    registryBuilder.applySetting(AvailableSettings.PASS, "");
+    // The DHIS2 schema is owned by Flyway, but this test schema only exists in memory
+    registryBuilder.applySetting(AvailableSettings.HBM2DDL_AUTO, "create-drop");
+    registryBuilder.applySetting(AvailableSettings.GENERATE_STATISTICS, "true");
+
+    return new MetadataSources(registryBuilder.build())
+        .addAnnotatedClass(CachedTestEntity.class)
+        .buildMetadata()
+        .buildSessionFactory();
+  }
+
+  private RegionFactory regionFactory() {
+    return ((SessionFactoryImplementor) sessionFactory)
+        .getServiceRegistry()
+        .getService(RegionFactory.class);
+  }
+
+  private Set<String> regionNames() {
+    return ((SessionFactoryImplementor) sessionFactory).getCache().getCacheRegionNames();
+  }
+
+  private CacheManager cacheManager() {
+    JCacheRegionFactory regionFactory =
+        assertInstanceOf(JCacheRegionFactory.class, regionFactory());
+    return regionFactory.getCacheManager();
+  }
+
+  private static long heapEntries(CacheManager cacheManager, String region) {
+    javax.cache.Cache<Object, Object> cache = cacheManager.getCache(region);
+    assertNotNull(cache, "cache region must exist: " + region);
+    Eh107Configuration<?, ?> configuration = cache.getConfiguration(Eh107Configuration.class);
+    CacheRuntimeConfiguration<?, ?> runtimeConfiguration =
+        configuration.unwrap(CacheRuntimeConfiguration.class);
+    SizedResourcePool heap =
+        runtimeConfiguration.getResourcePools().getPoolForResource(ResourceType.Core.HEAP);
+    assertNotNull(heap, "cache region must have a heap resource pool: " + region);
+    return heap.getSize();
+  }
+
+  private void persistEntity() {
+    try (Session session = sessionFactory.openSession()) {
+      Transaction transaction = session.beginTransaction();
+      session.persist(new CachedTestEntity(1L, "cached"));
+      transaction.commit();
+    }
+  }
+
+  private void loadEntityInNewSession() {
+    try (Session session = sessionFactory.openSession()) {
+      assertNotNull(session.get(CachedTestEntity.class, 1L));
+    }
+  }
+
+  private void queryEntitiesInNewSession() {
+    try (Session session = sessionFactory.openSession()) {
+      assertEquals(
+          1,
+          session
+              .createQuery("from CachedTestEntity", CachedTestEntity.class)
+              .setCacheable(true)
+              .getResultList()
+              .size());
+    }
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/HibernateCacheEffectTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/HibernateCacheEffectTest.java
@@ -45,10 +45,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
 import org.ehcache.config.CacheRuntimeConfiguration;
@@ -65,6 +68,8 @@ import org.hibernate.cache.jcache.internal.JCacheRegionFactory;
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.hibernate.stat.CacheRegionStatistics;
 import org.hibernate.stat.Statistics;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.hibernate.dialect.DhisH2Dialect;
@@ -86,6 +91,10 @@ import org.junit.jupiter.params.provider.ValueSource;
  *   <li>the actual cache region names created at boot,
  *   <li>second level cache and query cache behavior via {@code hibernate.generate_statistics}
  *       counters,
+ *   <li>the exact SQL statement count per representative flow (entity load by id, cached collection
+ *       access, cacheable query) via a {@link StatementInspector}, proving with numbers that
+ *       collection and query cache hits rehydrate element ids one SELECT at a time (N+1 on hit)
+ *       while the element region is cold,
  *   <li>that the {@code cache.ehcache.config.file} location resolves and the settings from
  *       ehcache.xml (bounded heap sizes) are in effect on regions, so a silent fallback to
  *       unbounded provider default caches becomes a test failure.
@@ -96,6 +105,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 class HibernateCacheEffectTest {
 
   private static final String ENTITY_REGION = CachedTestEntity.class.getName();
+
+  private static final String COLLECTION_REGION =
+      CachedParentTestEntity.class.getName() + ".children";
+
+  /** Number of collection elements / query result rows used by the statement count tests. */
+  private static final int CHILD_COUNT = 5;
 
   private static final String QUERY_RESULTS_REGION = "default-query-results-region";
 
@@ -108,6 +123,8 @@ class HibernateCacheEffectTest {
   private static final long EHCACHE_XML_TEMPLATE_HEAP_ENTRIES = 1_000_000;
 
   private SessionFactory sessionFactory;
+
+  private final RecordingStatementInspector statementInspector = new RecordingStatementInspector();
 
   @AfterEach
   void tearDown() {
@@ -209,6 +226,144 @@ class HibernateCacheEffectTest {
     assertEquals(2, statistics.getQueryExecutionCount(), "both queries must hit the database");
   }
 
+  // -------------------------------------------------------------------------
+  // Deterministic per-flow statement counts (Phase 2)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void secondLevelCacheOnSecondEntityLoadIssuesNoSql() {
+    sessionFactory = buildSessionFactory(dhisConfig("true", "false", ""));
+    persistEntity();
+    sessionFactory.getCache().evictAllRegions();
+
+    statementInspector.clear();
+    loadEntityInNewSession();
+    assertEquals(1, statementInspector.selectCount(), "first load must query the database once");
+
+    statementInspector.clear();
+    loadEntityInNewSession();
+    assertEquals(0, statementInspector.selectCount(), "second load must be served from the cache");
+  }
+
+  @Test
+  void secondLevelCacheOffEveryEntityLoadQueriesTheDatabase() {
+    sessionFactory = buildSessionFactory(dhisConfig("false", "true", ""));
+    persistEntity();
+
+    statementInspector.clear();
+    loadEntityInNewSession();
+    loadEntityInNewSession();
+    assertEquals(2, statementInspector.selectCount(), "every load must query the database");
+  }
+
+  /**
+   * Encodes F5, the worst case of the collection cache: collection regions store element ids only,
+   * so a collection region HIT with a cold element region rehydrates every element with its own
+   * SELECT by id, N statements for N elements. The uncached baseline for the same access is a
+   * single SELECT for all elements (see {@link
+   * #collectionAccessWithCacheOffLoadsAllElementsInOneSelect()}), so a collection cache "hit" can
+   * cost N times the SQL of no cache at all.
+   */
+  @Test
+  void collectionCacheHitWithColdElementRegionRehydratesEachElementById() {
+    sessionFactory = buildSessionFactory(dhisConfig("true", "false", ""));
+    persistParentWithChildren(CHILD_COUNT);
+    sessionFactory.getCache().evictAllRegions();
+    // warm the parent, collection and element regions
+    readParentAndChildrenInNewSession();
+    // cold element region, warm collection region: the production steady state after any
+    // element region eviction (bounded heap, TTL) while the collection entry survives
+    sessionFactory.getCache().evictEntityData(CachedTestEntity.class);
+
+    Statistics statistics = sessionFactory.getStatistics();
+    statistics.clear();
+    statementInspector.clear();
+    readParentAndChildrenInNewSession();
+
+    CacheRegionStatistics collectionStatistics =
+        statistics.getDomainDataRegionStatistics(COLLECTION_REGION);
+    assertNotNull(collectionStatistics);
+    assertEquals(1, collectionStatistics.getHitCount(), "collection region must hit");
+    assertEquals(
+        CHILD_COUNT,
+        statementInspector.selectCount(),
+        "a collection cache hit must issue one SELECT per element when the element region is"
+            + " cold");
+  }
+
+  @Test
+  void collectionAccessWithCacheOffLoadsAllElementsInOneSelect() {
+    sessionFactory = buildSessionFactory(dhisConfig("false", "true", ""));
+    persistParentWithChildren(CHILD_COUNT);
+
+    statementInspector.clear();
+    readParentAndChildrenInNewSession();
+
+    assertEquals(
+        2,
+        statementInspector.selectCount(),
+        "without the cache the same access is one SELECT for the parent and one SELECT for all"
+            + " elements");
+  }
+
+  @Test
+  void collectionCacheHitWithWarmElementRegionIssuesNoSql() {
+    sessionFactory = buildSessionFactory(dhisConfig("true", "false", ""));
+    persistParentWithChildren(CHILD_COUNT);
+    sessionFactory.getCache().evictAllRegions();
+    // warm the parent, collection and element regions
+    readParentAndChildrenInNewSession();
+
+    statementInspector.clear();
+    readParentAndChildrenInNewSession();
+
+    assertEquals(
+        0, statementInspector.selectCount(), "fully warm regions must serve without any SQL");
+  }
+
+  /**
+   * Encodes the query cache flavor of the same mechanism (see PR #22711): cached query results
+   * store entity ids only, so a query cache HIT with a cold entity region issues one SELECT per
+   * result row, N statements where the original query was one.
+   */
+  @Test
+  void queryCacheHitWithColdEntityRegionRehydratesEachRowById() {
+    sessionFactory = buildSessionFactory(dhisConfig("true", "true", ""));
+    persistEntities(CHILD_COUNT);
+
+    Statistics statistics = sessionFactory.getStatistics();
+    statistics.clear();
+    statementInspector.clear();
+    queryEntitiesInNewSession(CHILD_COUNT);
+    assertEquals(1, statementInspector.selectCount(), "first query must be a single SELECT");
+
+    sessionFactory.getCache().evictEntityData(CachedTestEntity.class);
+    statementInspector.clear();
+    queryEntitiesInNewSession(CHILD_COUNT);
+
+    assertEquals(1, statistics.getQueryCacheHitCount(), "second query must hit the query cache");
+    assertEquals(1, statistics.getQueryExecutionCount(), "the query itself must not run again");
+    assertEquals(
+        CHILD_COUNT,
+        statementInspector.selectCount(),
+        "a query cache hit must issue one SELECT per result row when the entity region is cold");
+  }
+
+  @Test
+  void queryCacheHitWithWarmEntityRegionIssuesNoSql() {
+    sessionFactory = buildSessionFactory(dhisConfig("true", "true", ""));
+    persistEntities(CHILD_COUNT);
+
+    queryEntitiesInNewSession(CHILD_COUNT);
+    statementInspector.clear();
+    queryEntitiesInNewSession(CHILD_COUNT);
+
+    assertEquals(
+        0,
+        statementInspector.selectCount(),
+        "a query cache hit with a warm entity region must not issue any SQL");
+  }
+
   @Test
   void noEhcacheConfigFileFallsBackToUnboundedProviderDefaultCaches() {
     sessionFactory = buildSessionFactory(dhisConfig("true", "true", ""));
@@ -291,7 +446,7 @@ class HibernateCacheEffectTest {
     return dhisConfig;
   }
 
-  private static SessionFactory buildSessionFactory(DhisConfigurationProvider dhisConfig) {
+  private SessionFactory buildSessionFactory(DhisConfigurationProvider dhisConfig) {
     Properties properties = HibernateConfig.getAdditionalProperties(dhisConfig);
 
     StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder();
@@ -306,9 +461,11 @@ class HibernateCacheEffectTest {
     // The DHIS2 schema is owned by Flyway, but this test schema only exists in memory
     registryBuilder.applySetting(AvailableSettings.HBM2DDL_AUTO, "create-drop");
     registryBuilder.applySetting(AvailableSettings.GENERATE_STATISTICS, "true");
+    registryBuilder.applySetting(AvailableSettings.STATEMENT_INSPECTOR, statementInspector);
 
     return new MetadataSources(registryBuilder.build())
         .addAnnotatedClass(CachedTestEntity.class)
+        .addAnnotatedClass(CachedParentTestEntity.class)
         .buildMetadata()
         .buildSessionFactory();
   }
@@ -349,6 +506,41 @@ class HibernateCacheEffectTest {
     }
   }
 
+  private void persistEntities(int count) {
+    try (Session session = sessionFactory.openSession()) {
+      Transaction transaction = session.beginTransaction();
+      for (long id = 1; id <= count; id++) {
+        session.persist(new CachedTestEntity(id, "cached" + id));
+      }
+      transaction.commit();
+    }
+  }
+
+  private void persistParentWithChildren(int count) {
+    try (Session session = sessionFactory.openSession()) {
+      Transaction transaction = session.beginTransaction();
+      CachedParentTestEntity parent = new CachedParentTestEntity(1L, "parent");
+      for (long id = 1; id <= count; id++) {
+        parent.getChildren().add(new CachedTestEntity(id, "child" + id));
+      }
+      session.persist(parent);
+      transaction.commit();
+    }
+  }
+
+  private void readParentAndChildrenInNewSession() {
+    try (Session session = sessionFactory.openSession()) {
+      CachedParentTestEntity parent = session.get(CachedParentTestEntity.class, 1L);
+      assertNotNull(parent);
+      int read = 0;
+      for (CachedTestEntity child : parent.getChildren()) {
+        assertNotNull(child.getName());
+        read++;
+      }
+      assertEquals(CHILD_COUNT, read, "all collection elements must be readable");
+    }
+  }
+
   private void loadEntityInNewSession() {
     try (Session session = sessionFactory.openSession()) {
       assertNotNull(session.get(CachedTestEntity.class, 1L));
@@ -356,14 +548,40 @@ class HibernateCacheEffectTest {
   }
 
   private void queryEntitiesInNewSession() {
+    queryEntitiesInNewSession(1);
+  }
+
+  private void queryEntitiesInNewSession(int expectedCount) {
     try (Session session = sessionFactory.openSession()) {
       assertEquals(
-          1,
+          expectedCount,
           session
               .createQuery("from CachedTestEntity", CachedTestEntity.class)
               .setCacheable(true)
               .getResultList()
               .size());
+    }
+  }
+
+  /** Records every SQL statement Hibernate issues so tests can assert exact statement counts. */
+  private static final class RecordingStatementInspector implements StatementInspector {
+
+    private final List<String> statements = new CopyOnWriteArrayList<>();
+
+    @Override
+    public String inspect(String sql) {
+      statements.add(sql);
+      return sql;
+    }
+
+    long selectCount() {
+      return statements.stream()
+          .filter(sql -> sql.toLowerCase(Locale.ROOT).startsWith("select"))
+          .count();
+    }
+
+    void clear() {
+      statements.clear();
     }
   }
 }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/HibernateConfigTest.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/test/java/org/hisp/dhis/config/HibernateConfigTest.java
@@ -126,6 +126,29 @@ class HibernateConfigTest {
     assertEquals("file:/opt/dhis2/ehcache.xml", properties.get(ConfigSettings.CONFIG_URI));
   }
 
+  /**
+   * Hibernate's ClassLoaderService only strips the nonstandard 'classpath://' scheme, so both
+   * classpath spellings must be normalized to a bare resource name before they are handed over,
+   * otherwise the SessionFactory fails to boot with "Couldn't load URI".
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "classpath:ehcache.xml",
+        "classpath://ehcache.xml",
+        "CLASSPATH:ehcache.xml",
+        " classpath:ehcache.xml "
+      })
+  void ehcacheConfigFileClasspathSpellingsAreNormalized(String configValue) {
+    when(dhisConfig.getProperty(USE_SECOND_LEVEL_CACHE)).thenReturn("true");
+    when(dhisConfig.getProperty(USE_QUERY_CACHE)).thenReturn("true");
+    when(dhisConfig.getProperty(CACHE_EHCACHE_CONFIG_FILE)).thenReturn(configValue);
+
+    Properties properties = HibernateConfig.getAdditionalProperties(dhisConfig);
+
+    assertEquals("ehcache.xml", properties.get(ConfigSettings.CONFIG_URI));
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"false", "FALSE", "off", "OFF", ""})
   void secondLevelCacheDisabledDisablesBothCachesExplicitly(String configValue) {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestDhis.conf
@@ -9,9 +9,9 @@ encryption.password=54C73D06-1D34-477F-94B0-8F94E59BE41D
 hibernate.cache.use_query_cache=false
 hibernate.cache.use_second_level_cache=true
 # Blank on purpose: use default JCache caches instead of ehcache.xml, again matching the
-# effective behavior CI has always run with. Hibernate's ClassLoaderServiceImpl cannot
-# resolve the 'classpath:ehcache.xml' default value in a plain JVM (it only strips the
-# 'classpath://' scheme), which fails the SessionFactory build in surefire.
+# effective behavior CI has always run with. The 'classpath:ehcache.xml' default value is
+# exercised separately by HibernateEhcacheConfigFileTest; flipping this default for all
+# integration tests (bounded ehcache.xml regions) is a deliberate decision for later.
 cache.ehcache.config.file=
 
 enable.api_token.authentication = on

--- a/dhis-2/dhis-test-e2e/config/dhis2_home/dhis.conf
+++ b/dhis-2/dhis-test-e2e/config/dhis2_home/dhis.conf
@@ -54,6 +54,8 @@ route.remote_servers_allowed = http://web:8080
 monitoring.api.enabled = on
 monitoring.jvm.enabled = on
 monitoring.dbpool.enabled = on
+# Per-region Hibernate L2 cache metrics (EhCacheMetricsTest)
+monitoring.ehcache.enabled = on
 
 # Context in DB queries
 monitoring.sql.context = on

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/monitoring/EhCacheMetricsTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/monitoring/EhCacheMetricsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.monitoring;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.hisp.dhis.ApiTest;
+import org.hisp.dhis.test.e2e.actions.LoginActions;
+import org.hisp.dhis.test.e2e.actions.RestApiActions;
+import org.hisp.dhis.test.e2e.dto.ApiResponse;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that per-region Hibernate second level cache metrics are exposed on the Prometheus
+ * scrape endpoint when {@code monitoring.ehcache.enabled} is on. This proves end to end that the
+ * server booted with the second level cache active, that the ehcache regions exist, and that their
+ * statistics are wired into Micrometer (see EhCacheMetricsConfig): if the cache silently stops
+ * being configured, or region statistics stop being resolvable, these metrics disappear and this
+ * test fails.
+ *
+ * @author Morten Svanæs
+ */
+public class EhCacheMetricsTest extends ApiTest {
+  private RestApiActions metricsActions;
+
+  private LoginActions loginActions;
+
+  @BeforeAll
+  public void setUp() {
+    loginActions = new LoginActions();
+    metricsActions = new RestApiActions("/metrics");
+  }
+
+  @Test
+  public void shouldExposePerRegionSecondLevelCacheMetrics() {
+    loginActions.loginAsSuperUser();
+
+    // Touch an endpoint that reads cached entities so region counters exist and move
+    new RestApiActions("/me").get().validate().statusCode(200);
+
+    ApiResponse response = metricsActions.get("", "text/plain", "text/plain", null);
+
+    response
+        .validate()
+        .statusCode(200)
+        .body(containsString("# TYPE ehcache_gets_total counter"))
+        .body(containsString("# TYPE ehcache_hits_total counter"))
+        .body(containsString("# TYPE ehcache_misses_total counter"))
+        .body(containsString("# TYPE ehcache_puts_total counter"))
+        // Per-region counters carry the region short name and the L2 marker tag; the User
+        // entity region always exists because authentication loads the current user
+        .body(containsString("ehcache_gets_total{cache=\"User\",type=\"L2\"}"));
+  }
+}

--- a/dhis-2/dhis-test-integration/pom.xml
+++ b/dhis-2/dhis-test-integration/pom.xml
@@ -303,6 +303,23 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-jcache</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+      <classifier>jakarta</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.persistence</groupId>
       <artifactId>jakarta.persistence-api</artifactId>
       <scope>test</scope>
@@ -414,6 +431,10 @@
             <ignoredNonTestScopedDependency>software.amazon.awssdk:aws-core</ignoredNonTestScopedDependency>
             <ignoredNonTestScopedDependency>software.amazon.awssdk:auth</ignoredNonTestScopedDependency>
             <ignoredNonTestScopedDependency>software.amazon.awssdk:regions</ignoredNonTestScopedDependency>
+            <!-- javax.cache API arrives transitively at compile scope (via dhis-support-hibernate);
+                 used directly only in the second level cache effect tests. It is never declared
+                 anywhere in the build (no managed version), matching dhis-support-hibernate. -->
+            <ignoredNonTestScopedDependency>javax.cache:cache-api</ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
           <ignoredUsedUndeclaredDependencies>
             <ignoredUsedUndeclaredDependency>software.amazon.awssdk:s3</ignoredUsedUndeclaredDependency>
@@ -421,6 +442,7 @@
             <ignoredUsedUndeclaredDependency>software.amazon.awssdk:aws-core</ignoredUsedUndeclaredDependency>
             <ignoredUsedUndeclaredDependency>software.amazon.awssdk:auth</ignoredUsedUndeclaredDependency>
             <ignoredUsedUndeclaredDependency>software.amazon.awssdk:regions</ignoredUsedUndeclaredDependency>
+            <ignoredUsedUndeclaredDependency>javax.cache:cache-api:jar</ignoredUsedUndeclaredDependency>
           </ignoredUsedUndeclaredDependencies>
           <!-- If code from the following modules is accessed in tests they'll have to move up to ignoredNonTestScopedDependency -->
           <ignoredUnusedDeclaredDependencies>

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateCacheRegionsTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateCacheRegionsTest.java
@@ -38,10 +38,14 @@ import jakarta.persistence.EntityManagerFactory;
 import java.util.Set;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
+import org.hibernate.Session;
 import org.hibernate.cache.jcache.internal.JCacheRegionFactory;
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.stat.CacheRegionStatistics;
+import org.hibernate.stat.Statistics;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
@@ -52,13 +56,20 @@ import org.springframework.beans.factory.annotation.Autowired;
  * actually run with ({@code postgresTestDhis.conf}: cache on, query cache off, no ehcache.xml): the
  * region factory Hibernate resolved, the cache regions that exist at boot, and the fact that the
  * JCache {@link CacheManager} runs on the ehcache provider default configuration, not on
- * ehcache.xml.
+ * ehcache.xml. Also proves the per-flow region behavior on real production mappings: a second
+ * entity load by id is a region hit, and a collection region hit rehydrates every element
+ * individually through the entity region (F5, N+1 on hit).
  *
  * @author Morten Svanæs
  */
 class HibernateCacheRegionsTest extends PostgresIntegrationTestBase {
 
   @Autowired private EntityManagerFactory entityManagerFactory;
+
+  /** Number of children of the parent organisation unit in the collection flow test. */
+  private static final int CHILD_COUNT = 3;
+
+  @Autowired private OrganisationUnitService organisationUnitService;
 
   @Test
   void secondLevelCacheIsOnWithJCacheRegionFactory() {
@@ -96,6 +107,63 @@ class HibernateCacheRegionsTest extends PostgresIntegrationTestBase {
             + " provider default configuration");
   }
 
+  @Test
+  void secondEntityLoadByIdIsARegionHit() {
+    OrganisationUnit unit = createOrganisationUnit('A');
+    organisationUnitService.addOrganisationUnit(unit);
+
+    Statistics statistics = enableStatistics();
+    sessionFactory().getCache().evictEntityData(OrganisationUnit.class);
+    statistics.clear();
+
+    loadOrganisationUnitInNewSession(unit.getId());
+    CacheRegionStatistics regionStatistics = entityRegionStatistics(statistics);
+    assertEquals(1, regionStatistics.getMissCount(), "first load must miss the region");
+    assertEquals(1, regionStatistics.getPutCount(), "first load must populate the region");
+    assertEquals(0, regionStatistics.getHitCount(), "first load cannot hit the region");
+
+    loadOrganisationUnitInNewSession(unit.getId());
+    regionStatistics = entityRegionStatistics(statistics);
+    assertEquals(1, regionStatistics.getHitCount(), "second load must hit the region");
+    assertEquals(1, regionStatistics.getMissCount(), "second load must not miss the region");
+  }
+
+  /**
+   * Encodes F5 on a real production mapping ({@code OrganisationUnit.children}): collection regions
+   * store element ids only, so a collection region HIT with a cold element region rehydrates every
+   * element individually through the entity region and, on miss, the database. The exact SQL cost
+   * of this flow (one SELECT per element) is pinned by HibernateCacheEffectTest in
+   * dhis-support-hibernate.
+   */
+  @Test
+  void collectionCacheHitRehydratesEachElementThroughTheEntityRegion() {
+    OrganisationUnit parent = createOrganisationUnit('B');
+    organisationUnitService.addOrganisationUnit(parent);
+    for (int i = 0; i < CHILD_COUNT; i++) {
+      organisationUnitService.addOrganisationUnit(createOrganisationUnit((char) ('C' + i), parent));
+    }
+
+    Statistics statistics = enableStatistics();
+    sessionFactory().getCache().evictAllRegions();
+    // warm the parent and element entity regions and the children collection region
+    readChildrenInNewSession(parent.getId());
+    // cold entity region, warm collection region: the steady state after any entity region
+    // eviction (bounded heap, TTL, write) while the collection entry survives
+    sessionFactory().getCache().evictEntityData(OrganisationUnit.class);
+    statistics.clear();
+
+    readChildrenInNewSession(parent.getId());
+
+    CacheRegionStatistics collectionStatistics =
+        statistics.getDomainDataRegionStatistics(OrganisationUnit.class.getName() + ".children");
+    assertNotNull(collectionStatistics);
+    assertEquals(1, collectionStatistics.getHitCount(), "children collection region must hit");
+    assertEquals(
+        1 + CHILD_COUNT,
+        entityRegionStatistics(statistics).getMissCount(),
+        "the parent and every collection element must be rehydrated individually");
+  }
+
   private SessionFactoryImplementor sessionFactory() {
     // Unwrap to the implementor directly: the Spring-managed EntityManagerFactory is a
     // proxy, and unwrapping to plain SessionFactory returns a proxy that cannot be cast
@@ -104,5 +172,37 @@ class HibernateCacheRegionsTest extends PostgresIntegrationTestBase {
 
   private RegionFactory regionFactory() {
     return sessionFactory().getServiceRegistry().getService(RegionFactory.class);
+  }
+
+  private Statistics enableStatistics() {
+    Statistics statistics = sessionFactory().getStatistics();
+    statistics.setStatisticsEnabled(true);
+    return statistics;
+  }
+
+  private CacheRegionStatistics entityRegionStatistics(Statistics statistics) {
+    CacheRegionStatistics regionStatistics =
+        statistics.getDomainDataRegionStatistics(OrganisationUnit.class.getName());
+    assertNotNull(regionStatistics);
+    return regionStatistics;
+  }
+
+  private void loadOrganisationUnitInNewSession(long id) {
+    try (Session session = sessionFactory().openSession()) {
+      assertNotNull(session.get(OrganisationUnit.class, id));
+    }
+  }
+
+  private void readChildrenInNewSession(long parentId) {
+    try (Session session = sessionFactory().openSession()) {
+      OrganisationUnit parent = session.get(OrganisationUnit.class, parentId);
+      assertNotNull(parent);
+      int read = 0;
+      for (OrganisationUnit child : parent.getChildren()) {
+        assertNotNull(child.getName());
+        read++;
+      }
+      assertEquals(CHILD_COUNT, read, "all children must be readable");
+    }
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateCacheRegionsTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateCacheRegionsTest.java
@@ -58,7 +58,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * JCache {@link CacheManager} runs on the ehcache provider default configuration, not on
  * ehcache.xml. Also proves the per-flow region behavior on real production mappings: a second
  * entity load by id is a region hit, and a collection region hit rehydrates every element
- * individually through the entity region (F5, N+1 on hit).
+ * individually through the entity region (N+1 on hit).
  *
  * @author Morten Svanæs
  */

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateCacheRegionsTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateCacheRegionsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.persistence.EntityManagerFactory;
+import java.util.Set;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import org.hibernate.cache.jcache.internal.JCacheRegionFactory;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Effect tests for the second level cache configuration that Postgres integration tests (and CI)
+ * actually run with ({@code postgresTestDhis.conf}: cache on, query cache off, no ehcache.xml): the
+ * region factory Hibernate resolved, the cache regions that exist at boot, and the fact that the
+ * JCache {@link CacheManager} runs on the ehcache provider default configuration, not on
+ * ehcache.xml.
+ *
+ * @author Morten Svanæs
+ */
+class HibernateCacheRegionsTest extends PostgresIntegrationTestBase {
+
+  @Autowired private EntityManagerFactory entityManagerFactory;
+
+  @Test
+  void secondLevelCacheIsOnWithJCacheRegionFactory() {
+    assertInstanceOf(JCacheRegionFactory.class, regionFactory());
+  }
+
+  @Test
+  void allCachedEntityAndCollectionRegionsExistAtBoot() {
+    Set<String> regions = sessionFactory().getCache().getCacheRegionNames();
+
+    assertNotNull(regions);
+    assertTrue(regions.contains(User.class.getName()), "User entity region must exist: " + regions);
+    assertTrue(
+        regions.contains(OrganisationUnit.class.getName()),
+        "OrganisationUnit entity region must exist: " + regions);
+    // The cached-region inventory is ~235 declarations: 33 annotated entities plus ~202
+    // cached collections in hbm.xml mappings. Guard the order of magnitude so a mapping
+    // change that silently drops caching for whole groups of regions is caught.
+    assertTrue(
+        regions.size() >= 200,
+        "expected the full cached-region inventory (~235), but found: " + regions.size());
+  }
+
+  @Test
+  void cacheManagerRunsOnProviderDefaultsWithoutEhcacheConfigFile() {
+    JCacheRegionFactory regionFactory =
+        assertInstanceOf(JCacheRegionFactory.class, regionFactory());
+    CacheManager cacheManager = regionFactory.getCacheManager();
+
+    assertNotNull(cacheManager);
+    assertEquals(
+        Caching.getCachingProvider().getDefaultURI(),
+        cacheManager.getURI(),
+        "with a blank cache.ehcache.config.file the CacheManager must run on the ehcache"
+            + " provider default configuration");
+  }
+
+  private SessionFactoryImplementor sessionFactory() {
+    // Unwrap to the implementor directly: the Spring-managed EntityManagerFactory is a
+    // proxy, and unwrapping to plain SessionFactory returns a proxy that cannot be cast
+    return entityManagerFactory.unwrap(SessionFactoryImplementor.class);
+  }
+
+  private RegionFactory regionFactory() {
+    return sessionFactory().getServiceRegistry().getService(RegionFactory.class);
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateEhcacheConfigFileTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateEhcacheConfigFileTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.persistence.EntityManagerFactory;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import org.ehcache.config.CacheRuntimeConfiguration;
+import org.ehcache.config.ResourceType;
+import org.ehcache.config.SizedResourcePool;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.hibernate.SessionFactory;
+import org.hibernate.cache.jcache.internal.JCacheRegionFactory;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hisp.dhis.cache.HibernateEhcacheConfigFileTest.DhisConfig;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.test.config.PostgresTestConfigOverride;
+import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Proves that the {@code cache.ehcache.config.file} default value ({@code classpath:ehcache.xml})
+ * loads against the full production {@link SessionFactory}: the JCache {@link CacheManager} is
+ * configured from ehcache.xml and the regions carry its settings (bounded heaps) instead of the
+ * unbounded ehcache provider defaults. Until the classpath: spelling was normalized in
+ * HibernateConfig, this exact configuration failed the SessionFactory boot with "Couldn't load URI
+ * from classpath:ehcache.xml".
+ *
+ * @author Morten Svanæs
+ */
+@ContextConfiguration(classes = {DhisConfig.class})
+class HibernateEhcacheConfigFileTest extends PostgresIntegrationTestBase {
+
+  static class DhisConfig {
+    @Bean
+    public PostgresTestConfigOverride postgresTestConfigOverride() {
+      PostgresTestConfigOverride override = new PostgresTestConfigOverride();
+      override.put(
+          ConfigurationKey.CACHE_EHCACHE_CONFIG_FILE.getKey(),
+          ConfigurationKey.CACHE_EHCACHE_CONFIG_FILE.getDefaultValue());
+      return override;
+    }
+  }
+
+  /** Heap bound for the update timestamps region declared in ehcache.xml. */
+  private static final long EHCACHE_XML_TIMESTAMPS_HEAP_ENTRIES = 5_000;
+
+  /** Heap bound from the ehcache.xml default cache template (jsr107:defaults). */
+  private static final long EHCACHE_XML_TEMPLATE_HEAP_ENTRIES = 1_000_000;
+
+  @Autowired private EntityManagerFactory entityManagerFactory;
+
+  @Test
+  void cacheManagerIsConfiguredFromEhcacheXml() {
+    CacheManager cacheManager = cacheManager();
+
+    assertNotEquals(
+        Caching.getCachingProvider().getDefaultURI(),
+        cacheManager.getURI(),
+        "CacheManager must not run on the provider default configuration");
+    assertTrue(
+        cacheManager.getURI().toString().contains("ehcache.xml"),
+        "CacheManager must be configured from ehcache.xml: " + cacheManager.getURI());
+  }
+
+  @Test
+  void regionsCarryTheEhcacheXmlHeapBounds() {
+    CacheManager cacheManager = cacheManager();
+
+    assertEquals(
+        EHCACHE_XML_TEMPLATE_HEAP_ENTRIES,
+        heapEntries(cacheManager, User.class.getName()),
+        "entity regions must carry the heap bound of the ehcache.xml default template");
+    assertEquals(
+        EHCACHE_XML_TIMESTAMPS_HEAP_ENTRIES,
+        heapEntries(cacheManager, "default-update-timestamps-region"),
+        "update timestamps region must carry the heap bound declared in ehcache.xml");
+  }
+
+  private CacheManager cacheManager() {
+    // Unwrap to the implementor directly: the Spring-managed EntityManagerFactory is a
+    // proxy, and unwrapping to plain SessionFactory returns a proxy that cannot be cast
+    RegionFactory regionFactory =
+        entityManagerFactory
+            .unwrap(SessionFactoryImplementor.class)
+            .getServiceRegistry()
+            .getService(RegionFactory.class);
+    JCacheRegionFactory jCacheRegionFactory =
+        assertInstanceOf(JCacheRegionFactory.class, regionFactory);
+    CacheManager cacheManager = jCacheRegionFactory.getCacheManager();
+    assertNotNull(cacheManager);
+    return cacheManager;
+  }
+
+  private static long heapEntries(CacheManager cacheManager, String region) {
+    javax.cache.Cache<Object, Object> cache = cacheManager.getCache(region);
+    assertNotNull(cache, "cache region must exist: " + region);
+    Eh107Configuration<?, ?> configuration = cache.getConfiguration(Eh107Configuration.class);
+    CacheRuntimeConfiguration<?, ?> runtimeConfiguration =
+        configuration.unwrap(CacheRuntimeConfiguration.class);
+    SizedResourcePool heap =
+        runtimeConfiguration.getResourcePools().getPoolForResource(ResourceType.Core.HEAP);
+    assertNotNull(heap, "cache region must have a heap resource pool: " + region);
+    return heap.getSize();
+  }
+}


### PR DESCRIPTION
## Summary

Test-only. Deterministic statement-count tests that pin the exact SQL cost of every representative second level cache flow, so cache regressions (and future cache interventions) are caught with numbers instead of assumptions:

- Collection cache HIT with a cold element region issues **one SELECT per element** (N+1 on hit): 5 SELECTs for 5 elements where the uncached access is 2 (parent + one join select).
- Query cache HIT with a cold entity region issues **one SELECT per result row** where the original query was 1 (the PR #22711 mechanism).
- Warm regions serve with 0 SQL; entity second load by id is 0 SQL; cache-off baselines included.

## Changes

- `HibernateCacheEffectTest` (surefire, H2): 7 new tests using a `StatementInspector` for exact statement counts; new fixture `CachedParentTestEntity` with a READ_WRITE cached lazy collection, mapped like the production hbm.xml collections.
- `HibernateCacheRegionsTest` (Testcontainers Postgres): 2 new tests proving the same flows on real production mappings (`OrganisationUnit` + `OrganisationUnit.children`) via per-region hit/miss/put statistics.

Note: production sets no `hibernate.default_batch_fetch_size`, so the per-element rehydration counts are the true production behavior.

**Stacked on #24742** — only the top commit (`97c4e21e5d`) is new here.

AI Assisted