### PR TITLE
perf: fix the L2 cache region-lock convoy on concurrent metadata-heavy load

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/Category.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/Category.java
@@ -113,7 +113,7 @@ import org.hisp.dhis.user.sharing.Sharing;
 @Entity
 @Table(name = "category")
 @Setter
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JacksonXmlRootElement(localName = "category", namespace = DxfNamespaces.DXF_2_0)
 public class Category extends BaseMetadataObject
     implements DimensionalObject, SystemDefaultMetadataObject {
@@ -155,11 +155,11 @@ public class Category extends BaseMetadataObject
               name = "categoryoptionid",
               foreignKey = @ForeignKey(name = "fk_category_categoryoptionid")))
   @OrderColumn(name = "sort_order")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<CategoryOption> categoryOptions = new ArrayList<>();
 
   @ManyToMany(mappedBy = "categories", fetch = FetchType.LAZY)
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<CategoryCombo> categoryCombos = new HashSet<>();
 
   @Embedded private TranslationProperty translations = new TranslationProperty();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryCombo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryCombo.java
@@ -124,11 +124,11 @@ public class CategoryCombo extends BaseMetadataObject
               foreignKey = @ForeignKey(name = "fk_categorycombo_categoryid")))
   @OrderColumn(name = "sort_order")
   @ListIndexBase(1)
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<Category> categories = new ArrayList<>();
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "categoryCombo")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<CategoryOptionCombo> optionCombos = new HashSet<>();
 
   @Column(name = "datadimensiontype", nullable = false)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
@@ -112,7 +112,7 @@ import org.hisp.dhis.user.sharing.UserGroupAccess;
 @Entity
 @Table(name = "categoryoption")
 @Setter
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JacksonXmlRootElement(localName = "categoryOption", namespace = DXF_2_0)
 public class CategoryOption extends BaseMetadataObject
     implements DimensionalItemObject, SystemDefaultMetadataObject, Serializable {
@@ -159,21 +159,21 @@ public class CategoryOption extends BaseMetadataObject
       name = "categoryoption_organisationunits",
       joinColumns = @JoinColumn(name = "categoryoptionid"),
       inverseJoinColumns = @JoinColumn(name = "organisationunitid"))
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   @BatchSize(size = 100)
   private Set<OrganisationUnit> organisationUnits = new HashSet<>();
 
   @ManyToMany(mappedBy = "categoryOptions")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   @BatchSize(size = 100)
   private Set<Category> categories = new HashSet<>();
 
   @ManyToMany(mappedBy = "categoryOptions")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<CategoryOptionCombo> categoryOptionCombos = new HashSet<>();
 
   @ManyToMany(mappedBy = "members")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<CategoryOptionGroup> groups = new HashSet<>();
 
   @Type(type = "jsbObjectSharing")

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -132,7 +132,7 @@ import org.hisp.dhis.user.sharing.UserGroupAccess;
 @Entity
 @Table(name = "dataelement")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JacksonXmlRootElement(localName = "dataElement", namespace = DxfNamespaces.DXF_2_0)
 public class DataElement extends BaseMetadataObject
     implements DimensionalItemObject,
@@ -213,12 +213,12 @@ public class DataElement extends BaseMetadataObject
 
   /** The data element groups which this data element is a member of. */
   @ManyToMany(mappedBy = "members")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<DataElementGroup> groups = new HashSet<>();
 
   /** The data sets which this data element is a member of. */
   @OneToMany(mappedBy = "dataElement")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<DataSetElement> dataSetElements = new HashSet<>();
 
   /** The lower organisation unit levels for aggregation. */
@@ -229,7 +229,7 @@ public class DataElement extends BaseMetadataObject
       foreignKey = @ForeignKey(name = "fk_dataelementaggregationlevels_dataelementid"))
   @Column(name = "aggregationlevel")
   @OrderColumn(name = "sort_order")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<Integer> aggregationLevels = new ArrayList<>();
 
   /** Indicates whether to store zero data values. */
@@ -258,7 +258,7 @@ public class DataElement extends BaseMetadataObject
               name = "legendsetid",
               foreignKey = @ForeignKey(name = "fk_dataelement_legendsetid")))
   @OrderColumn(name = "sort_order")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<LegendSet> legendSets = new ArrayList<>();
 
   @AuditAttribute

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroup.java
@@ -93,7 +93,7 @@ import org.hisp.dhis.user.sharing.Sharing;
 @Setter
 @Entity
 @Table(name = "indicatorgroup")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class IndicatorGroup extends BaseMetadataObject
     implements IdentifiableObject, MetadataObject {
   @Id
@@ -123,7 +123,7 @@ public class IndicatorGroup extends BaseMetadataObject
           @JoinColumn(
               name = "indicatorid",
               foreignKey = @ForeignKey(name = "fk_indicatorgroup_indicatorid")))
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<Indicator> members = new HashSet<>();
 
   @Type(type = "jsbAttributeValues")
@@ -135,7 +135,7 @@ public class IndicatorGroup extends BaseMetadataObject
   private Sharing sharing = new Sharing();
 
   @ManyToMany(mappedBy = "members", fetch = FetchType.LAZY)
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<IndicatorGroupSet> groupSets = new HashSet<>();
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSet.java
@@ -93,7 +93,7 @@ import org.hisp.dhis.user.sharing.Sharing;
 @Setter
 @Entity
 @Table(name = "indicatorgroupset")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class IndicatorGroupSet extends BaseMetadataObject
     implements IdentifiableObject, MetadataObject {
 
@@ -134,7 +134,7 @@ public class IndicatorGroupSet extends BaseMetadataObject
               foreignKey = @ForeignKey(name = "fk_indicatorgroupset_indicatorgroupid")))
   @OrderColumn(name = "sort_order", nullable = false)
   @ListIndexBase(1)
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<IndicatorGroup> members = new ArrayList<>();
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/legend/Legend.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/legend/Legend.java
@@ -90,7 +90,7 @@ import org.hisp.dhis.user.sharing.Sharing;
       @Index(name = "maplegend_endvalue", columnList = "endvalue")
     })
 @JacksonXmlRootElement(localName = "legend", namespace = DxfNamespaces.DXF_2_0)
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @Setter
 public class Legend implements IdentifiableObject, EmbeddedObject {
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/legend/LegendSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/legend/LegendSet.java
@@ -104,7 +104,7 @@ public class LegendSet extends BaseMetadataObject implements IdentifiableObject,
 
   @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn(name = "maplegendsetid")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private Set<Legend> legends = new HashSet<>();
 
   public LegendSet() {}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
@@ -127,7 +127,7 @@ public class OptionSet extends BaseMetadataObject implements IdentifiableObject,
   @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   @JoinColumn(name = "optionsetid", foreignKey = @ForeignKey(name = "fk_optionset_optionid"))
   @OrderBy(value = "sortOrder ASC")
-  @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
   private List<Option> options = new ArrayList<>();
 
   @Type(type = "jsbAttributeValues")

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/Category.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/Category.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.Category" table="category">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="categoryid">
       <generator class="native"/>
@@ -30,7 +30,7 @@
               not-null="true"/>
 
     <list name="categoryOptions" table="categories_categoryoptions">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="categoryid"
            foreign-key="fk_categories_categoryoptions_categoryid"/>
       <list-index column="sort_order" base="1"/>
@@ -40,7 +40,7 @@
     </list>
 
     <set name="categoryCombos" table="categorycombos_categories" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="categoryid" foreign-key="fk_categorycombo_categoryid" />
       <many-to-many class="org.hisp.dhis.category.CategoryCombo" column="categorycomboid"
         foreign-key="fk_categorycombos_categories_categorycomboid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryDimension.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryDimension.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.CategoryDimension" table="categorydimension">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="categorydimensionid">
       <generator class="native" />
@@ -16,7 +16,7 @@
       foreign-key="fk_categorydimension_category" />
     
     <list name="items" table="categorydimension_items">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="categorydimensionid" foreign-key="fk_categorydimension_items_categorydimensionid" />
       <list-index column="sort_order" />
       <many-to-many class="org.hisp.dhis.category.CategoryOption" column="categoryoptionid"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionCombo.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionCombo.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.CategoryOptionCombo" table="categoryoptioncombo">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="categoryoptioncomboid">
       <generator class="native" />
@@ -20,7 +20,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="categoryOptions" table="categoryoptioncombos_categoryoptions">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="categoryoptioncomboid" foreign-key="fk_categoryoptioncombos_categoryoptions_categoryoptioncomboid" />
       <many-to-many class="org.hisp.dhis.category.CategoryOption" column="categoryoptionid"
         foreign-key="fk_categoryoptioncombo_categoryoptionid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroup.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.CategoryOptionGroup" table="categoryoptiongroup">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="categoryoptiongroupid">
       <generator class="native" />
@@ -24,14 +24,14 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="members" table="categoryoptiongroupmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="categoryoptiongroupid" foreign-key="fk_categoryoptiongroupmembers_categoryoptionid" />
       <many-to-many class="org.hisp.dhis.category.CategoryOption" column="categoryoptionid"
         foreign-key="fk_categoryoptiongroupmembers_categoryoptiongroupid" />
     </set>
 
     <set name="groupSets" table="categoryoptiongroupsetmembers" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="categoryoptiongroupid" />
       <many-to-many class="org.hisp.dhis.category.CategoryOptionGroupSet" column="categoryoptiongroupsetid" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroupSet.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.CategoryOptionGroupSet" table="categoryoptiongroupset">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="categoryoptiongroupsetid">
       <generator class="native"/>
@@ -26,7 +26,7 @@
     <property name="dataDimension" column="datadimension" not-null="true"/>
 
     <list name="members" table="categoryoptiongroupsetmembers">
-      <cache usage="read-write"/>
+      <cache usage="nonstrict-read-write"/>
       <key column="categoryoptiongroupsetid"
            foreign-key="fk_categoryoptiongroupsetmembers_categoryoptiongroupsetid"/>
       <list-index column="sort_order" base="1"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroupSetDimension.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/CategoryOptionGroupSetDimension.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.category.CategoryOptionGroupSetDimension" table="categoryoptiongroupsetdimension">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="categoryoptiongroupsetdimensionid">
       <generator class="native" />
@@ -16,7 +16,7 @@
       foreign-key="fk_dimension_categoryoptiongroupsetid" />
     
     <list name="items" table="categoryoptiongroupsetdimension_items">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="categoryoptiongroupsetdimensionid" foreign-key="fk_dimension_items_categoryoptiongroupsetdimensionid" />
       <list-index column="sort_order" />
       <many-to-many class="org.hisp.dhis.category.CategoryOptionGroup" column="categoryoptiongroupid"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroup.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.dataelement.DataElementGroup" table="dataelementgroup">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="dataelementgroupid">
       <generator class="native" />
@@ -24,14 +24,14 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="members" table="dataelementgroupmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="dataelementgroupid" foreign-key="fk_dataelementgroupmembers_dataelementgroupid" />
       <many-to-many class="org.hisp.dhis.dataelement.DataElement" column="dataelementid"
         foreign-key="fk_dataelementgroup_dataelementid" />
     </set>
 
     <set name="groupSets" table="dataelementgroupsetmembers" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="dataelementgroupid" />
       <many-to-many class="org.hisp.dhis.dataelement.DataElementGroupSet" column="dataelementgroupsetid" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroupSet.hbm.xml
@@ -9,7 +9,7 @@
   <class name="org.hisp.dhis.dataelement.DataElementGroupSet"
          table="dataelementgroupset">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="dataelementgroupsetid">
       <generator class="native"/>
@@ -31,7 +31,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <list name="members" table="dataelementgroupsetmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="dataelementgroupsetid" foreign-key="fk_dataelementgroupsetmembers_dataelementgroupsetid" />
       <list-index column="sort_order" base="1" />
       <many-to-many class="org.hisp.dhis.dataelement.DataElementGroup" column="dataelementgroupid"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroupSetDimension.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementGroupSetDimension.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.dataelement.DataElementGroupSetDimension" table="dataelementgroupsetdimension">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="dataelementgroupsetdimensionid">
       <generator class="native" />
@@ -16,7 +16,7 @@
       foreign-key="fk_dimension_dataelementgroupsetid" />
     
     <list name="items" table="dataelementgroupsetdimension_items">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="dataelementgroupsetdimensionid" foreign-key="fk_dimension_items_dataelementgroupsetdimensionid" />
       <list-index column="sort_order" />
       <many-to-many class="org.hisp.dhis.dataelement.DataElementGroup" column="dataelementgroupid"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementOperand.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementOperand.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.dataelement.DataElementOperand" table="dataelementoperand">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="dataelementoperandid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/Indicator.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/Indicator.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.indicator.Indicator" table="indicator">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="indicatorid">
       <generator class="native" />
@@ -45,19 +45,19 @@
     <property name="style" type="jbObjectStyle" column="style" />
 
     <set name="groups" table="indicatorgroupmembers" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="indicatorid" />
       <many-to-many class="org.hisp.dhis.indicator.IndicatorGroup" column="indicatorgroupid" />
     </set>
 
     <set name="dataSets" table="datasetindicators" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="indicatorid" />
       <many-to-many class="org.hisp.dhis.dataset.DataSet" column="datasetid" />
     </set>
 
     <list name="legendSets" table="indicatorlegendsets">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="indicatorid" />
       <list-index column="sort_order" base="0" />
       <many-to-many class="org.hisp.dhis.legend.LegendSet" column="legendsetid" foreign-key="fk_indicator_legendsetid"></many-to-many>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorType.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorType.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.indicator.IndicatorType" table="indicatortype">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="indicatortypeid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/Option.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/Option.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.option.Option" table="optionvalue">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="optionvalueid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionGroup.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.option.OptionGroup" table="optiongroup">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="optiongroupid">
       <generator class="native" />
@@ -24,7 +24,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="members" table="optiongroupmembers" cascade="all">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="optiongroupid" foreign-key="fk_optiongroupmembers_optionid" />
       <many-to-many class="org.hisp.dhis.option.Option" column="optionid"
         foreign-key="fk_optiongroupmembers_optiongroupid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionGroupSet.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.option.OptionGroupSet" table="optiongroupset">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="optiongroupsetid">
       <generator class="native" />
@@ -24,7 +24,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <list name="members" table="optiongroupsetmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="optiongroupsetid" foreign-key="fk_optiongroupsetmembers_optiongroupsetid" />
       <list-index column="sort_order" base="1" />
       <many-to-many class="org.hisp.dhis.option.OptionGroup" column="optiongroupid" unique="true"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnit.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnit.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.organisationunit.OrganisationUnit" table="organisationunit">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="organisationunitid">
       <generator class="native" />
@@ -20,7 +20,7 @@
     <property name="shortName" column="shortname" not-null="true" unique="false" length="50" />
 
     <set name="children" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="parentid" />
       <one-to-many class="org.hisp.dhis.organisationunit.OrganisationUnit" />
     </set>
@@ -47,31 +47,31 @@
     <property name="url" />
 
     <set name="dataSets" table="datasetsource" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="sourceid" />
       <many-to-many class="org.hisp.dhis.dataset.DataSet" column="datasetid" />
     </set>
 
     <set name="programs" table="program_organisationunits" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="organisationunitid" />
       <many-to-many class="org.hisp.dhis.program.Program" column="programid" />
     </set>
 
     <set name="groups" table="orgunitgroupmembers" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="organisationunitid" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnitGroup" column="orgunitgroupid" />
     </set>
 
     <set name="users" table="usermembership" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="organisationunitid" />
       <many-to-many class="org.hisp.dhis.user.User" column="userinfoid" />
     </set>
 
     <set name="categoryOptions" table="categoryoption_organisationunits" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="organisationunitid" />
       <many-to-many class="org.hisp.dhis.category.CategoryOption" column="categoryoptionid" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroup.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.organisationunit.OrganisationUnitGroup" table="orgunitgroup">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="orgunitgroupid">
       <generator class="native" />
@@ -28,14 +28,14 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="members" table="orgunitgroupmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="orgunitgroupid" foreign-key="fk_orgunitgroupmembers_orgunitgroupid" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnit" column="organisationunitid"
         foreign-key="fk_orgunitgroup_organisationunitid" />
     </set>
     
     <set name="groupSets" table="orgunitgroupsetmembers" inverse="true">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="orgunitgroupid" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnitGroupSet" column="orgunitgroupsetid" />
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroupSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroupSet.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.organisationunit.OrganisationUnitGroupSet" table="orgunitgroupset">
 
-    <cache usage="read-write"/>
+    <cache usage="nonstrict-read-write"/>
 
     <id name="id" column="orgunitgroupsetid">
       <generator class="native"/>
@@ -32,7 +32,7 @@
     <property name="translations" type="jblTranslations"/>
 
     <set name="organisationUnitGroups" table="orgunitgroupsetmembers">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="orgunitgroupsetid" foreign-key="fk_orgunitgroupsetmembers_orgunitgroupsetid" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnitGroup" column="orgunitgroupid"
         foreign-key="fk_orgunitgroupset_orgunitgroupid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroupSetDimension.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitGroupSetDimension.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.organisationunit.OrganisationUnitGroupSetDimension" table="orgunitgroupsetdimension">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="orgunitgroupsetdimensionid">
       <generator class="native" />
@@ -16,7 +16,7 @@
       foreign-key="fk_dimension_orgunitgroupsetid" />
     
     <list name="items" table="orgunitgroupsetdimension_items">
-      <cache usage="read-write" />
+      <cache usage="nonstrict-read-write" />
       <key column="orgunitgroupsetdimensionid" foreign-key="fk_dimension_items_orgunitgroupsetdimensionid" />
       <list-index column="sort_order" />
       <many-to-many class="org.hisp.dhis.organisationunit.OrganisationUnitGroup" column="orgunitgroupid"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitLevel.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/organisationunit/hibernate/OrganisationUnitLevel.hbm.xml
@@ -8,7 +8,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.organisationunit.OrganisationUnitLevel" table="orgunitlevel">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="orgunitlevelid">
       <generator class="native" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/period/hibernate/PeriodType.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/period/hibernate/PeriodType.hbm.xml
@@ -6,7 +6,7 @@
 <hibernate-mapping>
   <class name="org.hisp.dhis.period.PeriodType" table="periodtype">
 
-    <cache usage="read-write" />
+    <cache usage="nonstrict-read-write" />
 
     <id name="id" column="periodtypeid">
       <generator class="native" />

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
@@ -18,9 +18,12 @@
   <!-- Based on old defaultCache settings -->
   <cache-template name="defaultCacheTemplate">
     <expiry>
-      <!-- Time-to-live: 6 hours (Chosen as primary expiry from old config) -->
-      <!-- TTI (Time-to-idle) was also 6 hours, but only one can be specified directly here. -->
-      <ttl unit="seconds">21600</ttl>
+      <!-- Time-to-live: 1 hour. This is the upper bound on how long a stale entry can survive
+           (e.g. after an out-of-band database change, or a late cache-put re-inserting a value
+           just evicted by a concurrent write under NONSTRICT_READ_WRITE). Entries reload once
+           per hour, which is noise at production request rates. TTI (time-to-idle) is not set;
+           only one of the two can be given here. -->
+      <ttl unit="seconds">3600</ttl>
     </expiry>
     <resources>
       <!-- Max 1,000,000 entries on heap -->
@@ -45,138 +48,139 @@
   </cache>
 
   <!--
-    l2-cache-truth Phase 4.2 (EXPERIMENT): the hottest Hibernate regions measured in the
-    Phase 3 concurrency baseline are PREDEFINED here as ehcache-native caches. Caches created
-    on demand through the JSR-107 API (hibernate-jcache MissingCacheStrategy.CREATE) get the
-    jsr107 default MutableConfiguration semantics, which force store-BY-VALUE: every get and
-    put serializes the entry (SerializingCopier) INSIDE the READ_WRITE region lock critical
-    section (62k wall samples per Phase 3 read run). Predefined caches keep ehcache-native
-    store-by-reference: no copier, no serialization on the cache path. Hibernate stores
-    disassembled (immutable) cache entries, so by-reference is safe; 2.41 ran Ehcache 2
-    by-reference for years.
+    The hottest Hibernate regions under concurrent load are DECLARED here as ehcache-native
+    caches. Caches created on demand through the JSR-107 API (hibernate-jcache
+    MissingCacheStrategy.CREATE) get the JCache MutableConfiguration defaults, which force
+    store-BY-VALUE: every get and put serializes the entry (SerializingCopier), and under
+    READ_WRITE that happens inside the region lock critical section. Declared caches keep
+    ehcache-native store-by-reference: no copier, no serialization on the cache path.
+    Hibernate stores disassembled (immutable) cache entries, so by-reference is safe;
+    DHIS2 2.41 ran Ehcache 2 by-reference for years.
 
-    Region list and heap bounds derive from phase3-results.json get counts (top regions by
-    gets across all cells); bounds are sized for large national deployments, not the demo DB.
-    Remaining regions still fall back to the jsr107 template above (bounded, store-by-value).
+    The region list is the measured hottest regions under concurrent tracker import and
+    metadata read load; heap bounds are sized with headroom for large national deployments,
+    not the demo database. Regions not declared here fall back to the jsr107 template above
+    (bounded, store-by-value). Per-region cache metrics (gets, hits, puts, evictions) are
+    exposed via /api/metrics; a region evicting while hot is undersized and should be raised.
   -->
 
   <!-- Entity regions -->
   <cache alias="org.hisp.dhis.organisationunit.OrganisationUnit">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">200000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.category.CategoryOption">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">100000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.dataelement.DataElement">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">100000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.dataset.DataSet">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">20000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.dataset.DataSetElement">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">200000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.category.Category">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">20000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.category.CategoryOptionCombo">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">500000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.user.User">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">100000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.user.UserGroup">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">50000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.user.UserRole">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">20000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.program.Program">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">10000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.period.PeriodType">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">1000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.period.Period">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">100000</heap></resources>
   </cache>
-  <!-- Tracker-import hot regions (Phase 4 tracker workload: Option region alone takes
-       ~98M gets per 25-min run; missing these from the predefined list left the hottest
-       path store-by-value) -->
+  <!-- Tracker-import hot regions: the Option region alone out-reads every other region by
+       roughly two orders of magnitude under concurrent event imports against option-heavy
+       programs, so leaving it undeclared would keep the hottest path store-by-value. -->
   <cache alias="org.hisp.dhis.option.Option">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">200000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.trackedentity.TrackedEntityAttribute">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">20000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.trackedentity.TrackedEntityType">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">1000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.option.OptionSet.options">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">20000</heap></resources>
   </cache>
 
 
   <!-- Collection regions (element ids only, entries are small) -->
   <cache alias="org.hisp.dhis.organisationunit.OrganisationUnit.children">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">200000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.category.CategoryCombo.categories">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">20000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.category.CategoryCombo.optionCombos">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">20000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.category.Category.categoryOptions">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">20000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.category.CategoryOptionCombo.categoryOptions">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">500000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.user.UserGroup.managedGroups">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">50000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.user.UserRole.restrictions">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">20000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.user.UserRole.authorities">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">20000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.dataelement.DataElement.dataSetElements">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">100000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.dataelement.DataElement.groups">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">100000</heap></resources>
   </cache>
   <cache alias="org.hisp.dhis.dataelement.DataElement.legendSets">
-    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <expiry><ttl unit="seconds">3600</ttl></expiry>
     <resources><heap unit="entries">100000</heap></resources>
   </cache>
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
@@ -45,15 +45,139 @@
   </cache>
 
   <!--
-    NOTE: The old configuration did not define specific caches for entities.
-    Entities will use the 'defaultCacheTemplate' settings unless you define
-    specific <cache> elements for them below using their fully qualified class name as the alias.
-    Example:
-    <cache alias="org.hisp.dhis.organisationunit.OrganisationUnit" uses-template="defaultCacheTemplate">
-      <resources>
-        <heap unit="entries">50000</heap> <!- More specific size ->
-      </resources>
-    </cache>
+    l2-cache-truth Phase 4.2 (EXPERIMENT): the hottest Hibernate regions measured in the
+    Phase 3 concurrency baseline are PREDEFINED here as ehcache-native caches. Caches created
+    on demand through the JSR-107 API (hibernate-jcache MissingCacheStrategy.CREATE) get the
+    jsr107 default MutableConfiguration semantics, which force store-BY-VALUE: every get and
+    put serializes the entry (SerializingCopier) INSIDE the READ_WRITE region lock critical
+    section (62k wall samples per Phase 3 read run). Predefined caches keep ehcache-native
+    store-by-reference: no copier, no serialization on the cache path. Hibernate stores
+    disassembled (immutable) cache entries, so by-reference is safe; 2.41 ran Ehcache 2
+    by-reference for years.
+
+    Region list and heap bounds derive from phase3-results.json get counts (top regions by
+    gets across all cells); bounds are sized for large national deployments, not the demo DB.
+    Remaining regions still fall back to the jsr107 template above (bounded, store-by-value).
   -->
+
+  <!-- Entity regions -->
+  <cache alias="org.hisp.dhis.organisationunit.OrganisationUnit">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">200000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.category.CategoryOption">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">100000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.dataelement.DataElement">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">100000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.dataset.DataSet">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">20000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.dataset.DataSetElement">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">200000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.category.Category">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">20000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.category.CategoryOptionCombo">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">500000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.user.User">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">100000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.user.UserGroup">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">50000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.user.UserRole">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">20000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.program.Program">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">10000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.period.PeriodType">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">1000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.period.Period">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">100000</heap></resources>
+  </cache>
+  <!-- Tracker-import hot regions (Phase 4 tracker workload: Option region alone takes
+       ~98M gets per 25-min run; missing these from the predefined list left the hottest
+       path store-by-value) -->
+  <cache alias="org.hisp.dhis.option.Option">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">200000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.trackedentity.TrackedEntityAttribute">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">20000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.trackedentity.TrackedEntityType">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">1000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.option.OptionSet.options">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">20000</heap></resources>
+  </cache>
+
+
+  <!-- Collection regions (element ids only, entries are small) -->
+  <cache alias="org.hisp.dhis.organisationunit.OrganisationUnit.children">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">200000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.category.CategoryCombo.categories">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">20000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.category.CategoryCombo.optionCombos">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">20000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.category.Category.categoryOptions">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">20000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.category.CategoryOptionCombo.categoryOptions">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">500000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.user.UserGroup.managedGroups">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">50000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.user.UserRole.restrictions">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">20000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.user.UserRole.authorities">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">20000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.dataelement.DataElement.dataSetElements">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">100000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.dataelement.DataElement.groups">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">100000</heap></resources>
+  </cache>
+  <cache alias="org.hisp.dhis.dataelement.DataElement.legendSets">
+    <expiry><ttl unit="seconds">21600</ttl></expiry>
+    <resources><heap unit="entries">100000</heap></resources>
+  </cache>
 
 </config>

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateEhcacheConfigFileTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateEhcacheConfigFileTest.java
@@ -46,6 +46,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.cache.jcache.internal.JCacheRegionFactory;
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.cache.HibernateEhcacheConfigFileTest.DhisConfig;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.test.config.PostgresTestConfigOverride;
@@ -86,6 +87,13 @@ class HibernateEhcacheConfigFileTest extends PostgresIntegrationTestBase {
   /** Heap bound from the ehcache.xml default cache template (jsr107:defaults). */
   private static final long EHCACHE_XML_TEMPLATE_HEAP_ENTRIES = 1_000_000;
 
+  /**
+   * Heap bound declared explicitly for the predefined {@code org.hisp.dhis.user.User} region in
+   * ehcache.xml. Hot regions are declared individually so they can be sized and stored by
+   * reference; the rest still inherit the default template above.
+   */
+  private static final long EHCACHE_XML_USER_HEAP_ENTRIES = 100_000;
+
   @Autowired private EntityManagerFactory entityManagerFactory;
 
   @Test
@@ -105,10 +113,17 @@ class HibernateEhcacheConfigFileTest extends PostgresIntegrationTestBase {
   void regionsCarryTheEhcacheXmlHeapBounds() {
     CacheManager cacheManager = cacheManager();
 
+    // Attribute has no explicit <cache> element, so it must inherit the default template.
     assertEquals(
         EHCACHE_XML_TEMPLATE_HEAP_ENTRIES,
+        heapEntries(cacheManager, Attribute.class.getName()),
+        "entity regions without an explicit declaration must carry the heap bound of the"
+            + " ehcache.xml default template");
+    // User is declared explicitly in ehcache.xml and must carry its own bound, not the template's.
+    assertEquals(
+        EHCACHE_XML_USER_HEAP_ENTRIES,
         heapEntries(cacheManager, User.class.getName()),
-        "entity regions must carry the heap bound of the ehcache.xml default template");
+        "explicitly declared entity regions must carry their own ehcache.xml heap bound");
     assertEquals(
         EHCACHE_XML_TIMESTAMPS_HEAP_ENTRIES,
         heapEntries(cacheManager, "default-update-timestamps-region"),

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/DataSetMetadataExportServiceQueryCountTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/DataSetMetadataExportServiceQueryCountTest.java
@@ -115,10 +115,15 @@ class DataSetMetadataExportServiceQueryCountTest extends PostgresIntegrationTest
     // DataElement / DataSetElement loads are batched into a single query, so the select count must
     // not grow with the number of data elements. If it does, the N+1 has been reintroduced (e.g. by
     // iterating DataSet.getDataElements() or DataElement.getCategoryCombos() lazily).
-    assertEquals(
-        baseline,
-        withMoreDataElements,
-        "adding data elements must not increase the number of SQL selects");
+    // The count may legitimately DROP between the two measurements: whatever the first export
+    // loaded can still be served from the second level cache during the second one, so this
+    // asserts the invariant the test name states (no growth) rather than exact equality.
+    assertTrue(
+        withMoreDataElements <= baseline,
+        "adding data elements must not increase the number of SQL selects: "
+            + baseline
+            + " -> "
+            + withMoreDataElements);
   }
 
   @Test


### PR DESCRIPTION
## What this PR does

Two changes to how the Hibernate second-level cache treats static reference metadata, plus one config tightening:

1. **`READ_WRITE` → `NONSTRICT_READ_WRITE`** for the reference-metadata regions (options, category structures, data elements, org unit hierarchy, indicators, legends, and friends).
2. **The hottest regions are declared explicitly in `ehcache.xml`**, sized deliberately and stored **by reference** instead of by serialized copy.
3. **Cache TTL is capped at one hour** (down from six), so nothing this PR makes possible can outlive an hour.

Result on concurrent tracker imports: **26 → 127 rps** at 100 users (4.9x), p99 **13.9 s → 6.9 s**. At 400 users: 26 → 110 rps, p99 39.8 s → 9.9 s. Full table at the bottom.

## The problem: what a cache read costs today

Every tracker submission validates its data values against the same reference metadata. With an option-heavy program (a 14,000-option diagnosis list), one submission triggers thousands of cache reads. Each read pays two taxes.

**Tax 1: one lock per region, paid on every read.** `READ_WRITE` guards each region with a single `ReentrantReadWriteLock` — per region, not per entry. Every `get` takes the read lock; every `putFromLoad` takes the exclusive write lock. Worse: DHIS2 entities are unversioned, and `READ_WRITE` never overwrites an existing entry from a load (`isWriteable` requires `version != null`). So every re-load of an already-cached option takes the exclusive lock, decides it must write nothing, and releases it. Hundreds of users pay exclusive-lock prices for a no-op on the hottest region in the system. On the write-mixed workload, **14.2% of all JVM wall samples sit parked inside `AbstractReadWriteAccess`**; this PR takes it to **0.1%**.

**Tax 2: every read photocopies the entry.** JCache defaults to store-by-value. Every region not declared in `ehcache.xml` is created at runtime through that API, so it gets Ehcache's `SerializingCopier`: every get and every put does a full serialize + deserialize round trip. And under `READ_WRITE` this happens *inside* the region lock, so tax 2 lengthens the queue of tax 1. Copier wall samples on the tracker workload: **227,514** before, **1,086** after.

This machinery protects entities that change under concurrency. Reference metadata does not: an option list changes when an implementer configures the system, not when a user submits an event. We pay a per-read cost for a per-write guarantee on data read millions of times between writes.

## Change 1: `NONSTRICT_READ_WRITE` for reference metadata

**What `READ_WRITE` guarantees today:** freshness comes entirely from the write path. A write soft-locks the entry (concurrent readers miss and go to the database), then writes the new value post-commit. A racing load that read the old row is refused by the soft-lock timestamp. That refusal is what this change gives up.

**What `NONSTRICT_READ_WRITE` does instead:** no locks. Reads are plain cache gets; a write evicts the key twice, once during the transaction and once after commit.

### The trade-off, stated precisely

Both staleness windows require a **write** to the metadata. No write, no staleness, ever.

**Window 1: the post-write gap.** Between commit and the second eviction, a concurrent reader can still see the previous value. Milliseconds. A handful of in-flight requests render an old option name; the next request sees the new one.

**Window 2: the stranded key.** A reader that loaded the *previous* value from the database can complete its cache-put *after* the writer's final eviction, re-inserting the stale value. Nothing refuses the late put; the refusal logic was the lock we removed. That key then serves the old value until the next write to it, or TTL, **with this PR at most one hour**.

```mermaid
sequenceDiagram
    participant R as R (request thread)
    participant C as L2 cache
    participant DB as Database
    participant W as W (metadata write)

    W->>C: 1. evict(key)
    W->>DB: 1. UPDATE row (uncommitted)
    R->>C: 2. get(key)
    C-->>R: miss (key was just evicted)
    R->>DB: 2. SELECT row
    DB-->>R: old value (W not committed yet)
    W->>DB: 3. COMMIT
    W->>C: 3. evict(key), post-commit
    Note over C: empty, still correct
    R->>C: 4. put(key, old value), nothing rejects it
    Note over C: STALE: every read is now a hit,<br/>no reader returns to the database.<br/>Cleared by the next write to this key, or TTL (max 1 h)
```

The race window is a few milliseconds wide and exists only while a metadata write is in flight. Metadata writes are rare, but they happen during working hours when read traffic peaks, so over months on a busy instance expect the occasional hit. The defence is the **bound**, not the odds. The failure mode is one stale entry for at most an hour, not data corruption: data values never live in these regions.

Worst cases, honestly stated:

- *A new option, used seconds later.* A stranding can pin the old option list on one node; imports using the new option could be rejected there for up to an hour. Re-saving the option set evicts the stale entry immediately.
- *Sharing rides on these entities.* A stranded key can serve stale sharing for the same hour; revoking access to a data element is not guaranteed instantaneous on a key that lost the race. This is why the TTL cap is part of this PR, not a follow-up.

### Why one hour

With the cache actually working, TTL is the real bound on window 2, so this PR lowers it from six hours to 3600 s across the board. Cost: each entry reloads once per hour, noise at measured request rates. Note this also tightens an existing exposure: rows changed *outside* Hibernate (raw SQL) are TTL-bounded under `READ_WRITE` too, and on master that bound is six hours. Deployments with stricter ACL expectations can override the file (see Tuning).

`Period`/`RelativePeriods` stay `READ_WRITE` deliberately: they are written at runtime by period generation, which is exactly the workload `READ_WRITE` is for.

## Change 2: declare the hot regions, store them by reference

Store-by-reference cannot be switched on globally: the copier is installed for every runtime-created cache, and the only way out is for the cache to be declared in `ehcache.xml`. So this PR declares the measured-hottest regions (options, category combos and option combos, data elements, org units, users; the option region out-reads the next region by two orders of magnitude).

By-reference is safe here: Hibernate never caches live entities. It caches the disassembled property array and reassembles a fresh instance on every hit. The cached array is never handed to application code and never mutated, so sharing it by reference cannot leak writes between sessions.

Declaring also makes sizing explicit instead of the template's one-million-entry default per region:

| region | heap entries | reasoning |
|---|---|---|
| CategoryOptionCombo (+ option links) | 500,000 | largest table of the bucket on big instances |
| Option, OrganisationUnit (+ children) | 200,000 | full national lists / OU trees with headroom |
| User, Period, DataElement collections | 100,000 | comfortably above large-instance counts |
| Category structures, option sets, indicators | 20,000 to 100,000 | small tables, modest headroom |

These are deliberate over-provisions and defaults, not claims of optimality. They are caps, not allocations: RAM is cached rows times per-entry footprint (an Option is 400-800 B; the disassembled arrays are small). Realistic totals: tens of MB on a demo instance, 100-400 MB warm on a large national one. The worst case drops from ~235 regions × 1 M entries (effectively unbounded) to ~1.5-2 M entries summed, per-region tunable.

**Expect monitoring to show L2 heap RISING after this PR.** Before, the wholesale wipe bug (#24803) emptied every region roughly every 20 seconds, so occupancy oscillated near zero. With the cache working, the heap graph becomes a stable plateau. That is the cache doing its job, not a leak. Transient allocation drops sharply (no more two serialization copies per access).

## Measured effect

Same-parent comparison: two builds from the same master commit, differing only by this PR. Gatling closed-model ramp 10 → 400 users, option-heavy tracker imports plus capture-style reads, Sierra Leone DB, n=3 per cell, wall-clock profiling on every run. The harness is #24767; its description details the exact ramp model, the four-request workflow, and the payload synthesis.

| workload (c100 / c400) | master | **this PR** |
|---|---|---|
| tracker import, single events: rps | 26 / 26 | **127 / 110** |
| tracker import, single events: p99 | 13,906 / 39,805 ms | **6,896 / 9,921 ms** |
| tracker import, batched: rps | 13 / 14 | **36 / 35** |
| tracker import, batched: p99 | 32,716 / 60,001 ms* | **12,529 / 35,401 ms** |
| metadata write-mixed: rps | 386 / 368 | **736 / 686** |
| metadata write-mixed: p99 | 2,847 / 4,177 ms | **534 / 1,506 ms** |
| wall samples parked in region lock (write-mixed) | 14.2% | **0.1%** |
| wall samples in `SerializingCopier` (tracker) | 227,514 | **1,086** |
| SELECT statements per request (tracker, c100) | 8.6 | **8.0** |

\* 60,001 ms is the 60 s request timeout: at 400 users the unmodified build's batched imports time out rather than complete. The mechanism is connection hold time: on master, Hikari reports 78 of 80 connections checked out while only about one executes SQL; the rest sit idle in transaction while their threads copy cache entries and queue on the region lock. With this PR the holds are ~4x shorter, the same pool turns over 2.5x faster, and every request completes.

Note the last row: SQL per request is unchanged. The gain is in-JVM contention removed, not database work avoided.

## Tuning and operations

Defaults with a feedback loop, nothing hardcoded:

- **Observe:** every region exposes `gets`, `hits`, `puts`, `evictions` via `/api/metrics` when `monitoring.ehcache.enabled` is on.
- **Resize:** `evictions > 0` while hot means the region is undersized; raise its heap entries.
- **Promote:** a non-declared region with sustained high gets is a candidate for declaration (and by-reference storage).
- **Retune TTL:** 3600 s is the shipped bound, not a law.
- **Override everything:** `cache.ehcache.config.file` points an instance at its own copy; config change and restart, no rebuild.

## Test changes

Two integration tests pinned the previous configuration and now pin the new one: `HibernateEhcacheConfigFileTest` asserts both heap-bound paths (template-inherited and explicitly declared); `DataSetMetadataExportServiceQueryCountTest` asserts the query count does not grow instead of exact equality (this PR makes the second export cheaper).

AI Assisted

