### PR TITLE
fix: Preload category model for data entry metadata - [DHIS2-21757](2.42)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryComboStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryComboStore.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.category;
 
+import java.util.Collection;
 import java.util.List;
 import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.common.IdentifiableObjectStore;
@@ -38,4 +39,15 @@ import org.hisp.dhis.common.IdentifiableObjectStore;
  */
 public interface CategoryComboStore extends IdentifiableObjectStore<CategoryCombo> {
   List<CategoryCombo> getCategoryCombosByDimensionType(DataDimensionType dataDimensionType);
+
+  /**
+   * Eagerly loads, in three queries rather than one per parent, the associations of the given
+   * {@link CategoryCombo}s: {@link CategoryCombo#getCategories()} with each category's {@link
+   * Category#getCategoryOptions()}, and {@link CategoryCombo#getOptionCombos()} with each option
+   * combo's {@link CategoryOptionCombo#getCategoryOptions()}. Used to prime the session before
+   * those associations are traversed or serialised, avoiding an N+1 select per parent.
+   *
+   * @param categoryCombos the category combos whose associations to load.
+   */
+  void preloadCategoryComboAssociations(Collection<CategoryCombo> categoryCombos);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionComboStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionComboStore.java
@@ -42,18 +42,6 @@ public interface CategoryOptionComboStore extends IdentifiableObjectStore<Catego
   CategoryOptionCombo getCategoryOptionCombo(
       CategoryCombo categoryCombo, Set<CategoryOption> categoryOptions);
 
-  /**
-   * Returns the {@link CategoryOptionCombo}s of the given {@link CategoryCombo}s with their {@link
-   * CategoryOptionCombo#getCategoryOptions()} eagerly fetched in a single query. Used to prime the
-   * session before serialising category option combos, avoiding the per-combo N+1 select on the
-   * {@code categoryoptioncombos_categoryoptions} join table.
-   *
-   * @param categoryCombos the category combos whose option combos to load.
-   * @return the option combos with their category options initialised.
-   */
-  List<CategoryOptionCombo> getCategoryOptionCombosWithCategoryOptions(
-      Collection<CategoryCombo> categoryCombos);
-
   void updateNames();
 
   void deleteNoRollBack(CategoryOptionCombo categoryOptionCombo);

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryService.java
@@ -401,16 +401,15 @@ public interface CategoryService {
   List<CategoryOptionCombo> getAllCategoryOptionCombos();
 
   /**
-   * Returns the {@link CategoryOptionCombo}s of the given {@link CategoryCombo}s with their
-   * category options eagerly fetched in a single query. Used to prime the session before
-   * serialising category option combos, avoiding the per-combo N+1 select on the {@code
-   * categoryoptioncombos_categoryoptions} join table.
+   * Eagerly loads, in three queries rather than one per parent, the associations of the given
+   * {@link CategoryCombo}s: {@link CategoryCombo#getCategories()} with each category's {@link
+   * Category#getCategoryOptions()}, and {@link CategoryCombo#getOptionCombos()} with each option
+   * combo's {@link CategoryOptionCombo#getCategoryOptions()}. Used to prime the session before
+   * those associations are traversed or serialised, avoiding an N+1 select per parent.
    *
-   * @param categoryCombos the category combos whose option combos to load.
-   * @return the option combos with their category options initialised.
+   * @param categoryCombos the category combos whose associations to load.
    */
-  List<CategoryOptionCombo> getCategoryOptionCombosWithCategoryOptions(
-      Collection<CategoryCombo> categoryCombos);
+  void preloadCategoryComboAssociations(Collection<CategoryCombo> categoryCombos);
 
   /**
    * Generates and persists a default Category, CategoryOption, CategoryCombo and

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/DefaultCategoryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/DefaultCategoryService.java
@@ -499,9 +499,8 @@ public class DefaultCategoryService implements CategoryService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<CategoryOptionCombo> getCategoryOptionCombosWithCategoryOptions(
-      Collection<CategoryCombo> categoryCombos) {
-    return categoryOptionComboStore.getCategoryOptionCombosWithCategoryOptions(categoryCombos);
+  public void preloadCategoryComboAssociations(Collection<CategoryCombo> categoryCombos) {
+    categoryComboStore.preloadCategoryComboAssociations(categoryCombos);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryComboStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryComboStore.java
@@ -31,9 +31,11 @@ package org.hisp.dhis.category.hibernate;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.CriteriaBuilder;
+import java.util.Collection;
 import java.util.List;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryComboStore;
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.security.acl.AclService;
@@ -64,5 +66,54 @@ public class HibernateCategoryComboStore extends HibernateIdentifiableObjectStor
         newJpaParameters()
             .addPredicate(root -> builder.equal(root.get("dataDimensionType"), dataDimensionType))
             .addPredicate(root -> builder.equal(root.get("name"), "default")));
+  }
+
+  @Override
+  public void preloadCategoryComboAssociations(Collection<CategoryCombo> categoryCombos) {
+    if (categoryCombos.isEmpty()) {
+      return;
+    }
+
+    // One query per collection of CategoryCombo: fetching categories and optionCombos in the same
+    // query would join the two independently and return their Cartesian product.
+    preload(
+        """
+        select cc from CategoryCombo cc
+        left join fetch cc.categories c
+        left join fetch c.categoryOptions
+        where cc in :categoryCombos
+        """,
+        CategoryCombo.class,
+        categoryCombos);
+
+    // The two queries below cannot be merged, and their order matters. CategoryCombo.optionCombos
+    // is a Set, so filling it calls CategoryOptionCombo.hashCode(), which reads categoryOptions:
+    // fetching both in one query fails with "collection was evicted", and fetching optionCombos on
+    // its own would lazy-load each combo's category options one at a time. So the category options
+    // are put in the session first, rooted at the option combo, and only then are the optionCombos
+    // sets filled.
+    preload(
+        """
+        select coc from CategoryCombo cc
+        join cc.optionCombos coc
+        left join fetch coc.categoryOptions
+        where cc in :categoryCombos
+        """,
+        CategoryOptionCombo.class,
+        categoryCombos);
+    preload(
+        """
+        select cc from CategoryCombo cc
+        left join fetch cc.optionCombos
+        where cc in :categoryCombos
+        """,
+        CategoryCombo.class,
+        categoryCombos);
+  }
+
+  /** Runs a query only for its side effect of initialising the collections it fetch-joins. */
+  private <C> void preload(
+      String hql, Class<C> resultType, Collection<CategoryCombo> categoryCombos) {
+    getQuery(hql, resultType).setParameter("categoryCombos", categoryCombos).list();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryOptionComboStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryOptionComboStore.java
@@ -103,25 +103,6 @@ public class HibernateCategoryOptionComboStore
   }
 
   @Override
-  public List<CategoryOptionCombo> getCategoryOptionCombosWithCategoryOptions(
-      Collection<CategoryCombo> categoryCombos) {
-    if (categoryCombos == null || categoryCombos.isEmpty()) {
-      return List.of();
-    }
-
-    return getQuery(
-            """
-            select distinct coc from CategoryCombo cc
-            join cc.optionCombos coc
-            left join fetch coc.categoryOptions
-            where cc in :categoryCombos
-            """,
-            CategoryOptionCombo.class)
-        .setParameter("categoryCombos", categoryCombos)
-        .list();
-  }
-
-  @Override
   public void updateNames() {
     List<CategoryOptionCombo> categoryOptionCombos =
         getQuery("from CategoryOptionCombo co where co.name is null").list();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -152,10 +152,10 @@ public class DefaultDataSetMetadataExportService implements DataSetMetadataExpor
     List<CategoryCombo> dataSetCategoryCombos =
         sortById(mapToSet(dataSets, DataSet::getCategoryCombo));
 
-    // Preload the category options of the data-element category-option-combos in a single query, so
-    // field-filter serialisation of categoryOptionCombos[...,categoryOptions~pluck[id]] does not
-    // trigger a per-combo N+1 (categoryoptioncombos_categoryoptions).
-    categoryService.getCategoryOptionCombosWithCategoryOptions(dataElementCategoryCombos);
+    // Preload the data-element category combos' associations, so that neither reading their
+    // categories below nor field-filter serialisation of categories~pluck[id] and
+    // categoryOptionCombos[...,categoryOptions~pluck[id]] initialises them one parent at a time.
+    categoryService.preloadCategoryComboAssociations(dataElementCategoryCombos);
     List<Category> dataElementCategories =
         sortById(flatMapToSet(dataElementCategoryCombos, CategoryCombo::getCategories));
     List<Category> dataSetCategories =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/DataSetMetadataExportServiceQueryCountTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/DataSetMetadataExportServiceQueryCountTest.java
@@ -33,8 +33,11 @@ import static io.hypersistence.utils.jdbc.validator.SQLStatementCountValidator.r
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import net.ttddyy.dsproxy.QueryCountHolder;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
@@ -60,7 +63,10 @@ import org.springframework.transaction.annotation.Transactional;
  * /api/dataEntry/metadata} handler), guarding against the N+1 selects that previously fired once
  * per {@link org.hisp.dhis.dataset.DataSetElement} ({@code DataSet.getDataElements()} / {@code
  * DataElement.getCategoryCombos()}) and once per {@link org.hisp.dhis.category.CategoryOptionCombo}
- * ({@code CategoryOptionCombo.getCategoryOptions()}).
+ * ({@code CategoryOptionCombo.getCategoryOptions()}), and once per {@link
+ * org.hisp.dhis.category.CategoryCombo} ({@code CategoryCombo.getCategories()} / {@code
+ * CategoryCombo.getOptionCombos()}) or {@link org.hisp.dhis.category.Category} ({@code
+ * Category.getCategoryOptions()}).
  *
  * @author david mackessy
  */
@@ -151,6 +157,111 @@ class DataSetMetadataExportServiceQueryCountTest extends PostgresIntegrationTest
             + " times");
   }
 
+  @Test
+  @DisplayName("Adding category combos does not add SQL selects to the metadata export")
+  void categoryComboCountDoesNotScaleQueryCount() {
+    // baseline: export with two data elements that each have their own category combo
+    addDataElementsWithOwnCategoryCombo(dataSet, 2);
+    manager.update(dataSet);
+    long baseline = countCategoryJoinTableSelects();
+    assertTrue(baseline > 0, "expected the metadata export to query the category join tables");
+
+    // reload the now-managed data set (the previous measurement cleared then repopulated the
+    // session) before mutating it, then add four more category combos
+    DataSet managedDataSet = manager.get(DataSet.class, dataSet.getUid());
+    addDataElementsWithOwnCategoryCombo(managedDataSet, 4);
+    manager.update(managedDataSet);
+
+    long withMoreCategoryCombos = countCategoryJoinTableSelects();
+
+    // Each of these associations is preloaded in one fetch-joining query, so the select count must
+    // not grow with the number of category combos. If it does, the association is being initialised
+    // one parent at a time again — during data gathering for CategoryCombo.getCategories() and
+    // Category.getCategoryOptions(), or during serialization for the other two.
+    assertEquals(
+        baseline,
+        withMoreCategoryCombos,
+        "adding category combos must not increase the number of SQL selects against the category"
+            + " join tables");
+  }
+
+  @Test
+  @DisplayName("Preloading the category combos keeps the exported categories in sort order")
+  void preloadedCategoriesKeepTheirOrder() {
+    // the categories of a combo, and the options of a category, are ordered lists (sort_order), and
+    // the data entry app relies on that order. Preloading them with a fetch join must not disturb
+    // it
+    List<CategoryOption> options = saveCategoryOptions(2);
+    Category first = createCategory("first" + uniqueCounter++, options.get(0), options.get(1));
+    Category second = createCategory("second" + uniqueCounter++, options.get(1), options.get(0));
+    manager.save(first);
+    manager.save(second);
+    CategoryCombo combo = createCategoryCombo("cc" + uniqueCounter++, first, second);
+    manager.save(combo);
+    categoryOptionComboGenerateService.addAndPruneOptionCombos(combo);
+
+    DataElement dataElement = createDataElement((char) ('A' + uniqueCounter++));
+    dataElement.setCategoryCombo(combo);
+    manager.save(dataElement);
+    dataSet.addDataSetElement(dataElement);
+    manager.update(dataSet);
+
+    clearSession();
+    ObjectNode metadata = exportService.getDataSetMetadata();
+
+    assertEquals(
+        List.of(first.getUid(), second.getUid()),
+        pluckedIds(metadata, "categoryCombos", combo.getUid(), "categories"),
+        "the combo's categories must be exported in sort order");
+    assertEquals(
+        List.of(options.get(0).getUid(), options.get(1).getUid()),
+        pluckedIds(metadata, "categories", first.getUid(), "categoryOptions"),
+        "the first category's options must be exported in sort order");
+    assertEquals(
+        List.of(options.get(1).getUid(), options.get(0).getUid()),
+        pluckedIds(metadata, "categories", second.getUid(), "categoryOptions"),
+        "the second category's options must be exported in its own sort order");
+  }
+
+  /** The {@code ~pluck[id]} array of the given property, on the object with the given uid. */
+  private List<String> pluckedIds(
+      ObjectNode metadata, String collection, String uid, String property) {
+    for (JsonNode object : metadata.get(collection)) {
+      if (uid.equals(object.get("id").asText())) {
+        List<String> ids = new ArrayList<>();
+        object.get(property).forEach(id -> ids.add(id.asText()));
+        return ids;
+      }
+    }
+    throw new AssertionError(uid + " not found in " + collection);
+  }
+
+  /**
+   * Runs the metadata export from a freshly cleared session and returns the number of selects
+   * issued against the join tables behind the category-combo associations it reads and serialises.
+   */
+  private long countCategoryJoinTableSelects() {
+    clearSession();
+    QueryCountDataSourceProxy.clearCapturedSql();
+    exportService.getDataSetMetadata();
+    return Stream.of(
+            "categorycombos_categories",
+            "categories_categoryoptions",
+            "categorycombos_optioncombos",
+            "categoryoptioncombos_categoryoptions")
+        .mapToLong(QueryCountDataSourceProxy::countCapturedSqlMatching)
+        .sum();
+  }
+
+  private void addDataElementsWithOwnCategoryCombo(DataSet ds, int count) {
+    for (int i = 0; i < count; i++) {
+      DataElement dataElement = createDataElement((char) ('A' + uniqueCounter++));
+      dataElement.setCategoryCombo(createCategoryComboWithOptions(4));
+      manager.save(dataElement);
+      ds.addDataSetElement(dataElement);
+    }
+  }
+
   /**
    * Runs the metadata export from a freshly cleared Hibernate session (to mimic a new request and
    * force queries to hit the database) and returns the number of select statements issued.
@@ -177,13 +288,18 @@ class DataSetMetadataExportServiceQueryCountTest extends PostgresIntegrationTest
     }
   }
 
-  private CategoryCombo createCategoryComboWithOptions(int optionCount) {
+  private List<CategoryOption> saveCategoryOptions(int optionCount) {
     List<CategoryOption> options = new ArrayList<>();
     for (int i = 0; i < optionCount; i++) {
       CategoryOption option = createCategoryOption((char) ('A' + uniqueCounter++));
       manager.save(option);
       options.add(option);
     }
+    return options;
+  }
+
+  private CategoryCombo createCategoryComboWithOptions(int optionCount) {
+    List<CategoryOption> options = saveCategoryOptions(optionCount);
     Category category =
         createCategory("cat" + uniqueCounter++, options.toArray(new CategoryOption[0]));
     manager.save(category);


### PR DESCRIPTION
port of https://github.com/dhis2/dhis2-core/pull/24766/

tested locally against large metadata model with shape:
```
┌────────────────────────┬─────────┬──────────────────────────────────────┬─────────┐
│        Metadata        │  Count  │              Join table              │  Rows   │
├────────────────────────┼─────────┼──────────────────────────────────────┼─────────┤
│ Category options       │  30,000 │ categoryoption_organisationunits     │  30,000 │
├────────────────────────┼─────────┼──────────────────────────────────────┼─────────┤
│ Categories             │   7,500 │ categories_categoryoptions           │  30,000 │
├────────────────────────┼─────────┼──────────────────────────────────────┼─────────┤
│ Category combos        │   2,500 │ categorycombos_categories            │   7,500 │
├────────────────────────┼─────────┼──────────────────────────────────────┼─────────┤
│ Category option combos │ 160,000 │ categorycombos_optioncombos          │ 160,000 │
├────────────────────────┼─────────┼──────────────────────────────────────┼─────────┤
│ Data elements          │   7,500 │ categoryoptioncombos_categoryoptions │ 480,000 │
├────────────────────────┼─────────┼──────────────────────────────────────┼─────────┤
│ Data sets              │     500 │ datasetelement                       │   7,500 │
├────────────────────────┼─────────┼──────────────────────────────────────┼─────────┤
│                        │         │ datasetsource (org unit assignments) │  10,000 │
└────────────────────────┴─────────┴──────────────────────────────────────┴─────────┘
```

with results:
```
response time 36s (60s before this change)
query                                                                               total time  total count     avg time    avg rows
select categoryop2_.categoryoptioncomboid as category1_13_0_, categoryop4_.cate...	1,086.5	    1	            1,086.5	    480,000.0
select categoryco0_.categorycomboid as category1_6_0_, categoryop2_.categoryopt...	345.1	    1	            345.1	    160,000.0
select categoryco0_.categorycomboid as category1_6_0_, category2_.categoryid as...	95.9	    1	            95.9	    30,000.0
select distinct dataelemen1_.dataelementid as dataelem1_37_0_, datasetele2_.dat...	47.9	    1	            47.9	    7,500.0
```

<img width="1264" height="442" alt="data-entry-42-uganda-fix-cpu-mem" src="https://github.com/user-attachments/assets/207e7456-ac13-4455-884c-d8decab58357" />
