### PR TITLE
feat: expose session statistics as Prometheus metrics on /api/metrics

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/SessionMetrics.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/SessionMetrics.java
@@ -48,6 +48,17 @@ import org.springframework.stereotype.Component;
  * scrape rather than caching its own copy, so this view can never drift from the JMX MBean, which
  * reads the same provider.
  *
+ * <p><b>Naming note:</b> the two lifecycle counters are named {@code dhis2_sessions_started_total}
+ * / {@code dhis2_sessions_ended_total}, not {@code _created_total} / {@code _destroyed_total} as
+ * the JMX {@code SessionStatisticsMBean} attributes ({@code SessionsCreatedTotal} / {@code
+ * SessionsDestroyedTotal}) would suggest. This is deliberate, not an inconsistency to "fix":
+ * OpenMetrics reserves the {@code _created} suffix for a companion created-timestamp series, so
+ * Prometheus's naming sanitizer strips {@code _created} (along with {@code _total}) from a counter
+ * name before re-appending {@code _total} — {@code dhis2_sessions_created_total} would therefore
+ * actually be scraped as {@code dhis2_sessions_total}, silently losing the "created" meaning and
+ * colliding in appearance with a gauge-like total. Renaming to {@code started}/{@code ended}
+ * sidesteps the reserved word entirely so the exposed name matches the constant.
+ *
  * <p>No-ops when no {@link MeterRegistry} is available in the application context.
  *
  * @author Jason Pickering
@@ -58,8 +69,8 @@ public class SessionMetrics {
   static final String ACTIVE_SESSIONS = "dhis2_active_sessions";
   static final String ACTIVE_SESSION_USERS = "dhis2_active_session_users";
   static final String HTTP_SESSIONS = "dhis2_http_sessions";
-  static final String SESSIONS_CREATED_TOTAL = "dhis2_sessions_created_total";
-  static final String SESSIONS_DESTROYED_TOTAL = "dhis2_sessions_destroyed_total";
+  static final String SESSIONS_STARTED_TOTAL = "dhis2_sessions_started_total";
+  static final String SESSIONS_ENDED_TOTAL = "dhis2_sessions_ended_total";
 
   @Autowired
   public SessionMetrics(
@@ -85,14 +96,12 @@ public class SessionMetrics {
         .register(registry);
 
     FunctionCounter.builder(
-            SESSIONS_CREATED_TOTAL, provider, SessionStatisticsProvider::getSessionsCreatedTotal)
+            SESSIONS_STARTED_TOTAL, provider, SessionStatisticsProvider::getSessionsCreatedTotal)
         .description("Sessions created since this instance started")
         .register(registry);
 
     FunctionCounter.builder(
-            SESSIONS_DESTROYED_TOTAL,
-            provider,
-            SessionStatisticsProvider::getSessionsDestroyedTotal)
+            SESSIONS_ENDED_TOTAL, provider, SessionStatisticsProvider::getSessionsDestroyedTotal)
         .description("Sessions invalidated, logged out or expired since this instance started")
         .register(registry);
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/SessionMetrics.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/session/SessionMetrics.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.session;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import javax.annotation.CheckForNull;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Registers {@link SessionStatisticsProvider} session statistics as Micrometer metrics on the
+ * {@code /api/metrics} Prometheus scrape endpoint, mirroring the JMX {@code SessionStatisticsMBean}
+ * attributes. Distinct from {@code data_summary_active_sessions} on {@code
+ * /api/dataSummary/metrics}, which is a separate, database-backed endpoint gated by {@code
+ * F_PERFORM_MAINTENANCE}.
+ *
+ * <p>Every meter here is function-backed: it reads {@link SessionStatisticsProvider} live on each
+ * scrape rather than caching its own copy, so this view can never drift from the JMX MBean, which
+ * reads the same provider.
+ *
+ * <p>No-ops when no {@link MeterRegistry} is available in the application context.
+ *
+ * @author Jason Pickering
+ */
+@Component
+public class SessionMetrics {
+
+  static final String ACTIVE_SESSIONS = "dhis2_active_sessions";
+  static final String ACTIVE_SESSION_USERS = "dhis2_active_session_users";
+  static final String HTTP_SESSIONS = "dhis2_http_sessions";
+  static final String SESSIONS_CREATED_TOTAL = "dhis2_sessions_created_total";
+  static final String SESSIONS_DESTROYED_TOTAL = "dhis2_sessions_destroyed_total";
+
+  @Autowired
+  public SessionMetrics(
+      SessionStatisticsProvider provider, ObjectProvider<MeterRegistry> registryProvider) {
+    this(provider, registryProvider.getIfAvailable());
+  }
+
+  SessionMetrics(SessionStatisticsProvider provider, @CheckForNull MeterRegistry registry) {
+    if (registry == null) {
+      return;
+    }
+
+    Gauge.builder(ACTIVE_SESSIONS, provider, p -> p.getSessionGauges().sessions())
+        .description("Active (non-expired) HTTP sessions known to the session registry")
+        .register(registry);
+
+    Gauge.builder(ACTIVE_SESSION_USERS, provider, p -> p.getSessionGauges().users())
+        .description("Distinct users behind dhis2_active_sessions")
+        .register(registry);
+
+    Gauge.builder(HTTP_SESSIONS, provider, SessionStatisticsProvider::getHttpSessions)
+        .description("Every HTTP session the servlet container currently holds in this JVM")
+        .register(registry);
+
+    FunctionCounter.builder(
+            SESSIONS_CREATED_TOTAL, provider, SessionStatisticsProvider::getSessionsCreatedTotal)
+        .description("Sessions created since this instance started")
+        .register(registry);
+
+    FunctionCounter.builder(
+            SESSIONS_DESTROYED_TOTAL,
+            provider,
+            SessionStatisticsProvider::getSessionsDestroyedTotal)
+        .description("Sessions invalidated, logged out or expired since this instance started")
+        .register(registry);
+  }
+}

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/security/session/SessionMetricsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/security/session/SessionMetricsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.session;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link SessionMetrics}. */
+class SessionMetricsTest {
+
+  @Test
+  @DisplayName("Registration is a no-op without a meter registry")
+  void nullRegistry_noOp() {
+    SessionStatisticsProvider provider = mock(SessionStatisticsProvider.class);
+
+    assertDoesNotThrow(() -> new SessionMetrics(provider, (MeterRegistry) null));
+  }
+
+  @Test
+  @DisplayName("Active session gauges read live from the provider")
+  void activeSessionGauges_readLive() {
+    SessionStatisticsProvider provider = mock(SessionStatisticsProvider.class);
+    when(provider.getSessionGauges()).thenReturn(new SessionStatisticsProvider.SessionGauges(3, 2));
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    new SessionMetrics(provider, registry);
+
+    assertEquals(3.0, registry.get(SessionMetrics.ACTIVE_SESSIONS).gauge().value());
+    assertEquals(2.0, registry.get(SessionMetrics.ACTIVE_SESSION_USERS).gauge().value());
+
+    when(provider.getSessionGauges()).thenReturn(new SessionStatisticsProvider.SessionGauges(7, 5));
+
+    assertEquals(7.0, registry.get(SessionMetrics.ACTIVE_SESSIONS).gauge().value());
+    assertEquals(5.0, registry.get(SessionMetrics.ACTIVE_SESSION_USERS).gauge().value());
+  }
+
+  @Test
+  @DisplayName("Http session gauge reads live from the provider")
+  void httpSessions_readLive() {
+    SessionStatisticsProvider provider = mock(SessionStatisticsProvider.class);
+    when(provider.getHttpSessions()).thenReturn(4L).thenReturn(9L);
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    new SessionMetrics(provider, registry);
+
+    assertEquals(4.0, registry.get(SessionMetrics.HTTP_SESSIONS).gauge().value());
+    assertEquals(9.0, registry.get(SessionMetrics.HTTP_SESSIONS).gauge().value());
+  }
+
+  @Test
+  @DisplayName("Session lifecycle totals are exposed as function counters")
+  void lifecycleTotals_readLive() {
+    SessionStatisticsProvider provider = mock(SessionStatisticsProvider.class);
+    when(provider.getSessionsCreatedTotal()).thenReturn(12L);
+    when(provider.getSessionsDestroyedTotal()).thenReturn(5L);
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    new SessionMetrics(provider, registry);
+
+    assertEquals(
+        12.0, registry.get(SessionMetrics.SESSIONS_CREATED_TOTAL).functionCounter().count());
+    assertEquals(
+        5.0, registry.get(SessionMetrics.SESSIONS_DESTROYED_TOTAL).functionCounter().count());
+  }
+}

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/security/session/SessionMetricsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/security/session/SessionMetricsTest.java
@@ -31,11 +31,14 @@ package org.hisp.dhis.webapi.security.session;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -92,8 +95,27 @@ class SessionMetricsTest {
     new SessionMetrics(provider, registry);
 
     assertEquals(
-        12.0, registry.get(SessionMetrics.SESSIONS_CREATED_TOTAL).functionCounter().count());
-    assertEquals(
-        5.0, registry.get(SessionMetrics.SESSIONS_DESTROYED_TOTAL).functionCounter().count());
+        12.0, registry.get(SessionMetrics.SESSIONS_STARTED_TOTAL).functionCounter().count());
+    assertEquals(5.0, registry.get(SessionMetrics.SESSIONS_ENDED_TOTAL).functionCounter().count());
+  }
+
+  @Test
+  @DisplayName("Metric names survive Prometheus's naming sanitization unchanged")
+  void meterNames_surviveScrape() {
+    SessionStatisticsProvider provider = mock(SessionStatisticsProvider.class);
+    when(provider.getSessionGauges()).thenReturn(new SessionStatisticsProvider.SessionGauges(3, 2));
+    when(provider.getHttpSessions()).thenReturn(4L);
+    when(provider.getSessionsCreatedTotal()).thenReturn(12L);
+    when(provider.getSessionsDestroyedTotal()).thenReturn(5L);
+    PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+
+    new SessionMetrics(provider, registry);
+    String scrape = registry.scrape();
+
+    assertTrue(scrape.contains(SessionMetrics.ACTIVE_SESSIONS), scrape);
+    assertTrue(scrape.contains(SessionMetrics.ACTIVE_SESSION_USERS), scrape);
+    assertTrue(scrape.contains(SessionMetrics.HTTP_SESSIONS), scrape);
+    assertTrue(scrape.contains(SessionMetrics.SESSIONS_STARTED_TOTAL), scrape);
+    assertTrue(scrape.contains(SessionMetrics.SESSIONS_ENDED_TOTAL), scrape);
   }
 }


### PR DESCRIPTION
## Summary

Stacks on #24730. Adds `SessionMetrics`, a small Spring component that exposes the same session
statistics `SessionStatisticsMBean` reports over JMX as Micrometer metrics on the real Prometheus
scrape endpoint (`/api/metrics`), so Prometheus users get parity with the JMX view without needing
`F_PERFORM_MAINTENANCE`.

This is distinct from `data_summary_active_sessions`/`data_summary_active_session_users` on
`/api/dataSummary/metrics` (already on master via #24708) — that is a separate, database-backed,
`F_PERFORM_MAINTENANCE`-gated endpoint and is untouched by this PR.

### New metrics on `/api/metrics`

| Metric | Type | Source |
|---|---|---|
| `dhis2_active_sessions` | Gauge | `SessionStatisticsProvider.getSessionGauges().sessions()` |
| `dhis2_active_session_users` | Gauge | `SessionStatisticsProvider.getSessionGauges().users()` |
| `dhis2_http_sessions` | Gauge | `SessionStatisticsProvider.getHttpSessions()` |
| `dhis2_sessions_started_total` | FunctionCounter | `SessionStatisticsProvider.getSessionsCreatedTotal()` |
| `dhis2_sessions_ended_total` | FunctionCounter | `SessionStatisticsProvider.getSessionsDestroyedTotal()` |

All five are function-backed (`Gauge.builder`/`FunctionCounter.builder`), reading
`SessionStatisticsProvider` live on every scrape rather than caching a separate copy — this view
can never drift from the JMX MBean, since both read the same provider. No `dhis.conf` gating,
matching `dhis2_user_logins_total`'s always-on behavior on the same endpoint.

**Naming note:** the created/destroyed counters are named `_started_total`/`_ended_total` rather
than the more literal `_created_total`/`_destroyed_total` that would mirror the JMX attribute
names 1:1. Micrometer's Prometheus naming convention treats both `_total` and `_created` as
reserved suffixes and strips them iteratively, so `dhis2_sessions_created_total` would have
actually been scraped as the misleading `dhis2_sessions_total`. Verified against the exact
`micrometer`/`prometheus-metrics-model` versions pinned in `dhis-2/pom.xml`; see the Javadoc note
in `SessionMetrics.java` and the `meterNames_surviveScrape` test that guards against a regression
here.

## Testing

`SessionMetricsTest`: null-registry no-op, live-read semantics for both gauges and counters
against a `SimpleMeterRegistry`, and a scrape-level test against a real `PrometheusMeterRegistry`
asserting all five metric names survive Prometheus's naming sanitization unchanged.

Design doc: `docs/superpowers/specs/2026-08-06-session-prometheus-metrics-design.md`

AI Assisted