### PR TITLE
perf: batch-fetch ProgramRule.programRuleActions to avoid per-rule N+1

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
@@ -29,7 +29,7 @@
 
     <!-- batch-size: without it, mapping all ProgramRules to rule-engine Rules
          (DefaultProgramRuleEntityMapperService.toMappedProgramRules) lazily inits this
-         collection once per distinct ProgramRule -- live-traced as ~400 single-row
+         collection once per distinct ProgramRule, live-traced as ~400 single-row
          "WHERE programruleid = ?" SELECTs per request. L2 cache doesn't help here since
          each rule is a first-touch within the request, not a repeat lookup. batch-size
          folds pending collection inits within one session into WHERE programruleid IN (...)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
@@ -27,7 +27,15 @@
     <many-to-one name="programStage" class="org.hisp.dhis.program.ProgramStage"
       column="programstageid" foreign-key="fk_programrule_programstage" />
 
-    <set name="programRuleActions" cascade="all-delete-orphan">
+    <!-- batch-size: without it, mapping all ProgramRules to rule-engine Rules
+         (DefaultProgramRuleEntityMapperService.toMappedProgramRules) lazily inits this
+         collection once per distinct ProgramRule -- live-traced as ~400 single-row
+         "WHERE programruleid = ?" SELECTs per request. L2 cache doesn't help here since
+         each rule is a first-touch within the request, not a repeat lookup. batch-size
+         folds pending collection inits within one session into WHERE programruleid IN (...)
+         batches instead. Same category as the CategoryOption/Option batch-size="100"
+         precedent already in this codebase. -->
+    <set name="programRuleActions" cascade="all-delete-orphan" batch-size="100">
       <cache usage="read-write"/>
       <key column="programruleid" />
       <one-to-many class="org.hisp.dhis.programrule.ProgramRuleAction" />


### PR DESCRIPTION
## Summary
- Mapping `ProgramRule`s to rule-engine `Rule`s (`DefaultProgramRuleEntityMapperService.toMappedProgramRules`) lazily initializes the `programRuleActions` collection once per distinct `ProgramRule` it maps.
- Live-traced as ~400 single-row `SELECT ... FROM programruleaction WHERE programruleid = ?` statements in one request (403 executions, ~1 row each) — each is a different rule, so the existing L2 collection cache (`nonstrict-read-write`/`read-write`) can't help: it only serves repeat lookups of the *same* rule's actions, not 403 distinct first-touches within one request.
- `batch-size="100"` on the `programRuleActions` `<set>` folds pending collection initializations within one Hibernate session into `WHERE programruleid IN (...)` batches instead, cutting ~400 round trips down to ~5.
- Same category as the existing `CategoryOption`/`Option` `batch-size="100"` precedent already in this codebase (`ProgramRuleAction` inherits `BaseIdentifiableObject`'s UID-based `equals`/`hashCode`, no mutable-collection risk factor).
- Purely additive mapping attribute — no behavior change, no cache-strategy change.

## Test plan
- [x] `mvn -pl dhis-services/dhis-service-core -am install -DskipTests` — clean build
- [x] `mvn spotless:check` — passes
- [ ] Re-run the traced workload and confirm the `programruleaction` query count drops from ~400 individual SELECTs to ~5 `IN (...)` batches

🤖 AI Assisted