### PR TITLE
fix: OU groups in event query [DHIS2-21939]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -810,7 +810,7 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
   /** Generates a sub query which provides a filter by organisation descendant level. */
   private String getOrgUnitDescendantsClause(
       OrgUnitField orgUnitField, List<DimensionalItemObject> dimensionOrFilterItems) {
-    Map<String, List<OrganisationUnit>> collect =
+    Map<String, List<OrganisationUnit>> orgUnitsMap =
         dimensionOrFilterItems.stream()
             .map(object -> (OrganisationUnit) object)
             .collect(
@@ -820,9 +820,29 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
                             .withSqlBuilder(sqlBuilder)
                             .getOrgUnitLevelCol(unit.getLevel(), getAnalyticsType())));
 
-    return collect.keySet().stream()
-        .map(org -> toInCondition(org, collect.get(org)))
-        .collect(joining(" and "));
+    return getOuInCondition(orgUnitsMap);
+  }
+
+  /**
+   * Builds a SQL filter clause from a map of org unit level columns to their matching org units.
+   * Each entry produces an {@code IN} condition, and the conditions are joined with {@code OR}.
+   *
+   * <p>Example output for two level groups:
+   *
+   * <pre>
+   * ax."uidlevel2" in ('uid1','uid2') or ax."uidlevel3" in ('uid3')
+   * </pre>
+   *
+   * @param orgUnitsMap a map where each key is a SQL column expression representing an org unit
+   *     level (e.g. {@code ax."uidlevel2"}) and each value is the list of {@link OrganisationUnit}
+   *     objects whose UIDs should appear in the {@code IN} condition for that level.
+   * @return a SQL {@code OR}-joined string of {@code IN} conditions, or an empty string if the map
+   *     is empty.
+   */
+  String getOuInCondition(Map<String, List<OrganisationUnit>> orgUnitsMap) {
+    return orgUnitsMap.keySet().stream()
+        .map(org -> toInCondition(org, orgUnitsMap.get(org)))
+        .collect(joining(" or "));
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManagerTest.java
@@ -32,16 +32,22 @@ package org.hisp.dhis.analytics.event.data;
 import static org.hisp.dhis.analytics.event.data.JdbcEventAnalyticsManager.ExceptionHandler.handle;
 import static org.hisp.dhis.feedback.ErrorCode.E7132;
 import static org.hisp.dhis.feedback.ErrorCode.E7133;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.postgresql.util.PSQLState.BAD_DATETIME_FORMAT;
 import static org.postgresql.util.PSQLState.DIVISION_BY_ZERO;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.hisp.dhis.common.QueryRuntimeException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.junit.jupiter.api.Test;
 import org.postgresql.util.PSQLException;
 import org.springframework.dao.DataIntegrityViolationException;
 
 class JdbcEventAnalyticsManagerTest {
+
   @Test
   void testHandlingDataIntegrityExceptionWhenDivisionByZero() {
     DataIntegrityViolationException aDivisionByZeroException =
@@ -84,6 +90,79 @@ class JdbcEventAnalyticsManagerTest {
 
     assertThrows(
         QueryRuntimeException.class, () -> handle(aNonPSQLExceptionCause), E7133.getMessage());
+  }
+
+  @Test
+  void getOuInConditionEmptyMapReturnsEmptyString() {
+    JdbcEventAnalyticsManager jdbcEventAnalyticsManager = getJdbcEventAnalyticsManager();
+
+    assertEquals("", jdbcEventAnalyticsManager.getOuInCondition(Map.of()));
+  }
+
+  @Test
+  void getOuInConditionSingleLevelSingleUnitReturnsInCondition() {
+    JdbcEventAnalyticsManager jdbcEventAnalyticsManager = getJdbcEventAnalyticsManager();
+
+    OrganisationUnit unit = ouWithUid("uid000001A");
+
+    String result =
+        jdbcEventAnalyticsManager.getOuInCondition(Map.of("ax.\"uidlevel2\"", List.of(unit)));
+
+    assertEquals("ax.\"uidlevel2\" in ('uid000001A') ", result);
+  }
+
+  @Test
+  void getOuInConditionSingleLevelMultipleUnitsCombinesUidsInSingleInClause() {
+    JdbcEventAnalyticsManager jdbcEventAnalyticsManager = getJdbcEventAnalyticsManager();
+
+    OrganisationUnit unitA = ouWithUid("uid000001A");
+    OrganisationUnit unitB = ouWithUid("uid000001B");
+
+    String result =
+        jdbcEventAnalyticsManager.getOuInCondition(
+            Map.of("ax.\"uidlevel3\"", List.of(unitA, unitB)));
+
+    assertEquals("ax.\"uidlevel3\" in ('uid000001A','uid000001B') ", result);
+  }
+
+  @Test
+  void getOuInConditionMultipleLevelsJoinsConditionsWithOr() {
+    JdbcEventAnalyticsManager jdbcEventAnalyticsManager = getJdbcEventAnalyticsManager();
+
+    Map<String, List<OrganisationUnit>> orgUnitsMap = new LinkedHashMap<>();
+    orgUnitsMap.put("ax.\"uidlevel2\"", List.of(ouWithUid("uid000001A")));
+    orgUnitsMap.put("ax.\"uidlevel3\"", List.of(ouWithUid("uid000001B")));
+
+    String result = jdbcEventAnalyticsManager.getOuInCondition(orgUnitsMap);
+
+    assertEquals(
+        "ax.\"uidlevel2\" in ('uid000001A')  or ax.\"uidlevel3\" in ('uid000001B') ", result);
+  }
+
+  @Test
+  void getOuInConditionUnitWithNullUidIsExcluded() {
+    JdbcEventAnalyticsManager jdbcEventAnalyticsManager = getJdbcEventAnalyticsManager();
+    OrganisationUnit organisationUnit = new OrganisationUnit();
+    organisationUnit.setUid(null);
+
+    Map<String, List<OrganisationUnit>> orgUnitsMap =
+        Map.of("ax.\"uidlevel2\"", List.of(ouWithUid("uid000001A"), organisationUnit));
+
+    String result = jdbcEventAnalyticsManager.getOuInCondition(orgUnitsMap);
+
+    assertEquals("ax.\"uidlevel2\" in ('uid000001A') ", result);
+  }
+
+  private OrganisationUnit ouWithUid(String uid) {
+    OrganisationUnit unit = new OrganisationUnit();
+    unit.setUid(uid);
+    return unit;
+  }
+
+  private JdbcEventAnalyticsManager getJdbcEventAnalyticsManager() {
+    return new JdbcEventAnalyticsManager(
+        null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+        null);
   }
 
   private DataIntegrityViolationException mockDataIntegrityExceptionDivisionByZero() {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery7AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery7AutoTest.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.analytics.event.query;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderExistence;
 import static org.hisp.dhis.analytics.ValidationHelper.validateHeaderPropertiesByName;
 import static org.hisp.dhis.analytics.ValidationHelper.validateResponseStructure;
 import static org.hisp.dhis.analytics.ValidationHelper.validateRowValueByName;
@@ -720,7 +721,7 @@ public class EventsQuery7AutoTest extends AnalyticsApiTest {
     validateResponseStructure(
         response,
         expectPostgis,
-        1,
+        100,
         4,
         4); // Pass runtime flag, row count, and expected header counts
 
@@ -774,5 +775,82 @@ public class EventsQuery7AutoTest extends AnalyticsApiTest {
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Ngelehun CHC");
     validateRowValueByName(response, actualHeaders, 0, "p2Zxg0wcPQ3", "0");
+  }
+
+  @Test
+  public void eventsWithOrgUnitGroups() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=false")
+            .add("headers=ouname,lastupdated")
+            .add("lastUpdated=LAST_5_FINANCIAL_YEARS")
+            .add("stage=dBwrot7S420")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("skipMeta=true")
+            .add("pageSize=100")
+            .add("outputType=EVENT")
+            .add("page=1")
+            .add(
+                "dimension=ou:USER_ORGUNIT;OU_GROUP-uYxK4wmcPqA;OU_GROUP-RpbiCJpIYEj;OU_GROUP-CXw2yu5fodb;OU_GROUP-f25dqv3Y7Z0;OU_GROUP-tDZVQ1WtwpA")
+            .add("relativePeriodDate=2026-08-06");
+
+    // When
+    ApiResponse response = actions.query().get("lxAQ7Zs9VYR", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response, false, 3, 2, 2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
+
+    // Assert PostGIS-specific headers existence based on 'expectPostgis' flag
+    validateHeaderExistence(actualHeaders, "geometry", false);
+    validateHeaderExistence(actualHeaders, "longitude", false);
+    validateHeaderExistence(actualHeaders, "latitude", false);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "ouname", "Ngelehun CHC");
+    validateRowValueByName(response, actualHeaders, 0, "lastupdated", "2018-04-12 16:05:16.957");
+
+    // Validate selected values for row index 2
+    validateRowValueByName(response, actualHeaders, 2, "ouname", "Ngelehun CHC");
+    validateRowValueByName(response, actualHeaders, 2, "lastupdated", "2018-04-12 16:05:41.933");
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery7AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery7AutoTest.java
@@ -708,6 +708,7 @@ public class EventsQuery7AutoTest extends AnalyticsApiTest {
             .add("pageSize=100")
             .add("outputType=EVENT")
             .add("page=1")
+            .add("desc=lastupdated")
             .add(
                 "dimension=GxdhnY5wmHq,ou:USER_ORGUNIT;LEVEL-wjP19dkFeIk;LEVEL-tTUf91fCytl;LEVEL-m9lBJogzE95,p2Zxg0wcPQ3");
 
@@ -790,6 +791,7 @@ public class EventsQuery7AutoTest extends AnalyticsApiTest {
             .add("totalPages=false")
             .add("skipMeta=true")
             .add("pageSize=100")
+            .add("desc=lastupdated")
             .add("outputType=EVENT")
             .add("page=1")
             .add(
@@ -847,10 +849,10 @@ public class EventsQuery7AutoTest extends AnalyticsApiTest {
     // 7. Assert row values by name at specific indices (sorted results).
     // Validate selected values for row index 0
     validateRowValueByName(response, actualHeaders, 0, "ouname", "Ngelehun CHC");
-    validateRowValueByName(response, actualHeaders, 0, "lastupdated", "2018-04-12 16:05:16.957");
+    validateRowValueByName(response, actualHeaders, 0, "lastupdated", "2018-04-12 16:05:41.933");
 
     // Validate selected values for row index 2
     validateRowValueByName(response, actualHeaders, 2, "ouname", "Ngelehun CHC");
-    validateRowValueByName(response, actualHeaders, 2, "lastupdated", "2018-04-12 16:05:41.933");
+    validateRowValueByName(response, actualHeaders, 2, "lastupdated", "2018-04-12 16:05:16.957");
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/event-query.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/event-query.json
@@ -331,7 +331,7 @@
     },
     {
       "name": "ouMultipleLevels",
-      "query": "/api/analytics/events/query/IpHINAT79UW.json?dimension=GxdhnY5wmHq,ou:USER_ORGUNIT;LEVEL-wjP19dkFeIk;LEVEL-tTUf91fCytl;LEVEL-m9lBJogzE95,p2Zxg0wcPQ3&headers=ouname,lastupdated,GxdhnY5wmHq,p2Zxg0wcPQ3&totalPages=false&lastUpdated=201707&displayProperty=NAME&pageSize=100&page=1&includeMetadataDetails=true&outputType=EVENT&stage=ZzYYXq4fJie",
+      "query": "/api/analytics/events/query/IpHINAT79UW.json?dimension=GxdhnY5wmHq,ou:USER_ORGUNIT;LEVEL-wjP19dkFeIk;LEVEL-tTUf91fCytl;LEVEL-m9lBJogzE95,p2Zxg0wcPQ3&headers=ouname,lastupdated,GxdhnY5wmHq,p2Zxg0wcPQ3&totalPages=false&lastUpdated=201707&displayProperty=NAME&pageSize=100&page=1&includeMetadataDetails=true&outputType=EVENT&stage=ZzYYXq4fJie&desc=lastupdated",
       "version": {
         "min": 41
       }
@@ -345,7 +345,7 @@
     },
     {
       "name": "eventsWithOrgUnitGroups",
-      "query": "/api/analytics/events/query/lxAQ7Zs9VYR.json?dimension=ou:USER_ORGUNIT;OU_GROUP-uYxK4wmcPqA;OU_GROUP-RpbiCJpIYEj;OU_GROUP-CXw2yu5fodb;OU_GROUP-f25dqv3Y7Z0;OU_GROUP-tDZVQ1WtwpA&skipMeta=true&headers=ouname,lastupdated&totalPages=false&lastUpdated=LAST_5_FINANCIAL_YEARS&displayProperty=NAME&pageSize=100&page=1&includeMetadataDetails=false&outputType=EVENT&stage=dBwrot7S420&relativePeriodDate=2026-08-06",
+      "query": "/api/analytics/events/query/lxAQ7Zs9VYR.json?dimension=ou:USER_ORGUNIT;OU_GROUP-uYxK4wmcPqA;OU_GROUP-RpbiCJpIYEj;OU_GROUP-CXw2yu5fodb;OU_GROUP-f25dqv3Y7Z0;OU_GROUP-tDZVQ1WtwpA&skipMeta=true&headers=ouname,lastupdated&totalPages=false&lastUpdated=LAST_5_FINANCIAL_YEARS&displayProperty=NAME&pageSize=100&page=1&includeMetadataDetails=false&outputType=EVENT&stage=dBwrot7S420&relativePeriodDate=2026-08-06&desc=lastupdated",
       "version": {
         "min": 41
       }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/event-query.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/event-query.json
@@ -342,6 +342,13 @@
       "version": {
         "min": 43
       }
+    },
+    {
+      "name": "eventsWithOrgUnitGroups",
+      "query": "/api/analytics/events/query/lxAQ7Zs9VYR.json?dimension=ou:USER_ORGUNIT;OU_GROUP-uYxK4wmcPqA;OU_GROUP-RpbiCJpIYEj;OU_GROUP-CXw2yu5fodb;OU_GROUP-f25dqv3Y7Z0;OU_GROUP-tDZVQ1WtwpA&skipMeta=true&headers=ouname,lastupdated&totalPages=false&lastUpdated=LAST_5_FINANCIAL_YEARS&displayProperty=NAME&pageSize=100&page=1&includeMetadataDetails=false&outputType=EVENT&stage=dBwrot7S420&relativePeriodDate=2026-08-06",
+      "version": {
+        "min": 41
+      }
     }
   ]
 }


### PR DESCRIPTION
Currently, the Analytics code related to the events query flow uses `AND` condition in order to build OU statements.
Analytics enrollments and tracker uses `OR`, condition which makes more sense in such kind of queries.

This PR switches the logic, so events query will also use the `OR` operator.
