### PR TITLE
fix: drop unused enrollment exists CTE causing duplicate SQL alias [DHIS2-21648]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/CteContext.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/CteContext.java
@@ -160,21 +160,6 @@ public class CteContext {
   }
 
   /**
-   * Adds a special "exists" CTE definition to the context. This CTE definition is required when a
-   * non-aggregated query has the flag "rowContext" set to true
-   *
-   * @param programStage the ProgramStage object
-   * @param item the QueryItem object
-   * @param cteDefinition the CTE definition (the SQL query)
-   */
-  public void addExistsCte(ProgramStage programStage, QueryItem item, String cteDefinition) {
-    var cteDef =
-        new CteDefinition(programStage.getUid(), item.getItemId(), cteDefinition, -999, false)
-            .setExists(true);
-    cteDefinitions.put(programStage.getUid(), cteDef);
-  }
-
-  /**
    * Adds a CTE definition to the context.
    *
    * @param programIndicator The program indicator

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -2891,8 +2891,6 @@ public abstract class AbstractJdbcEventAnalyticsManager {
 
       if (cteDef.isProgramStage()) {
         addProgramStageJoins(builder, itemUid, cteDef);
-      } else if (cteDef.isExists()) {
-        addExistsJoin(builder, cteDef);
       } else if (cteDef.isProgramIndicator()) {
         addProgramIndicatorJoin(builder, itemUid, cteDef, cteContext);
       } else if (cteDef.isFilter()) {
@@ -2915,11 +2913,6 @@ public abstract class AbstractJdbcEventAnalyticsManager {
         builder.leftJoin(itemUid, alias, tableAlias -> joinCondition);
       }
     }
-  }
-
-  private void addExistsJoin(SelectBuilder builder, CteDefinition cteDef) {
-    builder.leftJoin(
-        cteDef.getAlias(), "ee", tableAlias -> tableAlias + ".enrollment = ax.enrollment");
   }
 
   private void addProgramIndicatorJoin(
@@ -3013,11 +3006,6 @@ public abstract class AbstractJdbcEventAnalyticsManager {
         hasRowContext,
         filterBuilder.hasNonNvFilter(item),
         shouldProjectValueName(item));
-
-    // If row context is needed, we add an extra "exists" CTE for event checks.
-    if (hasRowContext) {
-      addExistsCte(cteContext, item, eventTableName);
-    }
   }
 
   /**
@@ -3578,30 +3566,6 @@ public abstract class AbstractJdbcEventAnalyticsManager {
     values.put("outerAdditionalCols", outerAdditionalCols);
 
     return new StringSubstitutor(values).replace(template);
-  }
-
-  /**
-   * Adds an "exists" CTE for event checks.
-   *
-   * @param cteContext the {@link CteContext} to which the new CTE definition(s) will be added
-   * @param item the {@link QueryItem} containing program-stage details
-   * @param eventTableName the event table name
-   */
-  private void addExistsCte(CteContext cteContext, QueryItem item, String eventTableName) {
-    String template =
-        """
-        select distinct enrollment
-        from ${eventTableName}
-        where eventstatus != 'SCHEDULE' and ps = '${programStageUid}'
-        """;
-
-    Map<String, String> values = new HashMap<>();
-    values.put("eventTableName", eventTableName);
-    values.put("programStageUid", item.getProgramStage().getUid());
-
-    String existCte = new StringSubstitutor(values).replace(template);
-
-    cteContext.addExistsCte(item.getProgramStage(), item, existCte);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -59,11 +59,15 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
 import org.hisp.dhis.analytics.TimeField;
@@ -1032,21 +1036,44 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
                 """
                     .formatted(stageUid, deUid, deUid, programAUid, stageUid))));
 
-    // Existence CTE
+    // Row context is served by the value CTE, so no separate enrollment existence CTE is emitted
     assertThat(
         generatedSql,
-        containsString(
-            noEof(
-                """
-                select distinct enrollment from analytics_event_%s
-                where eventstatus != 'SCHEDULE' and ps = '%s'
-                """
-                    .formatted(programAUid, stageUid))));
+        not(
+            containsString(
+                noEof(
+                    """
+                    select distinct enrollment from analytics_event_%s
+                    where eventstatus != 'SCHEDULE' and ps = '%s'
+                    """
+                        .formatted(programAUid, stageUid)))));
 
     // SELECT projections for repeatable stage
     assertThat(generatedSql, containsString("\"" + stageUid + "[-1]." + deUid + "\""));
     assertThat(generatedSql, containsString("\"" + stageUid + "[-1]." + deUid + ".exists\""));
     assertThat(generatedSql, containsString("\"" + stageUid + "[-1]." + deUid + ".status\""));
+  }
+
+  @Test
+  void verifyRepeatableStagesFromDifferentStagesProduceUniqueJoinAliases() {
+    ProgramStage otherRepeatableStage =
+        org.hisp.dhis.test.TestBase.createProgramStage('C', programA);
+    otherRepeatableStage.setRepeatable(true);
+
+    EventQueryParams params =
+        new EventQueryParams.Builder(createRequestParams(repeatableProgramStage, ValueType.NUMBER))
+            .addItem(createRepeatableDataElementItem(otherRepeatableStage))
+            .build();
+
+    subject.getEnrollments(params, new ListGrid(), 100);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    List<String> aliases = joinAliases(noEof(sql.getValue()));
+
+    assertThat(
+        "join aliases must be unique: " + aliases,
+        aliases.size(),
+        is(new HashSet<>(aliases).size()));
   }
 
   @Test
@@ -1378,6 +1405,27 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
     item.setRepeatableStageParams(
         RepeatableStageParams.of(offset, stageUid + "[" + offset + "]." + dataElementA.getUid()));
     return item;
+  }
+
+  private QueryItem createRepeatableDataElementItem(ProgramStage stage) {
+    QueryItem item = new QueryItem(new BaseDimensionalItemObject(dataElementA.getUid()));
+    item.setProgram(programA);
+    item.setProgramStage(stage);
+    item.setValueType(ValueType.NUMBER);
+    item.setRepeatableStageParams(
+        RepeatableStageParams.of(-1, stage.getUid() + "[-1]." + dataElementA.getUid()));
+    return item;
+  }
+
+  /** Extracts the table alias of every join in the given SQL statement. */
+  private List<String> joinAliases(String sql) {
+    Matcher matcher =
+        Pattern.compile("(?:left|inner|cross)\\s+join\\s+\\S+\\s+(\\S+)\\s+on\\s").matcher(sql);
+    List<String> aliases = new ArrayList<>();
+    while (matcher.find()) {
+      aliases.add(matcher.group(1));
+    }
+    return aliases;
   }
 
   private EventQueryParams createAggregateEnrollmentWithEventDateParams() {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery7AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery7AutoTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.hisp.dhis.AnalyticsApiTest;
+import org.hisp.dhis.analytics.ValidationHelper;
 import org.hisp.dhis.test.e2e.actions.analytics.AnalyticsEnrollmentsActions;
 import org.hisp.dhis.test.e2e.dto.ApiResponse;
 import org.hisp.dhis.test.e2e.helpers.QueryParamsBuilder;
@@ -1619,5 +1620,133 @@ public class EnrollmentsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Ngelehun CHC");
     validateRowValueByName(response, actualHeaders, 0, "lastupdated", "2017-07-23 12:45:49.807");
+  }
+
+  @DisplayName("Enrollment Query - rowContext with items from two repeatable stages [DHIS2-21648]")
+  @Test
+  public void rowContextWithItemsFromTwoRepeatableStages() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,enrollmentdate,uvMKOn1oWvd.DX4LVYeP7bw,CWaAcQYKVpq.HDRons6AfbL")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("rowContext=true")
+            .add("pageSize=100")
+            .add("outputType=ENROLLMENT")
+            .add("page=1")
+            .add("dimension=ou:USER_ORGUNIT")
+            .add("desc=enrollmentdate,CWaAcQYKVpq.HDRons6AfbL");
+
+    // When
+    ApiResponse response = actions.query().get("M3xtLkYBlKI", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        11,
+        4,
+        4); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"HDRons6AfbL\":{\"uid\":\"HDRons6AfbL\",\"name\":\"Population\",\"description\":\"Population\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"NUMBER\",\"aggregationType\":\"NONE\",\"totalAggregationType\":\"NONE\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"CWaAcQYKVpq\":{\"uid\":\"CWaAcQYKVpq\",\"name\":\"Foci investigation & classification\",\"description\":\"Includes the details on the foci investigation (including information on households, population, geography, breeding sites, species types, vector behaviour) as well as its final classification at the time of the investigation. This is a repeatable stage as foci can be investigated more than once and may change their classification as time goes on. \"},\"CWaAcQYKVpq.HDRons6AfbL\":{\"uid\":\"HDRons6AfbL\",\"name\":\"Population\",\"description\":\"Population\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"NUMBER\",\"aggregationType\":\"NONE\",\"totalAggregationType\":\"NONE\"},\"DX4LVYeP7bw\":{\"uid\":\"DX4LVYeP7bw\",\"name\":\"People included\",\"description\":\"Number of people included\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"NUMBER\",\"aggregationType\":\"NONE\",\"totalAggregationType\":\"NONE\"},\"uvMKOn1oWvd\":{\"uid\":\"uvMKOn1oWvd\",\"name\":\"Foci response\",\"description\":\"Details the public health response conducted within the foci  (including diagnosis and treatment activities, vector control actions and the effectiveness\\/results of the response). This is a repeatable stage as multiple public health responses for the same foci can occur depending on its classification at the time of investigation.\"},\"M3xtLkYBlKI\":{\"uid\":\"M3xtLkYBlKI\",\"name\":\"Malaria focus investigation\",\"description\":\"It allows to register new focus areas in the system. Each focus area needs to be investigated and classified. Includes the relevant identifiers for the foci including the name and geographical details including the locality and its area. \"},\"uvMKOn1oWvd.DX4LVYeP7bw\":{\"uid\":\"DX4LVYeP7bw\",\"name\":\"People included\",\"description\":\"Number of people included\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"NUMBER\",\"aggregationType\":\"NONE\",\"totalAggregationType\":\"NONE\"}},\"dimensions\":{\"CWaAcQYKVpq.HDRons6AfbL\":[],\"pe\":[],\"uvMKOn1oWvd.DX4LVYeP7bw\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "enrollmentdate",
+        "Date of Focus Registration",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "uvMKOn1oWvd.DX4LVYeP7bw",
+        "People included",
+        "INTEGER_POSITIVE",
+        "java.lang.Integer",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "CWaAcQYKVpq.HDRons6AfbL",
+        "Population",
+        "INTEGER_POSITIVE",
+        "java.lang.Integer",
+        false,
+        true);
+
+    // 5. Assert rowContext by name.
+    ValidationHelper.validateRowContextByName(
+        response, actualHeaders, 0, "CWaAcQYKVpq.HDRons6AfbL", "ND");
+    ValidationHelper.validateRowContextByName(
+        response, actualHeaders, 1, "CWaAcQYKVpq.HDRons6AfbL", "ND");
+    ValidationHelper.validateRowContextByName(
+        response, actualHeaders, 3, "CWaAcQYKVpq.HDRons6AfbL", "NS");
+    // No rowContext found for header 'CWaAcQYKVpq.HDRons6AfbL' in row index 4.
+    ValidationHelper.validateRowContextByName(
+        response, actualHeaders, 5, "CWaAcQYKVpq.HDRons6AfbL", "NS");
+    // No rowContext found for header 'CWaAcQYKVpq.HDRons6AfbL' in row index 6.
+    ValidationHelper.validateRowContextByName(
+        response, actualHeaders, 7, "CWaAcQYKVpq.HDRons6AfbL", "NS");
+    // No rowContext found for header 'CWaAcQYKVpq.HDRons6AfbL' in row index 8.
+    ValidationHelper.validateRowContextByName(
+        response, actualHeaders, 9, "CWaAcQYKVpq.HDRons6AfbL", "NS");
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "ouname", "Ngelehun CHC");
+    validateRowValueByName(response, actualHeaders, 0, "CWaAcQYKVpq.HDRons6AfbL", "");
+    validateRowValueByName(response, actualHeaders, 0, "enrollmentdate", "2022-03-04 00:00:00.0");
+
+    // Validate selected values for row index 3
+    validateRowValueByName(response, actualHeaders, 3, "ouname", "Ngelehun CHC");
+    validateRowValueByName(response, actualHeaders, 3, "CWaAcQYKVpq.HDRons6AfbL", "");
+    validateRowValueByName(response, actualHeaders, 3, "enrollmentdate", "2021-11-13 00:00:00.0");
+
+    // Validate selected values for row index 6
+    validateRowValueByName(response, actualHeaders, 6, "ouname", "Njandama MCHP");
+    validateRowValueByName(response, actualHeaders, 6, "CWaAcQYKVpq.HDRons6AfbL", "12000");
+    validateRowValueByName(response, actualHeaders, 6, "enrollmentdate", "2021-11-07 00:00:00.0");
+
+    // Validate selected values for row index 9
+    validateRowValueByName(response, actualHeaders, 9, "ouname", "Ngelehun CHC");
+    validateRowValueByName(response, actualHeaders, 9, "CWaAcQYKVpq.HDRons6AfbL", "");
+    validateRowValueByName(response, actualHeaders, 9, "enrollmentdate", "2021-10-16 00:00:00.0");
+
+    // Validate selected values for row index 10
+    validateRowValueByName(response, actualHeaders, 10, "ouname", "Ngelehun CHC");
+    validateRowValueByName(response, actualHeaders, 10, "CWaAcQYKVpq.HDRons6AfbL", "500");
+    validateRowValueByName(response, actualHeaders, 10, "enrollmentdate", "2021-07-26 00:00:00.0");
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-query.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/enroll-query.json
@@ -190,6 +190,13 @@
       }
     },
     {
+      "name": "rowContextWithItemsFromTwoRepeatableStages",
+      "query": "/api/analytics/enrollments/query/M3xtLkYBlKI.json?dimension=ou:USER_ORGUNIT&headers=ouname,enrollmentdate,uvMKOn1oWvd.DX4LVYeP7bw,CWaAcQYKVpq.HDRons6AfbL&totalPages=false&rowContext=true&displayProperty=NAME&pageSize=100&page=1&includeMetadataDetails=true&outputType=ENROLLMENT&desc=enrollmentdate,CWaAcQYKVpq.HDRons6AfbL",
+      "version": {
+        "min": 44
+      }
+    },
+    {
       "name": "ouMultipleLevels",
       "query": "/api/analytics/enrollments/query/IpHINAT79UW.json?dimension=ou:USER_ORGUNIT;LEVEL-wjP19dkFeIk;LEVEL-tTUf91fCytl;LEVEL-m9lBJogzE95&headers=ouname,lastupdated&totalPages=false&rowContext=true&lastUpdated=201707&displayProperty=NAME&pageSize=100&page=1&includeMetadataDetails=true&outputType=ENROLLMENT",
       "version": {


### PR DESCRIPTION
## Summary

Enrollment analytics queries with `rowContext=true` failed when selecting items from more than one **repeatable program stage**.

The generated SQL created one "exists" CTE per repeatable stage but joined every one using the fixed alias `ee`:

```
left join stage1_exists ee on ee.enrollment = ax.enrollment
left join stage2_exists ee on ee.enrollment = ax.enrollment
```

PostgreSQL rejects duplicate table aliases (`SQLSTATE 42712`), causing the request to fail with `HTTP 409`.

## SQL changes

The `exists` CTEs and their corresponding joins have been removed.

Before:

```
with value_cte_1 as (...),
     exists_cte_1 as (...),
     value_cte_2 as (...),
     exists_cte_2 as (...)
...
left join value_cte_1 v1 on ...
left join exists_cte_1 ee on ...
left join value_cte_2 v2 on ...
left join exists_cte_2 ee on ...   -- duplicate alias
```

After:

```
with value_cte_1 as (...),
     value_cte_2 as (...)
...
left join value_cte_1 v1 on ...
left join value_cte_2 v2 on ...
```

The removed CTEs were redundant:

* they were never referenced outside their own JOIN;
* they duplicated the filtering already performed by the value CTEs;
* the .exists and .status row-context columns are derived from the value CTEs (rn and eventstatus), not from the removed CTEs.

As a result, removing the exists CTEs preserves query results while eliminating the duplicate-alias failure.

Code changes

* Removed `addExistsCte` and the associated join generation from `AbstractJdbcEventAnalyticsManager`.
* Removed `CteContext.addExistsCte`.


