### PR TITLE
fix: Invalidate user role member sessions async without loading users [DHIS2-21854] (2.42)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserRoleAuthoritiesChangedEvent.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserRoleAuthoritiesChangedEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user;
+
+import org.hisp.dhis.common.UID;
+
+/**
+ * Event published after the authorities of a {@link UserRole} have changed, so that active sessions
+ * of users with that role can be invalidated asynchronously, outside the updating transaction and
+ * off the request thread.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public record UserRoleAuthoritiesChangedEvent(UID userRoleUid) {}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -620,6 +620,14 @@ public interface UserService {
   void invalidateUserSessions(Collection<String> usernames);
 
   /**
+   * Returns the usernames of all users that are members of the user role with the given UID.
+   *
+   * @param roleUid the UID of the user role.
+   * @return a list of usernames.
+   */
+  List<String> getUsernamesByUserRole(@Nonnull UID roleUid);
+
+  /**
    * Register a account recovery attempt for the given user account.
    *
    * @param username the username of the user account.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -168,6 +168,14 @@ public interface UserStore extends IdentifiableObjectStore<User> {
   List<User> getUserByUsernames(Collection<String> usernames);
 
   /**
+   * Retrieves the usernames of all users that are members of the user role with the given UID.
+   *
+   * @param roleUid the UID of the user role.
+   * @return a list of usernames.
+   */
+  List<String> getUsernamesByUserRole(@Nonnull UID roleUid);
+
+  /**
    * Retrieves the most recently-used enabled User associated with the given open ID.
    *
    * <p>This only returns enabled users.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/config/ServiceConfig.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.config;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import org.hisp.dhis.common.DeliveryChannel;
 import org.hisp.dhis.i18n.ui.resourcebundle.DefaultResourceBundleManager;
 import org.hisp.dhis.i18n.ui.resourcebundle.ResourceBundleManager;
@@ -39,6 +40,7 @@ import org.hisp.dhis.outboundmessage.DefaultOutboundMessageBatchService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
@@ -72,5 +74,21 @@ public class ServiceConfig {
   @Bean("org.hisp.dhis.i18n.ui.resourcebundle.ResourceBundleManager")
   public ResourceBundleManager resourceBundleManager() {
     return new DefaultResourceBundleManager();
+  }
+
+  /**
+   * Single-threaded, bounded executor for asynchronous user session invalidation, see {@code
+   * UserRoleSessionInvalidationListener}. A single thread serializes the work and keeps it from
+   * competing with more important work.
+   */
+  @Bean("userSessionInvalidationTaskExecutor")
+  public Executor userSessionInvalidationTaskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(1);
+    executor.setMaxPoolSize(1);
+    executor.setQueueCapacity(1000);
+    executor.setThreadNamePrefix("SessionInvalidation-");
+    executor.initialize();
+    return executor;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -1055,12 +1055,42 @@ public class DefaultUserService implements UserService {
 
   @Override
   public void invalidateUserSessions(String username) {
-    User user = getUserByUsername(username);
-    UserDetails userDetails = createUserDetails(user);
-    if (userDetails != null) {
-      List<SessionInformation> allSessions = sessionRegistry.getAllSessions(userDetails, false);
-      allSessions.forEach(SessionInformation::expireNow);
+    if (username == null) {
+      return;
     }
+    List<SessionInformation> sessions =
+        sessionRegistry.getAllSessions(sessionLookupPrincipal(username), false);
+    sessions.forEach(SessionInformation::expireNow);
+  }
+
+  /**
+   * Creates a minimal principal used only to look up sessions in the {@link SessionRegistry}. The
+   * in-memory registry matches principals by {@link UserDetailsImpl} equality, which includes the
+   * username only, and the Redis-backed registry resolves principals by name (username). Building
+   * this instead of loading the full user avoids one user fetch plus full {@code UserDetails}
+   * hydration (groups, roles, org units) per invalidated user.
+   */
+  private static UserDetails sessionLookupPrincipal(String username) {
+    return UserDetailsImpl.builder()
+        .username(username)
+        .authorities(List.of())
+        .allAuthorities(Set.of())
+        .allRestrictions(Set.of())
+        .userGroupIds(Set.of())
+        .userOrgUnitIds(Set.of())
+        .userDataOrgUnitIds(Set.of())
+        .userSearchOrgUnitIds(Set.of())
+        .userEffectiveSearchOrgUnitIds(Set.of())
+        .userRoleIds(Set.of())
+        .managedGroupLongIds(Set.of())
+        .userRoleLongIds(Set.of())
+        .build();
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<String> getUsernamesByUserRole(@Nonnull UID roleUid) {
+    return userStore.getUsernamesByUserRole(roleUid);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserRoleSessionInvalidationListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserRoleSessionInvalidationListener.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user;
+
+import com.google.common.collect.Lists;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Invalidates the sessions of all users that are members of a user role whose authorities have
+ * changed, so that the new authorities take effect on the next authentication.
+ *
+ * <p>The work runs after the updating transaction has committed, on a dedicated single-threaded
+ * executor, in batches with a pause in between. This keeps an authority change on a role with many
+ * members cheap on the request thread and spreads the invalidation work out over time. If the
+ * server shuts down before all batches have run, the remaining sessions simply keep the old
+ * authorities until they expire or the user re-authenticates.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserRoleSessionInvalidationListener {
+
+  /** Number of users whose sessions are invalidated per batch. */
+  static final int BATCH_SIZE = 100;
+
+  /** Pause between batches, to spread the work out over time. */
+  static final long BATCH_DELAY_MS = 500;
+
+  private final UserService userService;
+
+  @Async("userSessionInvalidationTaskExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+  public void onUserRoleAuthoritiesChanged(UserRoleAuthoritiesChangedEvent event) {
+    List<String> usernames = userService.getUsernamesByUserRole(event.userRoleUid());
+    log.info(
+        "Invalidating sessions of {} users after authority change of user role '{}'",
+        usernames.size(),
+        event.userRoleUid());
+
+    List<List<String>> batches = Lists.partition(usernames, BATCH_SIZE);
+    for (int i = 0; i < batches.size(); i++) {
+      if (i > 0 && !pauseBetweenBatches()) {
+        log.warn(
+            "Session invalidation for user role '{}' interrupted, {} of {} batches done",
+            event.userRoleUid(),
+            i,
+            batches.size());
+        return;
+      }
+      batches.get(i).forEach(userService::invalidateUserSessions);
+    }
+  }
+
+  private static boolean pauseBetweenBatches() {
+    try {
+      Thread.sleep(BATCH_DELAY_MS);
+      return true;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -622,6 +622,15 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
   }
 
   @Override
+  public List<String> getUsernamesByUserRole(@Nonnull UID roleUid) {
+    return getSession()
+        .createQuery(
+            "select u.username from User u join u.userRoles r where r.uid = :roleUid", String.class)
+        .setParameter("roleUid", roleUid.getValue())
+        .list();
+  }
+
+  @Override
   public void setActiveLinkedAccounts(
       @Nonnull String actingUsername, @Nonnull String activeUsername) {
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserRoleSessionInvalidationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserRoleSessionInvalidationListenerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import org.hisp.dhis.common.UID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit test of {@link UserRoleSessionInvalidationListener}.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@ExtendWith(MockitoExtension.class)
+class UserRoleSessionInvalidationListenerTest {
+
+  private static final UID ROLE_UID = UID.of("Rab1234abcd");
+
+  @Mock private UserService userService;
+
+  @InjectMocks private UserRoleSessionInvalidationListener listener;
+
+  @Test
+  void invalidatesSessionsOfAllRoleMembersInOrder() {
+    List<String> usernames = List.of("alice", "bob", "carol");
+    when(userService.getUsernamesByUserRole(ROLE_UID)).thenReturn(usernames);
+
+    listener.onUserRoleAuthoritiesChanged(new UserRoleAuthoritiesChangedEvent(ROLE_UID));
+
+    InOrder order = inOrder(userService);
+    usernames.forEach(username -> order.verify(userService).invalidateUserSessions(username));
+  }
+
+  @Test
+  void invalidatesSessionsOfAllRoleMembersAcrossBatches() {
+    List<String> usernames =
+        IntStream.range(0, UserRoleSessionInvalidationListener.BATCH_SIZE + 1)
+            .mapToObj(i -> "user" + i)
+            .toList();
+    when(userService.getUsernamesByUserRole(ROLE_UID)).thenReturn(usernames);
+
+    listener.onUserRoleAuthoritiesChanged(new UserRoleAuthoritiesChangedEvent(ROLE_UID));
+
+    verify(userService, times(usernames.size())).invalidateUserSessions(anyString());
+  }
+
+  @Test
+  void invalidatesNothingWhenRoleHasNoMembers() {
+    when(userService.getUsernamesByUserRole(ROLE_UID)).thenReturn(List.of());
+
+    listener.onUserRoleAuthoritiesChanged(new UserRoleAuthoritiesChangedEvent(ROLE_UID));
+
+    verify(userService, never()).invalidateUserSessions(anyString());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserSessionInvalidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserSessionInvalidationTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.message.MessageSender;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.security.PasswordManager;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.setting.SystemSettingsProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.session.SessionRegistryImpl;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Unit test of {@link DefaultUserService#invalidateUserSessions(String)}. Verifies that sessions
+ * registered with a fully populated principal are expired when looked up with a thin username-only
+ * principal, and that no user is loaded from the store in the process.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@ExtendWith(MockitoExtension.class)
+class UserSessionInvalidationTest {
+
+  private DefaultUserService userService;
+
+  private final SessionRegistryImpl sessionRegistry = new SessionRegistryImpl();
+
+  @Mock private UserSettingsService userSettingsService;
+  @Mock private RestTemplate restTemplate;
+  @Mock private MessageSender emailMessageSender;
+  @Mock private I18nManager i18nManager;
+  @Mock private ObjectMapper jsonMapper;
+  @Mock private UserStore userStore;
+  @Mock private UserGroupService userGroupService;
+  @Mock private UserRoleStore userRoleStore;
+  @Mock private SystemSettingsProvider settingsProvider;
+  @Mock private CacheProvider cacheProvider;
+  @Mock private PasswordManager passwordManager;
+  @Mock private AclService aclService;
+  @Mock private OrganisationUnitService organisationUnitService;
+  @Mock private Cache<String> userDisplayNameCache;
+  @Mock private Cache<Integer> userFailedLoginAttemptCache;
+  @Mock private Cache<Integer> userAccountRecoverAttemptCache;
+  @Mock private Cache<Integer> twoFaDisableFailedAttemptCache;
+
+  @BeforeEach
+  void setUp() {
+    when(cacheProvider.<String>createUserDisplayNameCache()).thenReturn(userDisplayNameCache);
+    when(cacheProvider.<Integer>createUserFailedLoginAttemptCache(0))
+        .thenReturn(userFailedLoginAttemptCache);
+    when(cacheProvider.<Integer>createUserAccountRecoverAttemptCache(0))
+        .thenReturn(userAccountRecoverAttemptCache);
+    when(cacheProvider.<Integer>createDisable2FAFailedAttemptCache(0))
+        .thenReturn(twoFaDisableFailedAttemptCache);
+
+    userService =
+        new DefaultUserService(
+            userSettingsService,
+            restTemplate,
+            emailMessageSender,
+            i18nManager,
+            jsonMapper,
+            userStore,
+            userGroupService,
+            userRoleStore,
+            settingsProvider,
+            cacheProvider,
+            passwordManager,
+            aclService,
+            organisationUnitService,
+            sessionRegistry);
+  }
+
+  @Test
+  void invalidateUserSessionsExpiresSessionsWithoutLoadingUser() {
+    sessionRegistry.registerNewSession("session1", fullPrincipal("alice"));
+    sessionRegistry.registerNewSession("session2", fullPrincipal("alice"));
+
+    userService.invalidateUserSessions("alice");
+
+    assertTrue(sessionRegistry.getSessionInformation("session1").isExpired());
+    assertTrue(sessionRegistry.getSessionInformation("session2").isExpired());
+    verifyNoInteractions(userStore);
+  }
+
+  @Test
+  void invalidateUserSessionsLeavesSessionsOfOtherUsersAlone() {
+    sessionRegistry.registerNewSession("session1", fullPrincipal("alice"));
+    sessionRegistry.registerNewSession("session2", fullPrincipal("bob"));
+
+    userService.invalidateUserSessions("alice");
+
+    assertTrue(sessionRegistry.getSessionInformation("session1").isExpired());
+    assertFalse(sessionRegistry.getSessionInformation("session2").isExpired());
+  }
+
+  @Test
+  void invalidateUserSessionsToleratesUnknownAndNullUsernames() {
+    assertDoesNotThrow(() -> userService.invalidateUserSessions("unknown"));
+    assertDoesNotThrow(() -> userService.invalidateUserSessions((String) null));
+    verifyNoInteractions(userStore);
+  }
+
+  /** A principal as it is registered at login, carrying more than just the username. */
+  private static UserDetails fullPrincipal(String username) {
+    return UserDetailsImpl.builder()
+        .id(42L)
+        .uid("a1234567890")
+        .username(username)
+        .password("secret")
+        .enabled(true)
+        .accountNonExpired(true)
+        .accountNonLocked(true)
+        .credentialsNonExpired(true)
+        .authorities(List.of())
+        .allAuthorities(Set.of())
+        .allRestrictions(Set.of())
+        .userGroupIds(Set.of())
+        .userOrgUnitIds(Set.of())
+        .userDataOrgUnitIds(Set.of())
+        .userSearchOrgUnitIds(Set.of())
+        .userEffectiveSearchOrgUnitIds(Set.of())
+        .userRoleIds(Set.of())
+        .managedGroupLongIds(Set.of())
+        .userRoleLongIds(Set.of())
+        .build();
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHook.java
@@ -33,10 +33,11 @@ import java.util.Objects;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
-import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserRole;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserRoleAuthoritiesChangedEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 /**
@@ -49,7 +50,7 @@ public class UserRoleBundleHook extends AbstractObjectBundleHook<UserRole> {
 
   public static final String INVALIDATE_SESSION_KEY = "shouldInvalidateUserSessions";
 
-  private final UserService userService;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Override
   public void preUpdate(UserRole update, UserRole existing, ObjectBundle bundle) {
@@ -69,10 +70,10 @@ public class UserRoleBundleHook extends AbstractObjectBundleHook<UserRole> {
         (Boolean) bundle.getExtras(updatedUserRole, INVALIDATE_SESSION_KEY);
 
     if (Boolean.TRUE.equals(invalidateSessions)) {
-      // Batch-resolve members in one query instead of one getUserByUsername per member
-      // (DHIS2-21842).
-      userService.invalidateUserSessions(
-          updatedUserRole.getUsers().stream().map(User::getUsername).toList());
+      // Session invalidation for all members of the role is done asynchronously after the
+      // transaction has committed, see UserRoleSessionInvalidationListener. Loading all members
+      // here would be O(members) full entity loads on the request thread.
+      eventPublisher.publishEvent(new UserRoleAuthoritiesChangedEvent(UID.of(updatedUserRole)));
     }
 
     bundle.removeExtras(updatedUserRole, INVALIDATE_SESSION_KEY);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHookTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.Map;
+import java.util.Set;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.user.UserRole;
+import org.hisp.dhis.user.UserRoleAuthoritiesChangedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+/**
+ * Unit test of {@link UserRoleBundleHook}.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@ExtendWith(MockitoExtension.class)
+class UserRoleBundleHookTest {
+
+  private static final String ROLE_UID = "Rab1234abcd";
+
+  @Mock private ApplicationEventPublisher eventPublisher;
+
+  private UserRoleBundleHook hook;
+
+  private ObjectBundle bundle;
+
+  @BeforeEach
+  void setUp() {
+    hook = new UserRoleBundleHook(eventPublisher);
+    bundle = new ObjectBundle(new ObjectBundleParams(), new Preheat(), Map.of());
+  }
+
+  @Test
+  void postUpdatePublishesEventWhenAuthoritiesChanged() {
+    UserRole existing = createUserRole(Set.of("F_USER_VIEW"));
+    UserRole update = spy(createUserRole(Set.of("F_USER_VIEW", "F_USER_ADD")));
+
+    hook.preUpdate(update, existing, bundle);
+    hook.postUpdate(update, bundle);
+
+    verify(eventPublisher).publishEvent(new UserRoleAuthoritiesChangedEvent(UID.of(ROLE_UID)));
+    // the members of the role must never be loaded on the update path
+    verify(update, never()).getUsers();
+    verify(update, never()).getMembers();
+  }
+
+  @Test
+  void postUpdateDoesNotPublishWhenAuthoritiesUnchanged() {
+    UserRole existing = createUserRole(Set.of("F_USER_VIEW"));
+    UserRole update = createUserRole(Set.of("F_USER_VIEW"));
+
+    hook.preUpdate(update, existing, bundle);
+    hook.postUpdate(update, bundle);
+
+    verifyNoInteractions(eventPublisher);
+  }
+
+  @Test
+  void postUpdateDoesNotPublishWithoutPrecedingPreUpdate() {
+    hook.postUpdate(createUserRole(Set.of("F_USER_VIEW")), bundle);
+
+    verifyNoInteractions(eventPublisher);
+  }
+
+  private static UserRole createUserRole(Set<String> authorities) {
+    UserRole role = new UserRole();
+    role.setUid(ROLE_UID);
+    role.setAuthorities(authorities);
+    return role;
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -150,37 +150,6 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
-  void updateRolesAuthoritiesShouldInvalidateUserSessions() {
-    UserDetails sessionPrincipal = userService.createUserDetails(getAdminUser());
-
-    UserRole roleB = createUserRole("ROLE_B", "ALL");
-    userService.addUserRole(roleB);
-
-    PATCH(
-            "/users/" + getAdminUid(),
-            "[{'op':'add','path':'/userRoles','value':[{'id':'" + roleB.getUid() + "'}]}]")
-        .content(HttpStatus.OK);
-
-    String roleBID = userService.getUserRoleByName("ROLE_B").getUid();
-
-    sessionRegistry.registerNewSession("session1", sessionPrincipal);
-    assertFalse(sessionRegistry.getAllSessions(sessionPrincipal, false).isEmpty());
-
-    PATCH(
-            "/userRoles/" + roleBID,
-            "["
-                + " {"
-                + "   'op': 'add',"
-                + "   'path': '/authorities',"
-                + "   'value': ['NONE']"
-                + " }"
-                + "]")
-        .content(HttpStatus.OK);
-
-    assertTrue(sessionRegistry.getAllSessions(sessionPrincipal, false).isEmpty());
-  }
-
-  @Test
   void testResetToInvite() {
     assertStatus(HttpStatus.NO_CONTENT, POST("/users/" + peter.getUid() + "/reset"));
     OutboundMessage email = assertMessageSendTo("peter@pan.net");

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserRoleSessionInvalidationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserRoleSessionInvalidationControllerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.awaitility.Awaitility.await;
+import static org.hisp.dhis.http.HttpStatus.OK;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserRole;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies the end-to-end asynchronous invalidation of role member sessions when the authorities of
+ * a {@link UserRole} change: the {@code UserRoleBundleHook} publishes an event on commit and {@code
+ * UserRoleSessionInvalidationListener} expires the members' sessions after the transaction has
+ * committed, off the request thread.
+ *
+ * <p>Because the invalidation runs {@code AFTER_COMMIT} on a separate thread, the change has to be
+ * committed (via {@link TestTransaction}) and the assertion has to poll ({@code await}) rather than
+ * read synchronously. {@link TestInstance.Lifecycle#PER_CLASS} makes the framework empty the
+ * database after the class, so the committed data does not leak into other tests.
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class UserRoleSessionInvalidationControllerTest extends H2ControllerIntegrationTestBase {
+
+  @Autowired private SessionRegistry sessionRegistry;
+
+  @Test
+  void authorityChangeInvalidatesRoleMemberSessionsAsync() {
+    UserDetails adminPrincipal = userService.createUserDetails(getAdminUser());
+
+    UserRole role = createUserRole('B', "ALL");
+    userService.addUserRole(role);
+
+    // make the admin a member of the role
+    PATCH(
+            "/users/" + getAdminUid(),
+            "[{'op':'add','path':'/userRoles','value':[{'id':'" + role.getUid() + "'}]}]")
+        .content(OK);
+
+    sessionRegistry.registerNewSession("session1", adminPrincipal);
+    assertFalse(sessionRegistry.getAllSessions(adminPrincipal, false).isEmpty());
+
+    // Change the role authorities and commit; the after-commit listener then invalidates the
+    // member sessions asynchronously.
+    TestTransaction.flagForCommit();
+    PATCH("/userRoles/" + role.getUid(), "[{'op':'add','path':'/authorities','value':['NONE']}]")
+        .content(OK);
+    TestTransaction.end();
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () -> assertTrue(sessionRegistry.getAllSessions(adminPrincipal, false).isEmpty()));
+  }
+}


### PR DESCRIPTION
## Summary
Backport of #24494 to `2.42`.

Changing user role authorities no longer invalidates member sessions synchronously on the request thread. Publishes `UserRoleAuthoritiesChangedEvent` and invalidates sessions async after commit with thin username-only principals.

## Original
- PR: https://github.com/dhis2/dhis2-core/pull/24494
- Master squash: `e4a9688cf13`
- Jira: DHIS2-21854

## Notes
- Conflicts in `UserService` and `UserRoleBundleHook`
- Kept both: existing batch `invalidateUserSessions(Collection)` from the 2.42 line, plus new `getUsernamesByUserRole`
- Hook switched to async event publisher (replaces synchronous batch path for role-authority changes)
- Compile-only local check; full tests on CI
- AI Assisted