### PR TITLE
fix: declare synchronized entity classes on native writes DHIS2-21963

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/hibernate/HibernateCategoryDimensionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/hibernate/HibernateCategoryDimensionStore.java
@@ -79,8 +79,7 @@ public class HibernateCategoryDimensionStore extends HibernateGenericStore<Categ
         set categoryid = :targetCategoryId
         where cd.categoryid in :sourceCategoryIds
         """;
-    return getSession()
-        .createNativeQuery(sql)
+    return nativeSynchronizedQuery(sql)
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryComboStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryComboStore.java
@@ -98,6 +98,8 @@ public class HibernateCategoryComboStore extends HibernateIdentifiableObjectStor
         """;
     return getSession()
         .createNativeQuery(sql)
+        // join table, so the store entity class would declare the wrong space
+        .addSynchronizedQuerySpace("categorycombos_categories")
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryComboStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryComboStore.java
@@ -99,11 +99,8 @@ public class HibernateCategoryComboStore extends HibernateIdentifiableObjectStor
         """;
     return getSession()
         .createNativeQuery(sql)
-        // This writes the join table behind both CategoryCombo.categories and the inverse
-        // Category.categoryCombos, and both of those collections are cached. Declaring the raw
-        // table name is not enough: BulkOperationCleanupAction only evicts collection roles for
-        // entities whose own query spaces match, so a bare join table matches nothing. Naming
-        // both entities pulls in their collection regions.
+        // join table behind CategoryCombo.categories and the inverse Category.categoryCombos,
+        // both cached, so both entities need naming
         .addSynchronizedEntityClass(CategoryCombo.class)
         .addSynchronizedEntityClass(Category.class)
         .setParameter("targetCategoryId", targetCategoryId)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryComboStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryComboStore.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.hibernate.LockOptions;
+import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryComboStore;
 import org.hisp.dhis.common.DataDimensionType;
@@ -98,8 +99,13 @@ public class HibernateCategoryComboStore extends HibernateIdentifiableObjectStor
         """;
     return getSession()
         .createNativeQuery(sql)
-        // join table, so the store entity class would declare the wrong space
-        .addSynchronizedQuerySpace("categorycombos_categories")
+        // This writes the join table behind both CategoryCombo.categories and the inverse
+        // Category.categoryCombos, and both of those collections are cached. Declaring the raw
+        // table name is not enough: BulkOperationCleanupAction only evicts collection roles for
+        // entities whose own query spaces match, so a bare join table matches nothing. Naming
+        // both entities pulls in their collection regions.
+        .addSynchronizedEntityClass(CategoryCombo.class)
+        .addSynchronizedEntityClass(Category.class)
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryComboStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryComboStore.java
@@ -97,11 +97,8 @@ public class HibernateCategoryComboStore extends HibernateIdentifiableObjectStor
         set categoryid = :targetCategoryId
         where cc_c.categoryid in :sourceCategoryIds
         """;
-    return getSession()
-        .createNativeQuery(sql)
-        // join table behind CategoryCombo.categories and the inverse Category.categoryCombos,
-        // both cached, so both entities need naming
-        .addSynchronizedEntityClass(CategoryCombo.class)
+    return nativeSynchronizedQuery(sql)
+        // the inverse Category.categoryCombos collection is cached too
         .addSynchronizedEntityClass(Category.class)
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryComboStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryComboStore.java
@@ -98,7 +98,9 @@ public class HibernateCategoryComboStore extends HibernateIdentifiableObjectStor
         where cc_c.categoryid in :sourceCategoryIds
         """;
     return nativeSynchronizedQuery(sql)
-        // the inverse Category.categoryCombos collection is cached too
+        // categorycombos_categories backs both the cached CategoryCombo.categories and
+        // Category.categoryCombos collections. Collection regions are keyed by the collection's
+        // element entity, so naming both entities is what reaches both regions.
         .addSynchronizedEntityClass(Category.class)
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryStore.java
@@ -120,8 +120,9 @@ public class HibernateCategoryStore extends HibernateIdentifiableObjectStore<Cat
               """;
     return getSession()
         .createNativeQuery(sql)
-        // join table, so the store entity class would declare the wrong space
-        .addSynchronizedQuerySpace("categories_categoryoptions")
+        // Category owns the cached categoryOptions collection on this join table. Naming the
+        // entity rather than the raw table is what makes Hibernate evict that collection region.
+        .addSynchronizedEntityClass(Category.class)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
         .executeUpdate();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryStore.java
@@ -120,8 +120,7 @@ public class HibernateCategoryStore extends HibernateIdentifiableObjectStore<Cat
               """;
     return getSession()
         .createNativeQuery(sql)
-        // Category owns the cached categoryOptions collection on this join table. Naming the
-        // entity rather than the raw table is what makes Hibernate evict that collection region.
+        // join table behind the cached Category.categoryOptions collection
         .addSynchronizedEntityClass(Category.class)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryStore.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import org.hibernate.LockOptions;
 import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryStore;
 import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
@@ -119,6 +120,10 @@ public class HibernateCategoryStore extends HibernateIdentifiableObjectStore<Cat
               where c_co.categoryid in :sourceCategoryIds
               """;
     return nativeSynchronizedQuery(sql)
+        // categories_categoryoptions is the Category.categoryOptions collection table. Collection
+        // regions are keyed by the collection's element entity, so CategoryOption is what reaches
+        // that region, not the owning Category.
+        .addSynchronizedEntityClass(CategoryOption.class)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
         .executeUpdate();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryStore.java
@@ -118,10 +118,7 @@ public class HibernateCategoryStore extends HibernateIdentifiableObjectStore<Cat
               delete from categories_categoryoptions c_co
               where c_co.categoryid in :sourceCategoryIds
               """;
-    return getSession()
-        .createNativeQuery(sql)
-        // join table behind the cached Category.categoryOptions collection
-        .addSynchronizedEntityClass(Category.class)
+    return nativeSynchronizedQuery(sql)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
         .executeUpdate();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryStore.java
@@ -120,6 +120,8 @@ public class HibernateCategoryStore extends HibernateIdentifiableObjectStore<Cat
               """;
     return getSession()
         .createNativeQuery(sql)
+        // join table, so the store entity class would declare the wrong space
+        .addSynchronizedQuerySpace("categories_categoryoptions")
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
         .executeUpdate();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalWorkflowStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalWorkflowStore.java
@@ -66,8 +66,7 @@ public class HibernateDataApprovalWorkflowStore
         set categorycomboid = :targetCategoryComboId
         where categorycomboid in :sourceCategoryComboIds
         """;
-    return getSession()
-        .createNativeQuery(sql)
+    return nativeSynchronizedQuery(sql)
         .setParameter("targetCategoryComboId", targetCategoryComboId)
         .setParameter("sourceCategoryComboIds", sourceCategoryComboIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateCompleteDataSetRegistrationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateCompleteDataSetRegistrationStore.java
@@ -135,8 +135,10 @@ public class HibernateCompleteDataSetRegistrationStore
           AND c.sourceid = (SELECT organisationunitid FROM organisationunit ou WHERE ou.uid = :ou)
           AND c.attributeoptioncomboid = (SELECT categoryoptioncomboid FROM categoryoptioncombo aoc WHERE aoc.uid = :aoc)
         """;
-    entityManager
+    getSession()
         .createNativeQuery(sql)
+        // the other tables are only read by the lookup subqueries
+        .addSynchronizedQuerySpace("completedatasetregistration")
         .setParameter("ds", dataSet.getValue())
         .setParameter("pe", period.getIsoDate())
         .setParameter("ou", orgUnit.getValue())

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateCompleteDataSetRegistrationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateCompleteDataSetRegistrationStore.java
@@ -137,7 +137,6 @@ public class HibernateCompleteDataSetRegistrationStore
         """;
     getSession()
         .createNativeQuery(sql)
-        // the other tables are only read by the lookup subqueries
         .addSynchronizedQuerySpace("completedatasetregistration")
         .setParameter("ds", dataSet.getValue())
         .setParameter("pe", period.getIsoDate())

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateCompleteDataSetRegistrationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateCompleteDataSetRegistrationStore.java
@@ -135,9 +135,7 @@ public class HibernateCompleteDataSetRegistrationStore
           AND c.sourceid = (SELECT organisationunitid FROM organisationunit ou WHERE ou.uid = :ou)
           AND c.attributeoptioncomboid = (SELECT categoryoptioncomboid FROM categoryoptioncombo aoc WHERE aoc.uid = :aoc)
         """;
-    getSession()
-        .createNativeQuery(sql)
-        .addSynchronizedQuerySpace("completedatasetregistration")
+    nativeSynchronizedQuery(sql)
         .setParameter("ds", dataSet.getValue())
         .setParameter("pe", period.getIsoDate())
         .setParameter("ou", orgUnit.getValue())

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateDataSetStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateDataSetStore.java
@@ -173,8 +173,7 @@ public class HibernateDataSetStore extends HibernateIdentifiableObjectStore<Data
         """;
     return getSession()
         .createNativeQuery(sql)
-        // DataSet owns the cached dataSetElements collection on this table, and DataSetElement
-        // is its own entity, so both need naming for their regions to be evicted.
+        // datasetelement is both DataSetElement's table and the cached DataSet.dataSetElements
         .addSynchronizedEntityClass(DataSet.class)
         .addSynchronizedEntityClass(DataSetElement.class)
         .setParameter("targetCategoryComboId", targetCategoryComboId)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateDataSetStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateDataSetStore.java
@@ -171,10 +171,8 @@ public class HibernateDataSetStore extends HibernateIdentifiableObjectStore<Data
         set categorycomboid = :targetCategoryComboId
         where categorycomboid in :sourceCategoryComboIds
         """;
-    return getSession()
-        .createNativeQuery(sql)
-        // datasetelement is both DataSetElement's table and the cached DataSet.dataSetElements
-        .addSynchronizedEntityClass(DataSet.class)
+    return nativeSynchronizedQuery(sql)
+        // datasetelement is DataSetElement's own table as well as the cached DataSet collection
         .addSynchronizedEntityClass(DataSetElement.class)
         .setParameter("targetCategoryComboId", targetCategoryComboId)
         .setParameter("sourceCategoryComboIds", sourceCategoryComboIds)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateDataSetStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateDataSetStore.java
@@ -173,6 +173,8 @@ public class HibernateDataSetStore extends HibernateIdentifiableObjectStore<Data
         """;
     return getSession()
         .createNativeQuery(sql)
+        // DataSetElement, not the DataSet table the store owns
+        .addSynchronizedQuerySpace("datasetelement")
         .setParameter("targetCategoryComboId", targetCategoryComboId)
         .setParameter("sourceCategoryComboIds", sourceCategoryComboIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateDataSetStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateDataSetStore.java
@@ -173,8 +173,10 @@ public class HibernateDataSetStore extends HibernateIdentifiableObjectStore<Data
         """;
     return getSession()
         .createNativeQuery(sql)
-        // DataSetElement, not the DataSet table the store owns
-        .addSynchronizedQuerySpace("datasetelement")
+        // DataSet owns the cached dataSetElements collection on this table, and DataSetElement
+        // is its own entity, so both need naming for their regions to be evicted.
+        .addSynchronizedEntityClass(DataSet.class)
+        .addSynchronizedEntityClass(DataSetElement.class)
         .setParameter("targetCategoryComboId", targetCategoryComboId)
         .setParameter("sourceCategoryComboIds", sourceCategoryComboIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateDataSetStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateDataSetStore.java
@@ -172,7 +172,9 @@ public class HibernateDataSetStore extends HibernateIdentifiableObjectStore<Data
         where categorycomboid in :sourceCategoryComboIds
         """;
     return nativeSynchronizedQuery(sql)
-        // datasetelement is DataSetElement's own table as well as the cached DataSet collection
+        // datasetelement is DataSetElement's own table. It is also the DataSet.dataSetElements
+        // collection table, and since collection regions are keyed by the collection's element
+        // entity, naming DataSetElement reaches that cached collection too.
         .addSynchronizedEntityClass(DataSetElement.class)
         .setParameter("targetCategoryComboId", targetCategoryComboId)
         .setParameter("sourceCategoryComboIds", sourceCategoryComboIds)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueChangelogStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueChangelogStore.java
@@ -257,8 +257,7 @@ public class HibernateDataValueChangelogStore extends HibernateGenericStore<Data
           END IF;
       END;
       $$""";
-    // DDL on the datavalue table. An empty space set is not expressible: Hibernate reads that as
-    // "unknown", which invalidates every region, so declare the one table the trigger sits on.
+    // DDL only, but an empty space set would evict every region
     getSession().createNativeQuery(sql).addSynchronizedQuerySpace("datavalue").executeUpdate();
   }
 
@@ -267,8 +266,7 @@ public class HibernateDataValueChangelogStore extends HibernateGenericStore<Data
     String sql =
         """
       DROP TRIGGER IF EXISTS trg_datavalue_audit ON datavalue""";
-    // DDL on the datavalue table. An empty space set is not expressible: Hibernate reads that as
-    // "unknown", which invalidates every region, so declare the one table the trigger sits on.
+    // DDL only, but an empty space set would evict every region
     getSession().createNativeQuery(sql).addSynchronizedQuerySpace("datavalue").executeUpdate();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueChangelogStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueChangelogStore.java
@@ -257,8 +257,8 @@ public class HibernateDataValueChangelogStore extends HibernateGenericStore<Data
           END IF;
       END;
       $$""";
-    // DDL only, but an empty space set would evict every region
-    getSession().createNativeQuery(sql).addSynchronizedQuerySpace("datavalue").executeUpdate();
+    // DDL, not entity persistence, so it skips Hibernate and its cache invalidation
+    jdbcTemplate.execute(sql);
   }
 
   @Override
@@ -266,7 +266,7 @@ public class HibernateDataValueChangelogStore extends HibernateGenericStore<Data
     String sql =
         """
       DROP TRIGGER IF EXISTS trg_datavalue_audit ON datavalue""";
-    // DDL only, but an empty space set would evict every region
-    getSession().createNativeQuery(sql).addSynchronizedQuerySpace("datavalue").executeUpdate();
+    // DDL, not entity persistence, so it skips Hibernate and its cache invalidation
+    jdbcTemplate.execute(sql);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueChangelogStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueChangelogStore.java
@@ -73,7 +73,7 @@ public class HibernateDataValueChangelogStore extends HibernateGenericStore<Data
       DELETE FROM datavalueaudit dva
       WHERE dva.organisationunitid = (SELECT ou.organisationunitid FROM organisationunit ou WHERE ou.uid = :ou)""";
 
-    entityManager.createNativeQuery(sql).setParameter("ou", orgUnit.getValue()).executeUpdate();
+    nativeSynchronizedQuery(sql).setParameter("ou", orgUnit.getValue()).executeUpdate();
   }
 
   @Override
@@ -83,7 +83,7 @@ public class HibernateDataValueChangelogStore extends HibernateGenericStore<Data
       DELETE FROM datavalueaudit dva
       WHERE dva.dataelementid = (SELECT de.dataelementid FROM dataelement de WHERE de.uid = :de)""";
 
-    entityManager.createNativeQuery(sql).setParameter("de", dataElement.getValue()).executeUpdate();
+    nativeSynchronizedQuery(sql).setParameter("de", dataElement.getValue()).executeUpdate();
   }
 
   @Override
@@ -93,8 +93,7 @@ public class HibernateDataValueChangelogStore extends HibernateGenericStore<Data
         DELETE FROM datavalueaudit dva
         WHERE dva.categoryoptioncomboid = (SELECT categoryoptioncomboid FROM categoryoptioncombo WHERE uid = :coc)
            OR dva.attributeoptioncomboid = (SELECT categoryoptioncomboid FROM categoryoptioncombo WHERE uid = :coc);""";
-    entityManager
-        .createNativeQuery(sql)
+    nativeSynchronizedQuery(sql)
         .setParameter("coc", categoryOptionCombo.getValue())
         .executeUpdate();
   }
@@ -258,7 +257,9 @@ public class HibernateDataValueChangelogStore extends HibernateGenericStore<Data
           END IF;
       END;
       $$""";
-    getSession().createNativeQuery(sql).executeUpdate();
+    // DDL on the datavalue table. An empty space set is not expressible: Hibernate reads that as
+    // "unknown", which invalidates every region, so declare the one table the trigger sits on.
+    getSession().createNativeQuery(sql).addSynchronizedQuerySpace("datavalue").executeUpdate();
   }
 
   @Override
@@ -266,6 +267,8 @@ public class HibernateDataValueChangelogStore extends HibernateGenericStore<Data
     String sql =
         """
       DROP TRIGGER IF EXISTS trg_datavalue_audit ON datavalue""";
-    getSession().createNativeQuery(sql).executeUpdate();
+    // DDL on the datavalue table. An empty space set is not expressible: Hibernate reads that as
+    // "unknown", which invalidates every region, so declare the one table the trigger sits on.
+    getSession().createNativeQuery(sql).addSynchronizedQuerySpace("datavalue").executeUpdate();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueTrimStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueTrimStore.java
@@ -87,10 +87,7 @@ public class HibernateDataValueTrimStore extends HibernateGenericStore<DataValue
           AND de.zeroissignificant = false
           AND dv.dataelementid = de.dataelementid
           AND (dv.value IS NULL OR dv.value = '')""";
-    return getSession()
-        .createNativeQuery(sql)
-        // only datavalue is written; dataelement is read for the join, so it needs no space
-        .addSynchronizedQuerySpace("datavalue")
+    return nativeSynchronizedQuery(sql)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(1000))
         .executeUpdate();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueTrimStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueTrimStore.java
@@ -89,6 +89,8 @@ public class HibernateDataValueTrimStore extends HibernateGenericStore<DataValue
           AND (dv.value IS NULL OR dv.value = '')""";
     return getSession()
         .createNativeQuery(sql)
+        // only datavalue is written; dataelement is read for the join, so it needs no space
+        .addSynchronizedQuerySpace("datavalue")
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(1000))
         .executeUpdate();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
@@ -124,9 +124,7 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
               if (pk != null) {
                 return pk;
               }
-              session
-                  .createNativeQuery(sql2)
-                  .addSynchronizedEntityClass(Period.class)
+              nativeSynchronizedQuery(session, sql2)
                   .setParameter("type", period.getPeriodType().getName())
                   .setParameter("start", period.getStartDate())
                   .setParameter("end", period.getEndDate())
@@ -263,6 +261,7 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
               }
               session
                   .createNativeQuery(sql2)
+                  // PeriodType, not the store's own Period
                   .addSynchronizedEntityClass(PeriodType.class)
                   .setParameter("name", name)
                   .executeUpdate();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
@@ -126,6 +126,9 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
               }
               session
                   .createNativeQuery(sql2)
+                  // Without synchronized spaces Hibernate cannot tell which tables this
+                  // touches and conservatively evicts EVERY L2 entity region, not just Period.
+                  .addSynchronizedEntityClass(Period.class)
                   .setParameter("type", period.getPeriodType().getName())
                   .setParameter("start", period.getStartDate())
                   .setParameter("end", period.getEndDate())
@@ -144,8 +147,7 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
   public void delete(@Nonnull Period period) {
     String isoDate = period.getIsoDate();
     int deleted =
-        getSession()
-            .createNativeQuery("DELETE FROM period where iso = :iso")
+        nativeSynchronizedQuery("DELETE FROM period where iso = :iso")
             .setParameter("iso", isoDate)
             .executeUpdate();
     if (deleted > 0) {
@@ -261,7 +263,11 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
               if (pk != null) {
                 return pk;
               }
-              session.createNativeQuery(sql2).setParameter("name", name).executeUpdate();
+              session
+                  .createNativeQuery(sql2)
+                  .addSynchronizedEntityClass(PeriodType.class)
+                  .setParameter("name", name)
+                  .executeUpdate();
               return session.createNativeQuery("SELECT lastval()").uniqueResult();
             });
     if (id instanceof Number n) {
@@ -286,6 +292,7 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
         session ->
             session
                 .createNativeQuery(sql)
+                .addSynchronizedEntityClass(PeriodType.class)
                 .setParameter("name", name)
                 .setParameter("label", label)
                 .executeUpdate());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
@@ -126,8 +126,6 @@ public class HibernatePeriodStore extends HibernateGenericStore<Period> implemen
               }
               session
                   .createNativeQuery(sql2)
-                  // Without synchronized spaces Hibernate cannot tell which tables this
-                  // touches and conservatively evicts EVERY L2 entity region, not just Period.
                   .addSynchronizedEntityClass(Period.class)
                   .setParameter("type", period.getPeriodType().getName())
                   .setParameter("start", period.getStartDate())

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramIndicatorStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramIndicatorStore.java
@@ -118,8 +118,7 @@ public class HibernateProgramIndicatorStore
             categorycomboid IN (:sourceCategoryComboIds)
             OR attributecomboid IN (:sourceCategoryComboIds);
         """;
-    return getSession()
-        .createNativeQuery(sql)
+    return nativeSynchronizedQuery(sql)
         .setParameter("targetCategoryComboId", targetCategoryComboId)
         .setParameter("sourceCategoryComboIds", sourceCategoryComboIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
@@ -50,6 +50,7 @@ import org.hibernate.Transaction;
 import org.hibernate.query.NativeQuery;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
+import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.hibernate.jsonb.type.JsonJobParametersType;
 import org.hisp.dhis.security.acl.AclService;
 import org.springframework.context.ApplicationEventPublisher;
@@ -385,7 +386,11 @@ public class HibernateJobConfigurationStore
         and (schedulingtype != 'ONCE_ASAP' or lastfinished is null)
         """;
     return runWriteInStatelessSession(
-            q -> q.createNativeQuery(sql).setParameter("id", jobId.getValue()).executeUpdate())
+            q ->
+                q.createNativeQuery(sql)
+                    .addSynchronizedEntityClass(JobConfiguration.class)
+                    .setParameter("id", jobId.getValue())
+                    .executeUpdate())
         > 0;
   }
 
@@ -413,7 +418,11 @@ public class HibernateJobConfigurationStore
         )
         """;
     return runWriteInStatelessSession(
-            q -> q.createNativeQuery(sql).setParameter("id", jobId.getValue()).executeUpdate())
+            q ->
+                q.createNativeQuery(sql)
+                    .addSynchronizedEntityClass(JobConfiguration.class)
+                    .setParameter("id", jobId.getValue())
+                    .executeUpdate())
         > 0;
   }
 
@@ -444,7 +453,11 @@ public class HibernateJobConfigurationStore
           )
         """;
     return runWriteInStatelessSession(
-            q -> q.createNativeQuery(sql).setParameter("id", jobId.getValue()).executeUpdate())
+            q ->
+                q.createNativeQuery(sql)
+                    .addSynchronizedEntityClass(JobConfiguration.class)
+                    .setParameter("id", jobId.getValue())
+                    .executeUpdate())
         > 0;
   }
 
@@ -476,6 +489,7 @@ public class HibernateJobConfigurationStore
     return runWriteInStatelessSession(
             q ->
                 q.createNativeQuery(sql)
+                    .addSynchronizedEntityClass(JobConfiguration.class)
                     .setParameter("id", jobId.getValue())
                     .setParameter("status", status.name())
                     .executeUpdate())
@@ -503,7 +517,11 @@ public class HibernateJobConfigurationStore
           or lastexecuted < (select lastexecuted from jobconfiguration where queuename = :queue and queueposition = 0 limit 1))
         """;
     return runWriteInStatelessSession(
-            q -> q.createNativeQuery(sql).setParameter("queue", queue).executeUpdate())
+            q ->
+                q.createNativeQuery(sql)
+                    .addSynchronizedEntityClass(JobConfiguration.class)
+                    .setParameter("queue", queue)
+                    .executeUpdate())
         > 0;
   }
 
@@ -522,6 +540,7 @@ public class HibernateJobConfigurationStore
     runWriteInStatelessSession(
         q ->
             q.createNativeQuery(sql)
+                .addSynchronizedEntityClass(JobConfiguration.class)
                 .setParameter("id", jobId.getValue())
                 .setParameter("json", progressJson)
                 .setParameter("errors", errorCodes)
@@ -539,7 +558,11 @@ public class HibernateJobConfigurationStore
         where jobstatus = 'SCHEDULED'
         and enabled = false
         """;
-    return runWriteInStatelessSession(q -> q.createNativeQuery(sql).executeUpdate());
+    return runWriteInStatelessSession(
+        q ->
+            q.createNativeQuery(sql)
+                .addSynchronizedEntityClass(JobConfiguration.class)
+                .executeUpdate());
   }
 
   @Override
@@ -558,6 +581,7 @@ public class HibernateJobConfigurationStore
         runWriteInStatelessSession(
             q ->
                 q.createNativeQuery(sql)
+                    .addSynchronizedEntityClass(JobConfiguration.class)
                     .setLockOptions(new LockOptions(LockMode.PESSIMISTIC_WRITE).setTimeOut(2000))
                     .setParameter("ttl", max(1, ttlMinutes))
                     .executeUpdate());
@@ -575,6 +599,7 @@ public class HibernateJobConfigurationStore
     runWriteInStatelessSession(
         q ->
             q.createNativeQuery(sql2)
+                .addSynchronizedEntityClass(FileResource.class)
                 .setLockOptions(new LockOptions(LockMode.PESSIMISTIC_WRITE).setTimeOut(2000))
                 .executeUpdate());
     return deletedCount;
@@ -607,6 +632,7 @@ public class HibernateJobConfigurationStore
     return runWriteInStatelessSession(
         q ->
             q.createNativeQuery(sql)
+                .addSynchronizedEntityClass(JobConfiguration.class)
                 .setParameter("timeout", max(1, timeoutMinutes))
                 .executeUpdate());
   }
@@ -637,7 +663,11 @@ public class HibernateJobConfigurationStore
         and now() > jobconfiguration.lastalive + interval '1 minute'
       """;
     return runWriteInStatelessSession(
-            q -> q.createNativeQuery(sql).setParameter("id", jobId.getValue()).executeUpdate())
+            q ->
+                q.createNativeQuery(sql)
+                    .addSynchronizedEntityClass(JobConfiguration.class)
+                    .setParameter("id", jobId.getValue())
+                    .executeUpdate())
         > 0;
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
@@ -387,8 +387,7 @@ public class HibernateJobConfigurationStore
         """;
     return runWriteInStatelessSession(
             q ->
-                q.createNativeQuery(sql)
-                    .addSynchronizedEntityClass(JobConfiguration.class)
+                nativeSynchronizedQuery(q, sql)
                     .setParameter("id", jobId.getValue())
                     .executeUpdate())
         > 0;
@@ -419,8 +418,7 @@ public class HibernateJobConfigurationStore
         """;
     return runWriteInStatelessSession(
             q ->
-                q.createNativeQuery(sql)
-                    .addSynchronizedEntityClass(JobConfiguration.class)
+                nativeSynchronizedQuery(q, sql)
                     .setParameter("id", jobId.getValue())
                     .executeUpdate())
         > 0;
@@ -454,8 +452,7 @@ public class HibernateJobConfigurationStore
         """;
     return runWriteInStatelessSession(
             q ->
-                q.createNativeQuery(sql)
-                    .addSynchronizedEntityClass(JobConfiguration.class)
+                nativeSynchronizedQuery(q, sql)
                     .setParameter("id", jobId.getValue())
                     .executeUpdate())
         > 0;
@@ -488,8 +485,7 @@ public class HibernateJobConfigurationStore
         """;
     return runWriteInStatelessSession(
             q ->
-                q.createNativeQuery(sql)
-                    .addSynchronizedEntityClass(JobConfiguration.class)
+                nativeSynchronizedQuery(q, sql)
                     .setParameter("id", jobId.getValue())
                     .setParameter("status", status.name())
                     .executeUpdate())
@@ -517,11 +513,7 @@ public class HibernateJobConfigurationStore
           or lastexecuted < (select lastexecuted from jobconfiguration where queuename = :queue and queueposition = 0 limit 1))
         """;
     return runWriteInStatelessSession(
-            q ->
-                q.createNativeQuery(sql)
-                    .addSynchronizedEntityClass(JobConfiguration.class)
-                    .setParameter("queue", queue)
-                    .executeUpdate())
+            q -> nativeSynchronizedQuery(q, sql).setParameter("queue", queue).executeUpdate())
         > 0;
   }
 
@@ -539,8 +531,7 @@ public class HibernateJobConfigurationStore
         """;
     runWriteInStatelessSession(
         q ->
-            q.createNativeQuery(sql)
-                .addSynchronizedEntityClass(JobConfiguration.class)
+            nativeSynchronizedQuery(q, sql)
                 .setParameter("id", jobId.getValue())
                 .setParameter("json", progressJson)
                 .setParameter("errors", errorCodes)
@@ -558,11 +549,7 @@ public class HibernateJobConfigurationStore
         where jobstatus = 'SCHEDULED'
         and enabled = false
         """;
-    return runWriteInStatelessSession(
-        q ->
-            q.createNativeQuery(sql)
-                .addSynchronizedEntityClass(JobConfiguration.class)
-                .executeUpdate());
+    return runWriteInStatelessSession(q -> nativeSynchronizedQuery(q, sql).executeUpdate());
   }
 
   @Override
@@ -580,8 +567,7 @@ public class HibernateJobConfigurationStore
     int deletedCount =
         runWriteInStatelessSession(
             q ->
-                q.createNativeQuery(sql)
-                    .addSynchronizedEntityClass(JobConfiguration.class)
+                nativeSynchronizedQuery(q, sql)
                     .setLockOptions(new LockOptions(LockMode.PESSIMISTIC_WRITE).setTimeOut(2000))
                     .setParameter("ttl", max(1, ttlMinutes))
                     .executeUpdate());
@@ -631,8 +617,7 @@ public class HibernateJobConfigurationStore
         """;
     return runWriteInStatelessSession(
         q ->
-            q.createNativeQuery(sql)
-                .addSynchronizedEntityClass(JobConfiguration.class)
+            nativeSynchronizedQuery(q, sql)
                 .setParameter("timeout", max(1, timeoutMinutes))
                 .executeUpdate());
   }
@@ -664,8 +649,7 @@ public class HibernateJobConfigurationStore
       """;
     return runWriteInStatelessSession(
             q ->
-                q.createNativeQuery(sql)
-                    .addSynchronizedEntityClass(JobConfiguration.class)
+                nativeSynchronizedQuery(q, sql)
                     .setParameter("id", jobId.getValue())
                     .executeUpdate())
         > 0;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -744,8 +744,7 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
         """;
     return getSession()
         .createNativeQuery(sql)
-        // User owns the cached catDimensionConstraints collection on this table. Naming the
-        // entity, not the raw table, is what evicts that collection region.
+        // join table behind the cached User.catDimensionConstraints collection
         .addSynchronizedEntityClass(User.class)
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -744,6 +744,8 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
         """;
     return getSession()
         .createNativeQuery(sql)
+        // the User collection table, not the User table, so the entity class would be wrong here
+        .addSynchronizedQuerySpace("users_catdimensionconstraints")
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
@@ -761,6 +763,7 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
         """;
     return getSession()
         .createNativeQuery(sql)
+        .addSynchronizedQuerySpace("users_catdimensionconstraints")
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
         .executeUpdate();
@@ -782,6 +785,7 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
         """;
     return getSession()
         .createNativeQuery(sql)
+        .addSynchronizedQuerySpace("users_catdimensionconstraints")
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -742,10 +742,7 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
             ORDER BY userid, dataelementcategoryid
         )
         """;
-    return getSession()
-        .createNativeQuery(sql)
-        // join table behind the cached User.catDimensionConstraints collection
-        .addSynchronizedEntityClass(User.class)
+    return nativeSynchronizedQuery(sql)
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
@@ -761,9 +758,7 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
         DELETE FROM users_catdimensionconstraints
         WHERE dataelementcategoryid IN (:sourceCategoryIds)
         """;
-    return getSession()
-        .createNativeQuery(sql)
-        .addSynchronizedEntityClass(User.class)
+    return nativeSynchronizedQuery(sql)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
         .executeUpdate();
@@ -783,9 +778,7 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
             WHERE dataelementcategoryid = :targetCategoryId
         )
         """;
-    return getSession()
-        .createNativeQuery(sql)
-        .addSynchronizedEntityClass(User.class)
+    return nativeSynchronizedQuery(sql)
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -63,6 +63,7 @@ import org.hibernate.jpa.QueryHints;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.Query;
 import org.hisp.dhis.cache.QueryCacheManager;
+import org.hisp.dhis.category.Category;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.common.UID;
@@ -743,6 +744,10 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
         )
         """;
     return nativeSynchronizedQuery(sql)
+        // users_catdimensionconstraints is the User.catDimensionConstraints collection table.
+        // Collection regions are keyed by the collection's element entity, so Category is what
+        // reaches that region, not the owning User.
+        .addSynchronizedEntityClass(Category.class)
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
@@ -759,6 +764,8 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
         WHERE dataelementcategoryid IN (:sourceCategoryIds)
         """;
     return nativeSynchronizedQuery(sql)
+        // see updateCatDimensionConstraintsCategoryRefs
+        .addSynchronizedEntityClass(Category.class)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
         .executeUpdate();
@@ -779,6 +786,8 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
         )
         """;
     return nativeSynchronizedQuery(sql)
+        // see updateCatDimensionConstraintsCategoryRefs
+        .addSynchronizedEntityClass(Category.class)
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -744,8 +744,9 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
         """;
     return getSession()
         .createNativeQuery(sql)
-        // the User collection table, not the User table, so the entity class would be wrong here
-        .addSynchronizedQuerySpace("users_catdimensionconstraints")
+        // User owns the cached catDimensionConstraints collection on this table. Naming the
+        // entity, not the raw table, is what evicts that collection region.
+        .addSynchronizedEntityClass(User.class)
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
@@ -763,7 +764,7 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
         """;
     return getSession()
         .createNativeQuery(sql)
-        .addSynchronizedQuerySpace("users_catdimensionconstraints")
+        .addSynchronizedEntityClass(User.class)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))
         .executeUpdate();
@@ -785,7 +786,7 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
         """;
     return getSession()
         .createNativeQuery(sql)
-        .addSynchronizedQuerySpace("users_catdimensionconstraints")
+        .addSynchronizedEntityClass(User.class)
         .setParameter("targetCategoryId", targetCategoryId)
         .setParameter("sourceCategoryIds", sourceCategoryIds)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(5000))

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/HibernateNativeStore.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/HibernateNativeStore.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Session;
+import org.hibernate.StatelessSession;
 import org.hibernate.metamodel.spi.MetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.SingleTableEntityPersister;
@@ -118,6 +119,17 @@ public abstract class HibernateNativeStore<T> {
   @SuppressWarnings("rawtypes")
   protected NativeQuery nativeSynchronizedQuery(@Language("SQL") String sql) {
     return getSession().createNativeQuery(sql).addSynchronizedEntityClass(getClazz());
+  }
+
+  /**
+   * Same as {@link #nativeSynchronizedQuery(String)} but on a {@link StatelessSession}, which is a
+   * different session from the store's own. Pass the session that opened the surrounding
+   * transaction, otherwise the query runs outside it.
+   */
+  @SuppressWarnings("rawtypes")
+  protected NativeQuery nativeSynchronizedQuery(
+      StatelessSession session, @Language("SQL") String sql) {
+    return session.createNativeQuery(sql).addSynchronizedEntityClass(getClazz());
   }
 
   /**

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/HibernateNativeStore.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/HibernateNativeStore.java
@@ -101,8 +101,16 @@ public abstract class HibernateNativeStore<T> {
    * current class of the store. Use this to avoid all Hibernate second level caches from being
    * invalidated.
    *
-   * <p>Be aware that it is only correct to use this if and only if the only table touched by the
-   * native query is the one table belonging to the store.
+   * <p>Every native write triggers a cache cleanup driven only by its declared query spaces (the
+   * tables it affects). Declare none and Hibernate reads that as "unknown" and evicts
+   * <em>every</em> entity and collection region, so always declare, even when this entity is not
+   * cached.
+   *
+   * <p>Correct only when the sole table this statement <em>writes</em> is the store's own; tables
+   * merely read by a join or subquery need no declaration. Otherwise call {@code
+   * addSynchronizedEntityClass} directly, once per entity written. For a join or child table name
+   * the participating <em>entities</em>, not the table: spaces map to regions via entity
+   * persisters, so a bare join table matches none and evicts nothing.
    *
    * @param sql the SQL query to execute
    * @return the {@link NativeQuery} instance

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/HibernateNativeStore.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/HibernateNativeStore.java
@@ -109,9 +109,15 @@ public abstract class HibernateNativeStore<T> {
    *
    * <p>Correct only when the sole table this statement <em>writes</em> is the store's own; tables
    * merely read by a join or subquery need no declaration. Otherwise call {@code
-   * addSynchronizedEntityClass} directly, once per entity written. For a join or child table name
-   * the participating <em>entities</em>, not the table: spaces map to regions via entity
-   * persisters, so a bare join table matches none and evicts nothing.
+   * addSynchronizedEntityClass} directly, once per entity written.
+   *
+   * <p>Beware collection tables. An entity's query spaces are its own table(s) only, never the
+   * tables of the collections it owns, so declaring the owner does <em>not</em> evict its cached
+   * collections. Hibernate resolves collection regions through {@code
+   * getCollectionRolesByEntityParticipant}, which is keyed by the collection's <em>element</em>
+   * entity. So for a write against a join or child table, declare the entity on the far side of the
+   * association: {@code categories_categoryoptions} needs {@code CategoryOption}, not {@code
+   * Category}.
    *
    * @param sql the SQL query to execute
    * @return the {@link NativeQuery} instance

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/hibernate/HibernateSingleEventStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/hibernate/HibernateSingleEventStore.java
@@ -146,6 +146,6 @@ public class HibernateSingleEventStore extends SoftDeleteHibernateObjectStore<Si
             where attributeoptioncomboid in (%s)"""
             .formatted(coc, cocs.stream().map(String::valueOf).collect(Collectors.joining(",")));
 
-    entityManager.createNativeQuery(sql).executeUpdate();
+    nativeSynchronizedQuery(sql).executeUpdate();
   }
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/hibernate/HibernateTrackerEventStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/hibernate/HibernateTrackerEventStore.java
@@ -149,6 +149,6 @@ public class HibernateTrackerEventStore extends SoftDeleteHibernateObjectStore<T
         where attributeoptioncomboid in (%s)"""
             .formatted(coc, cocs.stream().map(String::valueOf).collect(Collectors.joining(",")));
 
-    entityManager.createNativeQuery(sql).executeUpdate();
+    nativeSynchronizedQuery(sql).executeUpdate();
   }
 }


### PR DESCRIPTION
## The bug

A native query that calls `executeUpdate()` without declaring which tables it touches makes Hibernate discard **every** L2 entity region, not just the one it wrote to.

```java
// evicts every cached entity in the JVM
getSession().createNativeQuery("update jobconfiguration set ...").executeUpdate();

// evicts only the JobConfiguration region
getSession().createNativeQuery("update jobconfiguration set ...")
    .addSynchronizedEntityClass(JobConfiguration.class)
    .executeUpdate();
```

[`HibernateNativeStore.nativeSynchronizedQuery`](https://github.com/dhis2/dhis2-core/blob/a434189842/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/HibernateNativeStore.java#L111) already exists for exactly this and its javadoc says so ("Use this to avoid all Hibernate second level caches from being invalidated"), but these call sites bypass it.

About 32 call sites share this shape and all do the same damage. The one that matters most is `HousekeepingJob`, only because of how often it runs: **every 20 seconds** by default ([`JobType.java#L120`](https://github.com/dhis2/dhis2-core/blob/a434189842/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java#L120)), with all writes unsynchronized, so every cached entity region is dropped on that cadence no matter what the instance is doing. The rest are mostly admin-driven merges and deletes that wipe just as thoroughly but rarely enough to go unnoticed. This PR fixes all of them; a scan for `createNativeQuery(...).executeUpdate()` without an `addSynchronized*` now returns nothing.

## Before / after

Reproducible from `master` on a Sierra Leone database, with no code or test-module changes. The only requirement is two `dhis.conf` flags to expose the counters:

```
monitoring.hibernate.enabled = on
monitoring.ehcache.enabled   = on
```

**Input.** One request, which reads every data element so it touches every key in the `DataElement` region:

```
GET /api/dataElements?fields=id,name,optionSet&paging=false
```

Numbers below are from a database widened to **3037** data elements for unrelated tracker load tests; stock Sierra Leone has 1037.

**Cadence.** 9 requests, with a 30s idle gap between them:

```bash
for i in $(seq 1 8); do request; sleep 30; done
request
```

30s comfortably clears the 20s housekeeping interval, so the window spans at least one tick. Request 1 is unavoidably cold, leaving 8 as the test: each is either a pure hit if the region kept its entries, or cold if it did not. The two outcomes are far apart and cannot be confused: 8 x 3037 = **24,296 hits**, or ~**0 hits** and 9 cold fills.

Counters are `ehcache_*{cache="DataElement",type="L2"}`, since DHIS2 backs Hibernate's L2 with Ehcache 3 via JCache. Note **one Hibernate miss counts as 2 Ehcache misses + 1 put**, because [`putFromLoad`](https://github.com/hibernate/hibernate-orm/blob/e924c27e1259b0b5915819e9521d86fcb8164a46/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java#L92) re-reads the key before installing it.

**Result.** Same script, same database, baseline first then this branch:

| | `master` (`core-dev@d1eb41db`) | this PR |
|---|---|---|
| hits | 2,746 | **24,296** |
| misses | 55,248 | **6,074** |
| hit ratio | **4.7%** | **80%** |
| steady-state misses/min | **12,354** | **0** |
| evictions / removals | 0 / 0 | 0 / 0 |

Both sides account for every lookup exactly. This PR hits **24,296 = 8 x 3037**, the maximum possible, and its 6,074 misses are one cold-start fill. On `master` every request started cold.

Hits and misses per minute, `master` then this branch, switching over mid-run:

<img width="3772" height="1807" alt="hits and misses per minute across the switchover" src="https://github.com/user-attachments/assets/ad44b51f-ad67-4e40-b775-39783a811650" />

At the switchover misses (blue) collapse to zero while hits (green) take over, and hold there for the rest of the run, so the region is warm and serving traffic rather than idle.

A second test pins the cause to a single statement, with no idle gap or background job involved. `HibernatePeriodStore.save()` only runs its `INSERT` when the period row is missing, so on `master` one `POST /api/dataValues` with a **new** period empties the region, while the identical request repeated (period now exists, `INSERT` skipped) leaves it warm. Same endpoint, same payload shape, opposite outcome. On this branch both leave it warm.

## Mechanism

The API to use is [`SynchronizeableQuery`](https://docs.jboss.org/hibernate/orm/5.6/javadocs/org/hibernate/SynchronizeableQuery.html), which `NativeQuery` extends. It provides `addSynchronizedEntityClass`, `addSynchronizedEntityName` and `addSynchronizedQuerySpace`.

Hibernate's own documented statement of the behaviour is the `@implNote` on [`BulkOperationCleanupAction.affectedEntity`](https://github.com/hibernate/hibernate-orm/blob/e924c27e1259b0b5915819e9521d86fcb8164a46/hibernate-core/src/main/java/org/hibernate/action/internal/BulkOperationCleanupAction.java#L156):

> An entity is considered to be affected if either **(1) the affected table spaces are not known** or (2) any of the incoming check table spaces occur in that set.

"Not known" is exactly the case here: an empty query-space set means *every* entity is treated as affected. The chain in 5.6.15:

1. [`NativeSQLQueryPlan.coordinateSharedCacheCleanup:54`](https://github.com/hibernate/hibernate-orm/blob/e924c27e1259b0b5915819e9521d86fcb8164a46/hibernate-core/src/main/java/org/hibernate/engine/query/spi/NativeSQLQueryPlan.java#L54) builds `new BulkOperationCleanupAction(session, getCustomQuery().getQuerySpaces())` **before** the SQL runs, and [`SQLCustomQuery:42`](https://github.com/hibernate/hibernate-orm/blob/e924c27e1259b0b5915819e9521d86fcb8164a46/hibernate-core/src/main/java/org/hibernate/loader/custom/sql/SQLCustomQuery.java#L42) leaves that set empty unless an `addSynchronized*` call fills it.
2. `affectedEntity` then returns `true` for everything, so every persister with `canWriteToCache()` gets an `EntityCleanup`, whose `release()` calls [`unlockRegion`](https://github.com/hibernate/hibernate-orm/blob/e924c27e1259b0b5915819e9521d86fcb8164a46/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractCachedDomainDataAccess.java#L85) -> `evictAll()` -> `evictData()`, emptying the region.

The eviction is the easy part to miss. [`AbstractReadWriteAccess.removeAll:209`](https://github.com/hibernate/hibernate-orm/blob/e924c27e1259b0b5915819e9521d86fcb8164a46/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java#L209) **is** a no-op under `read-write`, so reading only that suggests nothing can be evicted. But `EntityCleanup` calls both `removeAll` and `unlockRegion`, and only the former is neutered.

In `HibernatePeriodStore` and `HibernateJobConfigurationStore`, which write through `openStatelessSession`, `StatelessSessionImpl.isEventSource()` returns `false`, so the cleanup runs **immediately and synchronously** instead of being deferred to the `ActionQueue`.

**Caveat on sourcing.** The 5.6 reference guide documents none of this: its native query chapter never mentions query spaces or the L2 consequences of a native bulk write, and the `SynchronizeableQuery` javadoc describes spaces as affecting only auto-flush and *query result* caching. The claim rests on the `@implNote` above, the source chain, and the measurements here.

### Collections need the element entity, not the owner

Declaring a space is not enough on its own, it has to resolve to the regions you mean, and for a write to a join table the obvious declaration resolves to nothing.

**An entity's query spaces are its own table(s) only, never the tables of the collections it owns.** `Category` owns `categoryOptions`, stored in `categories_categoryoptions`, but `Category`'s spaces are just `{category}`:

```java
// writes categories_categoryoptions, the Category.categoryOptions collection table
.addSynchronizedEntityClass(Category.class)       // spaces = {category}      -> collection NOT evicted
.addSynchronizedEntityClass(CategoryOption.class) // spaces = {categoryoption} -> collection evicted
```

The second works because collection regions are not matched by table name at all. Hibernate looks them up in [`collectionRolesByEntityParticipant`](https://github.com/hibernate/hibernate-orm/blob/e924c27e1259b0b5915819e9521d86fcb8164a46/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetamodelImpl.java#L232-L251), a map keyed by each collection's **element** type. It holds `CategoryOption -> {Category.categoryOptions, ...}`; there is no `Category -> {Category.categoryOptions}` entry to find. Owning a collection does not get you into that map, being an element of one does.

So **declare the entity on the far side of the association**: `categories_categoryoptions` needs `CategoryOption`, `users_catdimensionconstraints` needs `Category`. For `datasetelement`, `DataSetElement` is both its own entity and the element of `DataSet.dataSetElements`, so naming it covers both regions.

Getting this wrong is easy to miss. The entity region still gets evicted, so a re-fetched `Category` has fresh fields and the write looks correct; only its cached option list is stale. A cold cache reloads from the database and hides it entirely, so it only shows up when the collection was cached before the write.

### Why the wipe is hard to attribute

It is measurable, as above, but nothing points at it. It surfaces as a poor hit ratio, which has many plausible causes, and the obvious checks all come back clean:

* nothing is logged. `DefaultHibernateCacheManager.clearCache()`, which does log, is not involved, and DEBUG on `org.hibernate.cache.spi.support`, `org.hibernate.cache.jcache`, `org.hibernate.action.internal` and `org.ehcache` stays silent through a confirmed wipe.
* `ehcache_evictions_total` and `ehcache_removals_total` both stay **0**, because a bulk region clear is not counted per key. They cannot be used to rule this out.
* it is not capacity or TTL. [`ehcache.xml`](https://github.com/dhis2/dhis2-core/blob/a434189842/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml) gives every region 1,000,000 entries and a 6h ttl, against a few thousand entities, and this happens within seconds.

Also ruled out by measurement: the update-timestamps region, key instability, concurrency (a single sequential client reproduces it), and `clearCache()`.

## How this compounds the Uganda tracker issue

Found while investigating stalled `/api/tracker` imports on a Uganda instance (82s wall for 1.3s CPU, ~89% of samples parked on the `DataElement` L2 region lock). That contention is #24773's subject; as described there, the lock is only expensive on **misses**, since hits share a read lock while each miss takes it exclusively.

These wipes are what keep supplying the misses: the region is emptied every 20s, so imports repeatedly face a cold cache and pay an exclusive acquisition per data element. The wipes do not cause the contention, they stop it ever settling. Not tracker specific either, the same cycle hits every cached entity on every instance; tracker import just reads enough of one region per request to make it visible.

