### PR TITLE
perf: count rows instead of distinct primary keys in the dataSummary counts [DHIS2-21949]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -624,7 +624,7 @@ public class HibernateIdentifiableObjectStore<T extends IdentifiableObject>
             .addPredicates(getSharingPredicates(builder))
             .addPredicate(
                 root -> builder.greaterThanOrEqualTo(root.get("lastUpdated"), lastUpdated))
-            .count(root -> builder.countDistinct(root.get("id")));
+            .count(root -> builder.count(builder.literal(1)));
 
     return getCount(builder, param).intValue();
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataelement/DataElementStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataelement/DataElementStoreTest.java
@@ -341,6 +341,20 @@ class DataElementStoreTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void testGetCountGeLastUpdatedCountsEveryMatchingObject() {
+    Date before = new Date(0L);
+
+    for (char c : new char[] {'A', 'B', 'C', 'D', 'E'}) {
+      DataElement dataElement = createDataElement(c);
+      dataElement.setDescription("identical in every non-key column");
+      dataElementStore.save(dataElement);
+    }
+
+    assertEquals(5, dataElementStore.getCountGeLastUpdated(before));
+    assertEquals(dataElementStore.getCount(), dataElementStore.getCountGeLastUpdated(before));
+  }
+
+  @Test
   void testExistsByUser() {
     User userA = createAndAddUser("userA");
     User userB = getAdminUser();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueServiceTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -572,6 +573,27 @@ class DataValueServiceTest extends PostgresIntegrationTestBase {
         3, dataValueService.getDataValueCountLastUpdatedBetween(getDate(1970, 1, 1), null, true));
     assertEquals(
         1, dataValueService.getDataValueCountLastUpdatedBetween(getDate(1970, 1, 1), null, false));
+  }
+
+  @Test
+  void testGetDataValueCountCountsRowsDifferingOnlyInKeyColumns() {
+    DataValue reference = new DataValue(deA, peA, ouA, optionCombo, optionCombo, "42");
+    DataValue differingOnlyInOrgUnit = new DataValue(deA, peA, ouB, optionCombo, optionCombo, "42");
+    DataValue differingOnlyInDataElement =
+        new DataValue(deB, peA, ouA, optionCombo, optionCombo, "42");
+    DataValue differingOnlyInPeriod = new DataValue(deA, peC, ouA, optionCombo, optionCombo, "42");
+
+    for (DataValue dataValue :
+        List.of(
+            reference, differingOnlyInOrgUnit, differingOnlyInDataElement, differingOnlyInPeriod)) {
+      dataValue.setStoredBy("thesameuser");
+      dataValue.setComment("the same comment");
+    }
+    addDataValues(
+        reference, differingOnlyInOrgUnit, differingOnlyInDataElement, differingOnlyInPeriod);
+
+    assertEquals(
+        4, dataValueService.getDataValueCountLastUpdatedBetween(getDate(1970, 1, 1), null, false));
   }
 
   @Test


### PR DESCRIPTION
## Summary

`HibernateIdentifiableObjectStore.getCountGeLastUpdated` applies `DISTINCT` to a primary key. The key is unique, so the de-duplication cannot change the result, but the database still has to materialise and de-duplicate every matching row.

`GET /api/dataSummary` calls it four times over the `Event` type (days 0/1/7/30). On a production instance those four statements alone were **18.3 s of a 24.9 s request** that spent 99.9% of its wall time in JDBC and allocated under 1 MB — all of the cost was the database de-duplicating rows by a key that is already unique. The 20 plain `count(*)` statements in the same response cost 55 ms combined.

```
select count(distinct event0_.eventid) as col_0_0_ from event event0_ where event0_.lastUpdated>=?
```

## Changes

- `getCountGeLastUpdated`: `countDistinct(root.get("id"))` → `count(builder.literal(1))`.
- The sibling count in `HibernateDataValueStore` had the same defect and was **already fixed upstream in #23983**, so it is untouched here.
- A regression test for each count — the kind that a `DISTINCT` over the key would still pass, but a genuinely wrong de-duplication would not. `DataElementStoreTest` adds five data elements identical in every non-key column and asserts the count is five, and that it equals `getCount()`. `DataValueServiceTest` adds four data values that differ only in their key columns, with the same `storedBy` and comment, and asserts the count is four.

## Measured

On 3 000 000 events over a 30-day window, the count drops from **3579 ms to 295 ms**, and a 505 MB temporary sort disappears.

Developed and measured on a `2.42.5.1` production branch (dhis2/dhis2-core#24739) and ported here.

AI Assisted