### PR TITLE
perf: suppress auto-flush over the dataValueSets import's read-only span [DHIS2-21950] (2.42)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -37,6 +37,8 @@ import static org.hisp.dhis.system.util.ValidationUtils.dataValueIsZeroAndInsign
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.FlushModeType;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
@@ -167,6 +169,8 @@ public class DefaultDataValueSetService implements DataValueSetService {
   private final ObjectMapper jsonMapper;
 
   private final DataValueSetImportValidator importValidator;
+
+  private final EntityManager entityManager;
 
   private final SchemaService schemaService;
 
@@ -775,19 +779,35 @@ public class DefaultDataValueSetService implements DataValueSetService {
       Date now,
       int index,
       DataValueEntry dataValue) {
-    ImportContext.DataValueContext valueContext =
-        createDataValueContext(index, dataValue, context, dataSetContext);
+    // Metadata resolution, cache preheating and validation only read. Under the default
+    // FlushModeType.AUTO every query they issue makes Hibernate dirty-check the entire persistence
+    // context first, and that context grows for the whole import (one session, one transaction), so
+    // the cost per value rises with the values already processed. Suppressing the flush over this
+    // read-only span removes that quadratic without changing what any query returns: nothing here
+    // writes through Hibernate, so there is never a pending change for a flush to make visible.
+    // The window closes before the first write below.
+    ImportContext.DataValueContext valueContext;
+    boolean skip;
+    FlushModeType previousFlushMode = entityManager.getFlushMode();
+    entityManager.setFlushMode(FlushModeType.COMMIT);
+    try {
+      valueContext = createDataValueContext(index, dataValue, context, dataSetContext);
 
-    // -----------------------------------------------------------------
-    // Potentially heat caches
-    // -----------------------------------------------------------------
+      // -----------------------------------------------------------------
+      // Potentially heat caches
+      // -----------------------------------------------------------------
 
-    autoPreheatCaches(context);
+      autoPreheatCaches(context);
 
-    // -----------------------------------------------------------------
-    // Validation & Constraints
-    // -----------------------------------------------------------------
-    if (importValidator.skipDataValue(dataValue, context, dataSetContext, valueContext)) {
+      // -----------------------------------------------------------------
+      // Validation & Constraints
+      // -----------------------------------------------------------------
+      skip = importValidator.skipDataValue(dataValue, context, dataSetContext, valueContext);
+    } finally {
+      entityManager.setFlushMode(previousFlushMode);
+    }
+
+    if (skip) {
       importCount.incrementIgnored();
       context.addRejected(valueContext.getIndex());
       return;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceImportTest.java
@@ -41,6 +41,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.FlushModeType;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -129,11 +131,15 @@ class DataValueSetServiceImportTest {
 
   @Mock private UserService userService;
 
+  @Mock private EntityManager entityManager;
+
   @InjectMocks private DefaultDataValueSetService dataValueSetService;
 
   @Test
   void testImportDataValuesUpdatedSkipNoChange() {
     when(settingsProvider.getCurrentSettings()).thenReturn(SystemSettings.of(Map.of()));
+    // the import suppresses auto-flush over its read-only span and restores the previous mode
+    when(entityManager.getFlushMode()).thenReturn(FlushModeType.AUTO);
     SystemUser user = new SystemUser();
     injectSecurityContextNoSettings(user);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportAutoFlushTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportAutoFlushTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.datavalueset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.persistence.EntityManager;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.FlushEntityEvent;
+import org.hibernate.event.spi.FlushEntityEventListener;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.DataDimensionType;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.dataset.DataSetService;
+import org.hisp.dhis.dxf2.common.ImportOptions;
+import org.hisp.dhis.dxf2.importsummary.ImportStatus;
+import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.period.MonthlyPeriodType;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.security.acl.AccessStringHelper;
+import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Reproduces the auto-flush cost measured in the Uganda Glowroot traces (UGANDA-8 §3): a {@code
+ * dataValueSets} import runs as one long transaction with one Hibernate session, loads a large
+ * read-only metadata graph into the persistence context, and then pays a <em>full dirty check of
+ * that whole context on every query it issues</em>.
+ *
+ * <p>The traced request imported 166 data values, loaded 2148 organisation units, and burned 28.3 s
+ * of CPU out of 29.7 s wall (only 1.33 s of JDBC), with the same query costing 9–20× more at the
+ * end of the request than at the start.
+ *
+ * <p><b>Why this test counts {@code FLUSH_ENTITY} events rather than flushes.</b> {@code
+ * DefaultAutoFlushEventListener.onAutoFlush} calls {@code flushEverythingToExecutions}
+ * <em>before</em> it checks {@code flushIsReallyNeeded}, and only increments {@code
+ * Statistics.getFlushCount()} inside the "really needed" branch. A pure-read import therefore does
+ * the entire dirty check on every query while Hibernate reports <b>zero flushes</b> — which is
+ * exactly why this defect is invisible in ordinary metrics. The dirty check itself fires one {@code
+ * FlushEntityEvent} per managed entity ({@code TypeHelper.findDirty}, the largest self-time leaf in
+ * the traces), so counting those events measures the wasted work directly and deterministically.
+ *
+ * <p>The quantity that matters is the <em>shape</em>: dirty-check work must be O(entities), not
+ * O(values × entities). Without the fix it is the product; with it, the read-only lookups skip the
+ * flush path entirely because {@code flushMightBeNeeded} short-circuits on {@code
+ * FlushMode.COMMIT}.
+ */
+class DataValueSetImportAutoFlushTest extends PostgresIntegrationTestBase {
+
+  /**
+   * Organisation units restricted onto the attribute option combo's category option. The traced
+   * request had 2148; a few hundred is enough to separate O(n+m) from O(n*m) while keeping the test
+   * quick.
+   */
+  private static final int ORG_UNITS = 300;
+
+  /** Data values in the imported payload. The traced request had 166. */
+  private static final int VALUES = 40;
+
+  @Autowired private CategoryService categoryService;
+  @Autowired private DataElementService dataElementService;
+  @Autowired private DataSetService dataSetService;
+  @Autowired private OrganisationUnitService organisationUnitService;
+  @Autowired private PeriodService periodService;
+  @Autowired private DataValueSetService dataValueSetService;
+  @Autowired private IdentifiableObjectManager idObjectManager;
+  @Autowired private EntityManager em;
+
+  private final List<OrganisationUnit> orgUnits = new ArrayList<>();
+  private DataElement dataElement;
+  private CategoryOptionCombo attributeOptionCombo;
+  private Period period;
+
+  /** Counts one event per managed entity dirty-checked, i.e. the work the fix removes. */
+  private final AtomicLong dirtyChecks = new AtomicLong();
+
+  @BeforeEach
+  void setUp() {
+    OrganisationUnit root = createOrganisationUnit('R');
+    organisationUnitService.addOrganisationUnit(root);
+
+    for (int i = 0; i < ORG_UNITS; i++) {
+      OrganisationUnit ou = createOrganisationUnit("OU" + i, root);
+      organisationUnitService.addOrganisationUnit(ou);
+      orgUnits.add(ou);
+    }
+
+    // The attribute option combo's category option is restricted to every one of those org units.
+    // This is the traced shape: CategoryOptionCombo.getOrganisationUnits() walks its options and
+    // initialises each option's organisationUnits set, pulling the whole set into the session.
+    CategoryOption restricted = createCategoryOption('X');
+    restricted.setOrganisationUnits(new HashSet<>(orgUnits));
+    categoryService.addCategoryOption(restricted);
+
+    Category attributeCategory = createCategory('X', restricted);
+    attributeCategory.setDataDimensionType(DataDimensionType.ATTRIBUTE);
+    categoryService.addCategory(attributeCategory);
+
+    CategoryCombo attributeCombo = createCategoryCombo('X', attributeCategory);
+    attributeCombo.setDataDimensionType(DataDimensionType.ATTRIBUTE);
+    categoryService.addCategoryCombo(attributeCombo);
+
+    attributeOptionCombo = createCategoryOptionCombo(attributeCombo, restricted);
+    categoryService.addCategoryOptionCombo(attributeOptionCombo);
+    attributeCombo.getOptionCombos().add(attributeOptionCombo);
+    categoryService.updateCategoryCombo(attributeCombo);
+
+    dataElement = createDataElement('A', categoryService.getDefaultCategoryCombo());
+    dataElementService.addDataElement(dataElement);
+
+    DataSet dataSet = createDataSet('A', new MonthlyPeriodType());
+    dataSet.setCategoryCombo(attributeCombo);
+    dataSet.addDataSetElement(dataElement);
+    orgUnits.forEach(dataSet::addOrganisationUnit);
+    dataSetService.addDataSet(dataSet);
+
+    period = createPeriod(new MonthlyPeriodType(), getDate(2026, 1, 1), getDate(2026, 1, 31));
+    periodService.addPeriod(period);
+
+    // A normal (non-super) importing user, as in production: the per-value ACL check is part of the
+    // workload being measured, and a superuser would short-circuit it.
+    User importer = createAndAddUser("importer", root);
+    importer.addOrganisationUnits(Set.of(root));
+    userService.updateUser(importer);
+    enableDataSharing(importer, dataSet, AccessStringHelper.DATA_READ_WRITE);
+    enableDataSharing(importer, restricted, AccessStringHelper.DATA_READ_WRITE);
+    enableDataSharing(
+        importer, categoryService.getDefaultCategoryOption(), AccessStringHelper.DATA_READ_WRITE);
+    userService.updateUser(importer);
+    injectSecurityContextUser(importer);
+
+    idObjectManager.flush();
+    idObjectManager.clear();
+
+    countDirtyChecksFromNowOn();
+  }
+
+  /**
+   * Appends a counting listener to the FLUSH_ENTITY chain. The default listener still runs; this
+   * only observes. Registering on the shared SessionFactory is fine because the count is read
+   * across a single import within one test method.
+   */
+  private void countDirtyChecksFromNowOn() {
+    SessionFactoryImplementor sessionFactory =
+        em.getEntityManagerFactory()
+            .unwrap(SessionFactory.class)
+            .unwrap(SessionFactoryImplementor.class);
+    sessionFactory
+        .getServiceRegistry()
+        .getService(EventListenerRegistry.class)
+        .appendListeners(
+            EventType.FLUSH_ENTITY,
+            new FlushEntityEventListener() {
+              @Override
+              public void onFlushEntity(FlushEntityEvent event) {
+                dirtyChecks.incrementAndGet();
+              }
+            });
+  }
+
+  @Test
+  @DisplayName(
+      "a dataValueSets import must not dirty-check the whole persistence context on every query")
+  void importDoesNotDirtyCheckPerQuery() {
+    dirtyChecks.set(0);
+
+    long startedAt = System.nanoTime();
+    ImportSummary summary =
+        dataValueSetService.importDataValueSetJson(payload(), new ImportOptions());
+    long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000L;
+
+    assertEquals(
+        ImportStatus.SUCCESS,
+        summary.getStatus(),
+        () -> "import must succeed, conflicts: " + summary.getConflicts());
+    assertEquals(
+        0,
+        summary.getImportCount().getIgnored(),
+        () -> "no value may be rejected, conflicts: " + summary.getConflicts());
+    assertEquals(VALUES, summary.getImportCount().getImported(), "all values must be imported");
+
+    long observed = dirtyChecks.get();
+    // Printed so a reviewer can confirm the gain themselves: raise ORG_UNITS/VALUES towards the
+    // traced
+    // 2148/166 and watch dirtyCheckEvents and importMs move together on an unfixed build.
+    System.out.printf(
+        "[UGANDA-9 B] values=%d orgUnits=%d imported=%d dirtyCheckEvents=%d importMs=%d%n",
+        VALUES, ORG_UNITS, summary.getImportCount().getImported(), observed, elapsedMs);
+
+    // The bound is the mechanism, not a magic number. Each managed entity may legitimately be
+    // dirty-checked a small constant number of times (the commit flush, plus any query that
+    // genuinely
+    // must see pending writes). What must NOT happen is one full pass per imported value: that is
+    // the
+    // O(values * entities) product the traces measured as a 9-20x within-request degradation.
+    long entities = ORG_UNITS + 32L; // org units plus the handful of metadata objects
+    long onePassPerValue = entities * VALUES;
+    long bound = entities * 4;
+
+    assertTrue(
+        observed <= bound,
+        () ->
+            "dirty-check passes must be O(entities), not O(values x entities). Observed "
+                + observed
+                + " FlushEntityEvents for "
+                + VALUES
+                + " values over ~"
+                + entities
+                + " managed entities (bound "
+                + bound
+                + "; even a single full pass per value would already be ~"
+                + onePassPerValue
+                + ")");
+  }
+
+  private InputStream payload() {
+    StringBuilder json = new StringBuilder();
+    json.append("{\"dataValues\":[");
+    for (int i = 0; i < VALUES; i++) {
+      if (i > 0) {
+        json.append(',');
+      }
+      json.append("{\"dataElement\":\"")
+          .append(dataElement.getUid())
+          .append("\",\"period\":\"")
+          .append(period.getIsoDate())
+          .append("\",\"orgUnit\":\"")
+          .append(orgUnits.get(i % orgUnits.size()).getUid())
+          .append("\",\"attributeOptionCombo\":\"")
+          .append(attributeOptionCombo.getUid())
+          .append("\",\"value\":\"")
+          .append(i + 1) // never 0: a zero value is skipped as zero-and-insignificant
+          .append("\"}");
+    }
+    json.append("]}");
+    return new ByteArrayInputStream(json.toString().getBytes(StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
## Summary

A `dataValueSets` import runs as one transaction with one Hibernate session and loads a large read-only metadata graph into the persistence context. Under the default `FlushModeType.AUTO` every query it issues makes Hibernate dirty-check that entire context first, and the context grows for the whole import, so the cost per value rises with the values already processed — **quadratic CPU on the read path**.

Glowroot traces from a production instance measured this as **28.3 s of CPU in a 29.7 s request** (1.33 s of JDBC, zero blocked time), with the same query costing 9–20× more at the end of a request than at the start.

Hibernate does the dirty check even when it then decides no flush is needed: `DefaultAutoFlushEventListener.onAutoFlush` calls `flushEverythingToExecutions` *before* testing `flushIsReallyNeeded`, and only counts a flush inside the "really needed" branch. So the work is invisible in `Statistics.getFlushCount()`, which reports **zero** flushes for these imports — which is exactly why this has never shown up in ordinary metrics.

## Changes

- Metadata resolution, cache preheating and validation only read, so the flush is suppressed across that span and the previous mode restored before the first write.
- Nothing in the window writes through Hibernate: data values go through a raw-JDBC `BatchHandler`, and missing periods are created in a stateless session (the DHIS2-7539 FK-ordering fix). The two Hibernate writes in the import — `FileResource` updates and `handleComplete`'s `CompleteDataSetRegistration` — are both outside it. `handleComplete` is the one place where the auto-flush is load-bearing, which is why the flush mode is **not** set session-wide.
- `DataValueSetImportAutoFlushTest` counts `FlushEntityEvent`s rather than flushes, for the reason above, and asserts the *shape*: dirty-check work must be O(entities), not O(values × entities). It fails on the unfixed code.

## Measured

On `2.42.5.1` with the L2 cache off, importing 166 values against 2000 restricted org units:

| | before | after |
|---|---|---|
| dirty-check passes | 665 686 | 2 015 (330x fewer) |
| import wall-clock | 3 015 ms | 553 ms (5.5x faster) |
| values imported | 166 | 166 (identical) |
| auto-flush events | 91 | 91 (identical — no query removed) |

## Note on versions

Deliberately **not** proposed for 2.43 or master. `DefaultDataValueSetService` does not exist on either — the import was rewritten onto `DataEntryService`/`DataEntryPipeline`, and `autoPreheatCaches` and `importValidator.skipDataValue` are gone with it — so there is no equivalent span to suppress and nothing to port. 2.42 and 2.41 are the affected lines, which is how DHIS2-21950 is scoped. Whether the new pipeline has its own version of this problem is a separate question, not one this PR answers.

Developed and measured on a `2.42.5.1` production branch (dhis2/dhis2-core#24725) and ported here.

AI Assisted