### PR TITLE
perf: stream the XLSX grid export instead of assembling it in heap [DHIS2-21947] (2.42)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
@@ -75,6 +75,7 @@ import org.apache.poi.ss.usermodel.Font;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.velocity.VelocityContext;
 import org.hisp.dhis.common.DimensionalItemObject;
@@ -119,6 +120,13 @@ public class GridUtils {
   private static final String XLS_SHEET_PREFIX = "Sheet ";
 
   private static final int JXL_MAX_COLS = 256;
+
+  /**
+   * How many rows a streamed XLSX keeps in memory before flushing. POI's own default is 100; 1 000
+   * trades a little memory for far fewer flushes, and at the widths analytics grids reach it is
+   * still a fixed cost rather than one that grows with the export.
+   */
+  private static final int XLSX_ROW_WINDOW = 1000;
 
   private static final String FONT_ARIAL = "Arial";
 
@@ -298,9 +306,32 @@ public class GridUtils {
     toWorkbook(new HSSFWorkbook(), grid, out);
   }
 
-  /** Writes a XLSX (Excel workbook) representation of the given Grid to the given OutputStream. */
+  /**
+   * Writes a XLSX (Excel workbook) representation of the given Grid to the given OutputStream.
+   *
+   * <p>Streamed rather than assembled. A plain {@link XSSFWorkbook} keeps every {@code Cell} object
+   * alive until {@code write}, which on Uganda's 100 001-row line-list export was 19.9% of the
+   * request's CPU and a large share of the 132 GB it allocated; isolating it against the same query
+   * exported as XML put spreadsheet serialisation alone at ~37 s. {@link SXSSFWorkbook} keeps only
+   * {@link #XLSX_ROW_WINDOW} rows in memory and spills the rest, so peak memory is a function of
+   * the row width rather than of the result size.
+   *
+   * <p>Nothing in this path reads a row back after writing it, which is the one thing the streaming
+   * API cannot do. {@code toXls} is left on {@link org.apache.poi.hssf.usermodel.HSSFWorkbook}: the
+   * streaming API is XSSF-only, and the legacy format's own 65 536-row ceiling makes it moot.
+   */
   public static void toXlsx(Grid grid, OutputStream out) throws IOException {
-    toWorkbook(new XSSFWorkbook(), grid, out);
+    SXSSFWorkbook workbook = new SXSSFWorkbook(XLSX_ROW_WINDOW);
+    workbook.setCompressTempFiles(true);
+
+    try {
+      toWorkbook(workbook, grid, out);
+    } finally {
+      // The spilled rows are real files in the JVM's temp directory. toWorkbook closes the workbook
+      // on the happy path, but a failure part-way through a write must not leave them behind: on a
+      // server exporting hundred-thousand-row grids that fills a disk.
+      workbook.dispose();
+    }
   }
 
   /**

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/grid/GridUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/grid/GridUtilsTest.java
@@ -32,17 +32,29 @@ package org.hisp.dhis.system.grid;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Lists;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.junit.jupiter.api.Test;
@@ -111,5 +123,112 @@ class GridUtilsTest {
     grid.setTitle("Grid");
     OutputStream outputStream = new ByteArrayOutputStream();
     assertDoesNotThrow(() -> GridUtils.toXlsx(grid, outputStream));
+  }
+
+  /**
+   * toXlsx streams through an SXSSFWorkbook, which keeps only a window of rows in memory.
+   * Everything about the workbook it produces has to stay as it was: this reads the bytes back and
+   * pins the sheet name, the title and subtitle rows, the header row, and - the part a streaming
+   * rewrite is most likely to lose - the cell types and the two distinct number formats, integer
+   * against decimal.
+   */
+  @Test
+  void testToXlsxProducesTheSameWorkbookAsBefore() throws Exception {
+    Grid grid = new ListGrid();
+    grid.setTitle("My title");
+    grid.setSubtitle("My subtitle");
+    grid.addHeader(new GridHeader("colA", "Column A"));
+    grid.addHeader(new GridHeader("colB", "Column B"));
+    grid.addHeader(new GridHeader("colC", "Column C"));
+
+    // More rows than the in-memory window, so at least one flush happens before the write.
+    int rows = 2500;
+    for (int i = 0; i < rows; i++) {
+      grid.addRow();
+      grid.addValue("text " + i);
+      grid.addValue(Integer.valueOf(i));
+      grid.addValue(Double.valueOf(i + 0.5));
+    }
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    GridUtils.toXlsx(grid, out);
+
+    try (Workbook workbook = new XSSFWorkbook(new ByteArrayInputStream(out.toByteArray()))) {
+      Sheet sheet = workbook.getSheetAt(0);
+      assertEquals("My title", workbook.getSheetName(0));
+
+      assertEquals("My title", sheet.getRow(0).getCell(0).getStringCellValue());
+      assertEquals("My subtitle", sheet.getRow(2).getCell(0).getStringCellValue());
+
+      Row headerRow = sheet.getRow(4);
+      assertEquals("Column A", headerRow.getCell(0).getStringCellValue());
+      assertEquals("Column B", headerRow.getCell(1).getStringCellValue());
+      assertEquals("Column C", headerRow.getCell(2).getStringCellValue());
+
+      Row firstDataRow = sheet.getRow(5);
+      assertEquals(CellType.STRING, firstDataRow.getCell(0).getCellType());
+      assertEquals(CellType.NUMERIC, firstDataRow.getCell(1).getCellType());
+      assertEquals(CellType.NUMERIC, firstDataRow.getCell(2).getCellType());
+      assertEquals("text 0", firstDataRow.getCell(0).getStringCellValue());
+      assertEquals(0d, firstDataRow.getCell(1).getNumericCellValue());
+      assertEquals(0.5d, firstDataRow.getCell(2).getNumericCellValue());
+
+      // The integer column carries the built-in #,##0 format; the decimal column does not.
+      assertEquals("#,##0", firstDataRow.getCell(1).getCellStyle().getDataFormatString());
+      assertEquals("#.##########", firstDataRow.getCell(2).getCellStyle().getDataFormatString());
+
+      // Every row survived the flushing, including the last one.
+      Row lastDataRow = sheet.getRow(4 + rows);
+      assertEquals("text " + (rows - 1), lastDataRow.getCell(0).getStringCellValue());
+      assertEquals(rows - 1, (int) lastDataRow.getCell(1).getNumericCellValue());
+      assertEquals(4 + rows, sheet.getLastRowNum());
+    }
+  }
+
+  /**
+   * A failing write must not leave the spilled rows behind: on a server exporting grids this size
+   * that fills a disk.
+   */
+  @Test
+  void testTemporaryFilesAreRemovedWhenTheWriteFails() throws Exception {
+    Grid grid = new ListGrid();
+    grid.setTitle("Grid");
+    grid.addHeader(new GridHeader("colA", "Column A"));
+    for (int i = 0; i < 2500; i++) {
+      grid.addRow();
+      grid.addValue("text " + i);
+    }
+
+    long before = spilledSheetCount();
+
+    assertThrows(
+        IOException.class,
+        () ->
+            GridUtils.toXlsx(
+                grid,
+                new OutputStream() {
+                  @Override
+                  public void write(int b) throws IOException {
+                    throw new IOException("the client went away");
+                  }
+                }));
+
+    // POI creates this directory the first time it spills a sheet. If it is missing, the export
+    // never streamed at all and the count below would be vacuously right.
+    assertTrue(Files.isDirectory(POI_TEMP_DIRECTORY), POI_TEMP_DIRECTORY + " should exist");
+    assertEquals(before, spilledSheetCount());
+  }
+
+  /** Where POI's DefaultTempFileCreationStrategy puts the rows an SXSSFWorkbook has flushed. */
+  private static final Path POI_TEMP_DIRECTORY =
+      Path.of(System.getProperty("java.io.tmpdir"), "poifiles");
+
+  private static long spilledSheetCount() throws IOException {
+    if (!Files.isDirectory(POI_TEMP_DIRECTORY)) {
+      return 0;
+    }
+    try (var paths = Files.list(POI_TEMP_DIRECTORY)) {
+      return paths.filter(p -> p.getFileName().toString().startsWith("poi-sxssf-sheet")).count();
+    }
   }
 }


### PR DESCRIPTION
Backport of the master PR for [DHIS2-21947] to 2.42. Cherry-pick of `6c583cdf997e8c7fd65ded8feb913606d9cead81`. Clean cherry-pick, no adaptation.

`GridUtils.toXlsx` built the whole workbook as live POI objects before writing a byte — 19.9% of the request's CPU on a 100 001-row line-list export, and a large share of the 132 GB it allocated. It now writes through an `SXSSFWorkbook` with a 1 000-row window, so peak memory is a function of the row width rather than of the result size, and `dispose()` runs in a `finally` so a write that fails part-way does not leave the spilled rows on disk. `toXls` stays on `HSSFWorkbook` — the streaming API is XSSF-only.

Measured over a 20-column grid: 25 000 rows go from 15 680 ms / 1 165 MB peak heap to 3 514 ms / 207 MB, and 50 000 and 100 000 rows complete at 93 MB and 410 MB where the old path was OOM-killed.

AI Assisted

[DHIS2-21947]: https://dhis2.atlassian.net/browse/DHIS2-21947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ