### PR TITLE
fix: Skip sync of program attributes [DHIS2-21603][2.42]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
@@ -186,4 +186,12 @@ public interface TrackedEntityAttributeService {
    * @return a Set of {@link TrackedEntityAttribute} UIDs
    */
   Set<String> getTrackedEntityAttributesInProgram(@Nonnull Program program);
+
+  /**
+   * Fetches UIDs of all {@link TrackedEntityAttribute} that have {@code skipSynchronization} set to
+   * true.
+   *
+   * @return a Set of {@link TrackedEntityAttribute} UIDs
+   */
+  Set<String> getTrackedEntityAttributeUidsWithSkipSynchronizationSetToTrue();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStore.java
@@ -78,4 +78,12 @@ public interface TrackedEntityAttributeStore
    * @return a Set of {@link TrackedEntityAttribute} UIDs
    */
   Set<String> getTrackedEntityAttributesInProgram(Program program);
+
+  /**
+   * Fetches UIDs of all {@link TrackedEntityAttribute} that have {@code skipSynchronization} set to
+   * true.
+   *
+   * @return a Set of {@link TrackedEntityAttribute} UIDs
+   */
+  Set<String> getTrackedEntityAttributeUidsWithSkipSynchronizationSetToTrue();
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
@@ -310,6 +310,13 @@ public class DefaultTrackedEntityAttributeService implements TrackedEntityAttrib
     return this.trackedEntityAttributeStore.getTrackedEntityAttributesInProgram(program);
   }
 
+  @Override
+  @Transactional(readOnly = true)
+  public Set<String> getTrackedEntityAttributeUidsWithSkipSynchronizationSetToTrue() {
+    return this.trackedEntityAttributeStore
+        .getTrackedEntityAttributeUidsWithSkipSynchronizationSetToTrue();
+  }
+
   private String validateImage(String uid) {
     FileResource fileResource = fileResourceService.getFileResource(uid);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityAttributeStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityAttributeStore.java
@@ -142,4 +142,14 @@ public class HibernateTrackedEntityAttributeStore
 
     return new HashSet<>(query.getResultList());
   }
+
+  @Override
+  public Set<String> getTrackedEntityAttributeUidsWithSkipSynchronizationSetToTrue() {
+    TypedQuery<String> query =
+        entityManager.createQuery(
+            "select tea.uid from TrackedEntityAttribute tea where tea.skipSynchronization = true",
+            String.class);
+
+    return new HashSet<>(query.getResultList());
+  }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreTest.java
@@ -216,6 +216,18 @@ class TrackedEntityAttributeStoreTest extends PostgresIntegrationTestBase {
     assertThat(trackedEntityAttributes.size(), is(20));
   }
 
+  @Test
+  void shouldReturnOnlyAttributeUidWhenSkipSynchronizationSetToTrue() {
+    attributeW.setSkipSynchronization(true);
+    attributeService.addTrackedEntityAttribute(attributeW);
+    attributeService.addTrackedEntityAttribute(attributeY);
+
+    Set<String> uids =
+        attributeService.getTrackedEntityAttributeUidsWithSkipSynchronizationSetToTrue();
+
+    assertEquals(Set.of(attributeW.getUid()), uids);
+  }
+
   private List<ProgramTrackedEntityAttribute> createProgramAttributes(Program program) {
     return IntStream.range(A, T)
         .mapToObj(i -> Character.toString((char) i))

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerDataSynchronizationService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerDataSynchronizationService.java
@@ -56,7 +56,6 @@ import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dxf2.sync.SyncEndpoint;
 import org.hisp.dhis.dxf2.sync.SyncUtils;
@@ -71,7 +70,7 @@ import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.setting.SystemSettings;
 import org.hisp.dhis.setting.SystemSettingsService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
@@ -103,6 +102,7 @@ public class TrackerDataSynchronizationService extends TrackerDataSynchronizatio
   private record DeleteSyncResult(Set<UID> syncedTeUids, Set<UID> blockingFailedChildUids) {}
 
   private final TrackedEntityService trackedEntityService;
+  private final TrackedEntityAttributeService trackedEntityAttributeService;
   private final ProgramStageDataElementService programStageDataElementService;
   private final SystemSettingsService systemSettingsService;
   private final RestTemplate restTemplate;
@@ -111,6 +111,7 @@ public class TrackerDataSynchronizationService extends TrackerDataSynchronizatio
   @Getter
   private static final class TrackerSynchronizationContext extends PagedDataSynchronisationContext {
     private final Map<String, Set<String>> skipSyncDataElementsByProgramStage;
+    private final Set<String> skipSyncAttributeUids;
     // Distinct tracked entity uids fetched across all pages this run, so the run's completion can
     // report how many entities in the backlog were never attempted at all (see
     // executeSynchronizationWithPaging), e.g. because repeatedly failing entities kept occupying
@@ -118,7 +119,7 @@ public class TrackerDataSynchronizationService extends TrackerDataSynchronizatio
     private final Set<UID> attemptedTrackedEntityUids = new HashSet<>();
 
     public TrackerSynchronizationContext(Date skipChangedBefore, int pageSize) {
-      this(skipChangedBefore, 0, null, pageSize, Map.of());
+      this(skipChangedBefore, 0, null, pageSize, Map.of(), Set.of());
     }
 
     public TrackerSynchronizationContext(
@@ -126,9 +127,11 @@ public class TrackerDataSynchronizationService extends TrackerDataSynchronizatio
         long objectsToSynchronize,
         SystemInstance instance,
         int pageSize,
-        Map<String, Set<String>> skipSyncDataElementsByProgramStage) {
+        Map<String, Set<String>> skipSyncDataElementsByProgramStage,
+        Set<String> skipSyncAttributeUids) {
       super(skipChangedBefore, objectsToSynchronize, instance, pageSize);
       this.skipSyncDataElementsByProgramStage = skipSyncDataElementsByProgramStage;
+      this.skipSyncAttributeUids = skipSyncAttributeUids;
     }
 
     public boolean hasNoObjectsToSynchronize() {
@@ -187,12 +190,18 @@ public class TrackerDataSynchronizationService extends TrackerDataSynchronizatio
         trackedEntityCount,
         instance,
         pageSize,
-        getSkipSyncDataElementsByProgramStage());
+        getSkipSyncDataElementsByProgramStage(),
+        getSkipSyncAttributeUids());
   }
 
   private Map<String, Set<String>> getSkipSyncDataElementsByProgramStage() {
     return programStageDataElementService
         .getProgramStageDataElementsWithSkipSynchronizationSetToTrue();
+  }
+
+  private Set<String> getSkipSyncAttributeUids() {
+    return trackedEntityAttributeService
+        .getTrackedEntityAttributeUidsWithSkipSynchronizationSetToTrue();
   }
 
   private long countTrackedEntitiesForSynchronization(Date skipChangedBefore)
@@ -352,7 +361,7 @@ public class TrackerDataSynchronizationService extends TrackerDataSynchronizatio
           deletedChildUidsByTe);
       stripSkipSyncFields(
           activeTrackedEntities,
-          skipSyncAttributeUids(active),
+          context.getSkipSyncAttributeUids(),
           context.getSkipSyncDataElementsByProgramStage());
     }
 
@@ -481,25 +490,6 @@ public class TrackerDataSynchronizationService extends TrackerDataSynchronizatio
               ownedDeletedChildUids.add(r.getRelationship());
             });
     return relationships.stream().filter(r -> !r.isDeleted()).toList();
-  }
-
-  private Set<String> skipSyncAttributeUids(List<TrackedEntity> trackedEntities) {
-    return trackedEntities.stream()
-        .flatMap(
-            te ->
-                Stream.concat(
-                    te.getTrackedEntityAttributeValues().stream(),
-                    getEnrollmentAttributeValues(te)))
-        .map(TrackedEntityAttributeValue::getAttribute)
-        .filter(a -> Boolean.TRUE.equals(a.getSkipSynchronization()))
-        .map(BaseIdentifiableObject::getUid)
-        .collect(Collectors.toSet());
-  }
-
-  private Stream<TrackedEntityAttributeValue> getEnrollmentAttributeValues(TrackedEntity te) {
-    return te.getEnrollments().stream()
-        .map(org.hisp.dhis.program.Enrollment::getTrackedEntity)
-        .flatMap(t -> t.getTrackedEntityAttributeValues().stream());
   }
 
   private void stripSkipSyncFields(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerDataSynchronizationService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerDataSynchronizationService.java
@@ -485,11 +485,21 @@ public class TrackerDataSynchronizationService extends TrackerDataSynchronizatio
 
   private Set<String> skipSyncAttributeUids(List<TrackedEntity> trackedEntities) {
     return trackedEntities.stream()
-        .flatMap(te -> te.getTrackedEntityAttributeValues().stream())
+        .flatMap(
+            te ->
+                Stream.concat(
+                    te.getTrackedEntityAttributeValues().stream(),
+                    getEnrollmentAttributeValues(te)))
         .map(TrackedEntityAttributeValue::getAttribute)
         .filter(a -> Boolean.TRUE.equals(a.getSkipSynchronization()))
         .map(BaseIdentifiableObject::getUid)
         .collect(Collectors.toSet());
+  }
+
+  private Stream<TrackedEntityAttributeValue> getEnrollmentAttributeValues(TrackedEntity te) {
+    return te.getEnrollments().stream()
+        .map(org.hisp.dhis.program.Enrollment::getTrackedEntity)
+        .flatMap(t -> t.getTrackedEntityAttributeValues().stream());
   }
 
   private void stripSkipSyncFields(

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerDataSynchronizationServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerDataSynchronizationServiceTest.java
@@ -273,24 +273,8 @@ class TrackerDataSynchronizationServiceTest {
             .getProgramStageDataElementsWithSkipSynchronizationSetToTrue())
         .thenReturn(Map.of("ProgStageAB", Set.of("SkipDataElAB")));
 
-    mockServer
-        .expect(requestTo(Matchers.containsString("/api/system/ping")))
-        .andExpect(method(HttpMethod.GET))
-        .andRespond(withSuccess(PING_RESPONSE, MediaType.TEXT_PLAIN));
-    mockServer
-        .expect(requestTo(Matchers.containsString("importStrategy=CREATE_AND_UPDATE")))
-        .andExpect(method(HttpMethod.POST))
-        .andRespond(respondWith(successReport()));
-
-    ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
-    service.synchronizeTrackerData(100, JobProgress.noop());
-    verify(renderService, times(1)).toJson(any(), bodyCaptor.capture());
-    mockServer.verify();
-
-    Map<?, ?> payload = (Map<?, ?>) bodyCaptor.getValue();
-    List<?> teList = (List<?>) payload.get("trackedEntities");
     org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity teDto =
-        (org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity) teList.get(0);
+        synchronizeAndCaptureCreateAndUpdatePayload();
 
     assertEquals(
         List.of("KeepAttrUAB"),
@@ -305,6 +289,31 @@ class TrackerDataSynchronizationServiceTest {
         dataValues.stream()
             .map(org.hisp.dhis.webapi.controller.tracker.view.DataValue::getDataElement)
             .toList());
+  }
+
+  @Test
+  void shouldStripProgramAttributeSetToSkipSynchronization() throws Exception {
+    TrackedEntity te = buildTeWithEnrollmentContaining("ActEvtUidAB", null);
+
+    TrackedEntityAttribute programSkipAttribute = new TrackedEntityAttribute();
+    programSkipAttribute.setUid("ProgSkipAttAB");
+    programSkipAttribute.setSkipSynchronization(true);
+
+    Enrollment enrollment = te.getEnrollments().iterator().next();
+    TrackedEntity enrollmentTe = new TrackedEntity();
+    enrollmentTe.setUid(te.getUid());
+    enrollmentTe.setTrackedEntityAttributeValues(
+        new LinkedHashSet<>(
+            List.of(
+                new TrackedEntityAttributeValue(programSkipAttribute, enrollmentTe, "skip-me"))));
+    enrollment.setTrackedEntity(enrollmentTe);
+
+    stubTrackedEntityService(te);
+
+    org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity teDto =
+        synchronizeAndCaptureCreateAndUpdatePayload();
+
+    assertEquals(List.of(), teDto.getEnrollments().get(0).getAttributes());
   }
 
   @Test
@@ -527,6 +536,31 @@ class TrackerDataSynchronizationServiceTest {
     ArgumentCaptor<Set<UID>> uidsCaptor = ArgumentCaptor.forClass(Set.class);
     verify(trackedEntityService).updateTrackedEntitiesSyncTimestamp(uidsCaptor.capture(), any());
     assertEquals(Set.of(UID.of("DeletedTeAB")), uidsCaptor.getValue());
+  }
+
+  /**
+   * Runs a create/update-only sync (expecting exactly one tracked entity in the payload) and
+   * returns that entity's mapped view, for tests asserting on stripped/kept fields.
+   */
+  private org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity
+      synchronizeAndCaptureCreateAndUpdatePayload() throws Exception {
+    mockServer
+        .expect(requestTo(Matchers.containsString("/api/system/ping")))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess(PING_RESPONSE, MediaType.TEXT_PLAIN));
+    mockServer
+        .expect(requestTo(Matchers.containsString("importStrategy=CREATE_AND_UPDATE")))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(respondWith(successReport()));
+
+    ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+    service.synchronizeTrackerData(100, JobProgress.noop());
+    verify(renderService, times(1)).toJson(any(), bodyCaptor.capture());
+    mockServer.verify();
+
+    Map<?, ?> payload = (Map<?, ?>) bodyCaptor.getValue();
+    List<?> teList = (List<?>) payload.get("trackedEntities");
+    return (org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity) teList.get(0);
   }
 
   private void expectDeleteBeforeCreateAndUpdate(

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerDataSynchronizationServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerDataSynchronizationServiceTest.java
@@ -66,6 +66,7 @@ import org.hisp.dhis.setting.SystemSettings;
 import org.hisp.dhis.setting.SystemSettingsService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.Page;
@@ -105,6 +106,7 @@ class TrackerDataSynchronizationServiceTest {
               false);
 
   @Mock private TrackedEntityService trackedEntityService;
+  @Mock private TrackedEntityAttributeService trackedEntityAttributeService;
   @Mock private ProgramStageDataElementService programStageDataElementService;
   @Mock private SystemSettingsService systemSettingsService;
   @Mock private RenderService renderService;
@@ -119,6 +121,7 @@ class TrackerDataSynchronizationServiceTest {
     service =
         new TrackerDataSynchronizationService(
             trackedEntityService,
+            trackedEntityAttributeService,
             programStageDataElementService,
             systemSettingsService,
             restTemplate,
@@ -272,6 +275,9 @@ class TrackerDataSynchronizationServiceTest {
     when(programStageDataElementService
             .getProgramStageDataElementsWithSkipSynchronizationSetToTrue())
         .thenReturn(Map.of("ProgStageAB", Set.of("SkipDataElAB")));
+    when(trackedEntityAttributeService
+            .getTrackedEntityAttributeUidsWithSkipSynchronizationSetToTrue())
+        .thenReturn(Set.of("SkipAttrUAB"));
 
     org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity teDto =
         synchronizeAndCaptureCreateAndUpdatePayload();
@@ -309,6 +315,9 @@ class TrackerDataSynchronizationServiceTest {
     enrollment.setTrackedEntity(enrollmentTe);
 
     stubTrackedEntityService(te);
+    when(trackedEntityAttributeService
+            .getTrackedEntityAttributeUidsWithSkipSynchronizationSetToTrue())
+        .thenReturn(Set.of("ProgSkipAttAB"));
 
     org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity teDto =
         synchronizeAndCaptureCreateAndUpdatePayload();
@@ -605,6 +614,9 @@ class TrackerDataSynchronizationServiceTest {
     when(programStageDataElementService
             .getProgramStageDataElementsWithSkipSynchronizationSetToTrue())
         .thenReturn(Map.of());
+    when(trackedEntityAttributeService
+            .getTrackedEntityAttributeUidsWithSkipSynchronizationSetToTrue())
+        .thenReturn(Set.of());
   }
 
   private static String toJson(ImportReport report) {


### PR DESCRIPTION
After the work done on https://github.com/dhis2/dhis2-core/pull/24453, program attributes were still not synchronized to the remote instance. This is addressed and fixed in this PR.

It's also been manually verified running a test against two real instances, where both TET and program attributes are correctly synchronized between the instances.