### PR TITLE
perf: count rows instead of distinct primary keys in the dataSummary counts [DHIS2-21949] (2.42)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -618,7 +618,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
             .addPredicates(getSharingPredicates(builder))
             .addPredicate(
                 root -> builder.greaterThanOrEqualTo(root.get("lastUpdated"), lastUpdated))
-            .count(root -> builder.countDistinct(root.get("id")));
+            .count(root -> builder.count(builder.literal(1)));
 
     return getCount(builder, param).intValue();
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataelement/DataElementStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataelement/DataElementStoreTest.java
@@ -341,6 +341,20 @@ class DataElementStoreTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void testGetCountGeLastUpdatedCountsEveryMatchingObject() {
+    Date before = new Date(0L);
+
+    for (char c : new char[] {'A', 'B', 'C', 'D', 'E'}) {
+      DataElement dataElement = createDataElement(c);
+      dataElement.setDescription("identical in every non-key column");
+      dataElementStore.save(dataElement);
+    }
+
+    assertEquals(5, dataElementStore.getCountGeLastUpdated(before));
+    assertEquals(dataElementStore.getCount(), dataElementStore.getCountGeLastUpdated(before));
+  }
+
+  @Test
   void testExistsByUser() {
     User userA = createAndAddUser("userA");
     User userB = getAdminUser();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueServiceTest.java
@@ -545,6 +545,26 @@ class DataValueServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void testGetDataValueCountCountsRowsDifferingOnlyInKeyColumns() {
+    DataValue reference = new DataValue(deA, peA, ouA, optionCombo, optionCombo, "42");
+    DataValue differingOnlyInOrgUnit = new DataValue(deA, peA, ouB, optionCombo, optionCombo, "42");
+    DataValue differingOnlyInDataElement =
+        new DataValue(deB, peA, ouA, optionCombo, optionCombo, "42");
+    DataValue differingOnlyInPeriod = new DataValue(deA, peC, ouA, optionCombo, optionCombo, "42");
+
+    for (DataValue dataValue :
+        List.of(
+            reference, differingOnlyInOrgUnit, differingOnlyInDataElement, differingOnlyInPeriod)) {
+      dataValue.setStoredBy("thesameuser");
+      dataValue.setComment("the same comment");
+      dataValueService.addDataValue(dataValue);
+    }
+
+    assertEquals(
+        4, dataValueService.getDataValueCountLastUpdatedBetween(getDate(1970, 1, 1), null, false));
+  }
+
+  @Test
   void testVAlidateMissingDataElement() {
     assertIllegalQueryEx(
         assertThrows(


### PR DESCRIPTION
Backport of the master PR for [DHIS2-21949] to 2.42. Cherry-pick of `f90e3e68df2c91d3f3dbdc6d35e769a6c3a69f36`. Adapted: the `HibernateDataValueStore` half of the original commit is dropped, because #23983 already fixed that count on this branch; only `HibernateIdentifiableObjectStore` changes. Both tests apply unchanged.

`HibernateIdentifiableObjectStore.getCountGeLastUpdated` applies `DISTINCT` to a primary key. The key is unique, so the de-duplication cannot change the result, but the database still has to materialise and de-duplicate every matching row. `GET /api/dataSummary` calls it four times over the `Event` type, and on a production instance those four statements alone were 18.3 s of a 24.9 s request that was 99.9% JDBC.

The sibling count in `HibernateDataValueStore` had the same defect and is already fixed on this branch by #23983, so it is untouched here. Both counts get a regression test.

On 3 000 000 events over a 30-day window the count drops from **3579 ms to 295 ms**, and a 505 MB temporary sort disappears.

AI Assisted

[DHIS2-21949]: https://dhis2.atlassian.net/browse/DHIS2-21949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ