### PR TITLE
perf: parse the enrollments document once per row, not once per column [DHIS2-21948]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/query/jsonextractor/SqlRowSetJsonExtractorDelegator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/query/jsonextractor/SqlRowSetJsonExtractorDelegator.java
@@ -92,9 +92,40 @@ public class SqlRowSetJsonExtractorDelegator extends SqlRowSetDelegator {
     OBJECT_MAPPER.findAndRegisterModules();
   }
 
+  /** Package-private so that a test can count how often the document is actually parsed. */
   @SneakyThrows
-  private List<JsonEnrollment> parseEnrollmentsFromJson(String json) {
+  List<JsonEnrollment> parseEnrollmentsFromJson(String json) {
     return OBJECT_MAPPER.readValue(json, new TypeReference<>() {});
+  }
+
+  /**
+   * Returns the parsed {@code enrollments} document for the row the cursor is on, parsing it at
+   * most once per row.
+   *
+   * <p>Every requested column used to trigger its own {@code readValue} of the whole document, from
+   * two independent call sites ({@link #getObject(String)} and {@link #getRowContextItem(String,
+   * int)}), so a line list with ten data-element dimensions parsed the same string around twenty
+   * times per row.
+   *
+   * <p>The memo is keyed on the document itself rather than on the cursor position, which is what
+   * makes a stale hit impossible rather than merely unlikely: a hit requires the current row's
+   * document to be equal to the memoised one, and equal input cannot produce a different parse
+   * result. {@link String#equals} short-circuits on identity, which is the case a forward cursor
+   * hits on every column after the first.
+   *
+   * <p>The returned list is shared between the callers within a row. Nothing downstream mutates it
+   * - the extractors only stream over it, and {@code getItemBasedOnOffset} sorts the stream, not
+   * the source.
+   */
+  private List<JsonEnrollment> getEnrollments() {
+    String json = super.getString("enrollments");
+
+    if (memoisedEnrollments == null || !Objects.equals(memoisedJson, json)) {
+      memoisedEnrollments = parseEnrollmentsFromJson(json);
+      memoisedJson = json;
+    }
+
+    return memoisedEnrollments;
   }
 
   private static final Comparator<JsonEnrollment> ENR_ENROLLMENT_DATE_COMPARATOR =
@@ -106,6 +137,14 @@ public class SqlRowSetJsonExtractorDelegator extends SqlRowSetDelegator {
   private final transient Map<String, DimensionIdentifier<DimensionParam>> dimIdByKey;
 
   private final List<String> existingColumnsInRowSet;
+
+  /**
+   * The {@code enrollments} document of the row the cursor is on, and its parse. Per-instance state
+   * on a per-request object; this class is not shared between threads and must not become so.
+   */
+  private String memoisedJson;
+
+  private List<JsonEnrollment> memoisedEnrollments;
 
   public SqlRowSetJsonExtractorDelegator(
       SqlRowSet sqlRowSet, List<DimensionIdentifier<DimensionParam>> dimensionIdentifiers) {
@@ -179,7 +218,7 @@ public class SqlRowSetJsonExtractorDelegator extends SqlRowSetDelegator {
       return super.getObject(canonicalLabel);
     }
     // if the column is not present in the rowset, we check if it is present in the json string
-    List<JsonEnrollment> enrollments = parseEnrollmentsFromJson(super.getString("enrollments"));
+    List<JsonEnrollment> enrollments = getEnrollments();
 
     DimensionIdentifier<DimensionParam> dimensionIdentifier = dimIdByKey.get(canonicalLabel);
     if (dimensionIdentifier == null) {
@@ -350,8 +389,7 @@ public class SqlRowSetJsonExtractorDelegator extends SqlRowSetDelegator {
     }
 
     JsonEvent event =
-        getJsonEnrollment(
-                parseEnrollmentsFromJson(super.getString("enrollments")), dimensionIdentifier)
+        getJsonEnrollment(getEnrollments(), dimensionIdentifier)
             .map(jEnr -> getJsonEvent(dimensionIdentifier, jEnr))
             .orElse(null);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/query/jsonextractor/SqlRowSetJsonExtractorDelegatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/query/jsonextractor/SqlRowSetJsonExtractorDelegatorTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.common.query.jsonextractor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParamType;
+import org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset;
+import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.ValueStatus;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+import org.springframework.jdbc.support.rowset.SqlRowSetMetaData;
+
+/**
+ * The point of these tests is the parse count. {@code TrackedEntityListGrid.addNamedRows} asks this
+ * delegator for a value and for a row-context item once per requested column, inside a loop over
+ * rows, and each of those used to deserialise the whole {@code enrollments} document again - around
+ * twenty parses per row on the export UGANDA-10 traced, 46.8% of that request's CPU.
+ */
+class SqlRowSetJsonExtractorDelegatorTest {
+
+  private static final String PROGRAM_UID = "PrOgRaM0001";
+  private static final String STAGE_UID = "StAgE000001";
+  private static final String DE_A_UID = "DaTaEleMnTA";
+  private static final String DE_B_UID = "DaTaEleMnTB";
+
+  /** One enrolment, one event, values for A but not for B. */
+  private static String enrollments(String valueOfA) {
+    return "[{\"programUid\":\""
+        + PROGRAM_UID
+        + "\",\"enrollmentUid\":\"EnRoLmEnT01\",\"enrollmentDate\":\"2026-07-01T00:00:00\","
+        + "\"events\":[{\"programStageUid\":\""
+        + STAGE_UID
+        + "\",\"eventUid\":\"EvEnT000001\",\"occurredDate\":\"2026-07-02T00:00:00\","
+        + "\"eventStatus\":\"ACTIVE\",\"eventDataValues\":{\""
+        + DE_A_UID
+        + "\":{\"value\":\""
+        + valueOfA
+        + "\"}}}]}]";
+  }
+
+  @Test
+  void testEnrollmentsJsonIsParsedOncePerRowNoMatterHowManyColumnsAreRead() {
+    List<DimensionIdentifier<DimensionParam>> dimensions =
+        List.of(dimension(DE_A_UID), dimension(DE_B_UID));
+    SqlRowSetJsonExtractorDelegator delegator = spy(delegator(dimensions, enrollments("11")));
+
+    for (DimensionIdentifier<DimensionParam> dimension : dimensions) {
+      delegator.getObject(dimension.getKey());
+      delegator.getRowContextItem(dimension.getKey(), 0);
+    }
+
+    // Four accesses over two columns; before this was memoised, four parses.
+    verify(delegator, times(1)).parseEnrollmentsFromJson(anyString());
+  }
+
+  @Test
+  void testMemoIsNotReusedWhenTheCursorMovesToARowWithADifferentDocument() {
+    List<DimensionIdentifier<DimensionParam>> dimensions = List.of(dimension(DE_A_UID));
+    SqlRowSet rowSet = rowSet();
+    when(rowSet.getString("enrollments")).thenReturn(enrollments("11"), enrollments("22"));
+
+    SqlRowSetJsonExtractorDelegator delegator =
+        spy(new SqlRowSetJsonExtractorDelegator(rowSet, dimensions));
+
+    assertEquals("11", delegator.getObject(dimensions.get(0).getKey()));
+    assertEquals("22", delegator.getObject(dimensions.get(0).getKey()));
+
+    verify(delegator, times(2)).parseEnrollmentsFromJson(anyString());
+  }
+
+  @Test
+  void testValuesAndRowContextStatusesAreUnchangedByTheMemo() {
+    DimensionIdentifier<DimensionParam> withValue = dimension(DE_A_UID);
+    DimensionIdentifier<DimensionParam> withoutValue = dimension(DE_B_UID);
+    SqlRowSetJsonExtractorDelegator delegator =
+        delegator(List.of(withValue, withoutValue), enrollments("11"));
+
+    assertEquals("11", delegator.getObject(withValue.getKey()));
+    assertNull(delegator.getObject(withoutValue.getKey()));
+
+    // The stage is defined and the event exists, so the column that has a value is SET and
+    // therefore reported as nothing at all; the one without a value is NOT_SET.
+    assertTrue(delegator.getRowContextItem(withValue.getKey(), 0).isEmpty());
+    assertEquals(
+        Map.of("0", Map.of("valueStatus", ValueStatus.NOT_SET.getValue())),
+        delegator.getRowContextItem(withoutValue.getKey(), 0));
+  }
+
+  private static SqlRowSetJsonExtractorDelegator delegator(
+      List<DimensionIdentifier<DimensionParam>> dimensions, String json) {
+    SqlRowSet rowSet = rowSet();
+    when(rowSet.getString("enrollments")).thenReturn(json);
+    return new SqlRowSetJsonExtractorDelegator(rowSet, dimensions);
+  }
+
+  private static SqlRowSet rowSet() {
+    SqlRowSet rowSet = mock(SqlRowSet.class);
+    SqlRowSetMetaData metaData = mock(SqlRowSetMetaData.class);
+    when(metaData.getColumnNames()).thenReturn(new String[] {"enrollments"});
+    when(rowSet.getMetaData()).thenReturn(metaData);
+    return rowSet;
+  }
+
+  private static DimensionIdentifier<DimensionParam> dimension(String dataElementUid) {
+    Program program = new Program();
+    program.setUid(PROGRAM_UID);
+    ProgramStage programStage = new ProgramStage();
+    programStage.setUid(STAGE_UID);
+
+    DataElement dataElement = new DataElement();
+    dataElement.setUid(dataElementUid);
+    dataElement.setValueType(ValueType.TEXT);
+
+    DimensionParam dimensionParam =
+        DimensionParam.ofObject(
+            new QueryItem(dataElement), DimensionParamType.DIMENSIONS, IdScheme.UID, List.of());
+
+    return DimensionIdentifier.of(
+        ElementWithOffset.of(program), ElementWithOffset.of(programStage), dimensionParam);
+  }
+}


### PR DESCRIPTION
## Summary

`SqlRowSetJsonExtractorDelegator` deserialised the whole `enrollments` JSON document on **every single column access**, from two independent call sites — `getObject` and `getRowContextItem` — both of which took `super.getString("enrollments")` and handed it to a fresh `ObjectMapper.readValue`. `TrackedEntityListGrid.addNamedRows` loops columns inside a loop over rows, so the count was rows × columns × 2: roughly two million parses on the `trackedEntities/query` export that was traced, and **46.8% of that request's CPU**. The near-even 186/190 split of profile samples between the two call sites is what showed nothing was memoised.

## Changes

- The document is now parsed at most once per row. The memo is keyed on the document itself rather than on the cursor position, which is what makes a stale hit impossible rather than merely unlikely: a hit requires the current row's document to equal the memoised one, and equal input cannot parse to a different result. `String.equals` short-circuits on identity, and the identity case is the one that actually happens — `ResultSetWrappingSqlRowSet` returns the same `String` instance for repeated reads of a row, which the benchmark asserts rather than assumes.
- The state added is per-instance on a per-request object. This class is not shared between threads and must not become so; there is a comment on the fields saying so.
- `parseEnrollmentsFromJson` becomes package-private so the test can count how often the document is actually parsed.

## Measured

Over the real row-set path (`jdbcTemplate.queryForRowSet` against Postgres), 50 000 rows × 10 program-stage data-element dimensions = 1 000 000 accesses, three passes after a warm-up:

| | cpu | allocated |
|---|---|---|
| before | 9425 / 9804 / 9408 ms | 19 239 MB |
| after | 957 / 1145 / 1134 ms | 2 704 MB |

**8.6x less CPU, 7.1x less allocation**, and the same values out of the grid — byte-identical checksum over every value and row-context item.

The new test asserts the parse count, not the wall time: four accesses over two columns must produce exactly one parse, a second row with a different document must re-parse, and the values and rowContext value statuses are pinned.

Developed and measured on a `2.42.5.1` production branch (dhis2/dhis2-core#24740) and ported here.

AI Assisted