### PR TITLE
fix: remove L2 cache on the OptionSet.options collection to avoid tracker import N+1

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionSet.hbm.xml
@@ -31,8 +31,15 @@
 
     <property name="version" />
 
+    <!-- Collection L2 cache intentionally omitted: a cache hit here (a cached list of Option
+         ids) combined with an entity-cache miss on one of those ids makes Hibernate resolve each
+         id one at a time instead of just re-running this bag's own query, which is what produced
+         an observed N+1 (thousands of individual `SELECT ... FROM optionvalue WHERE
+         optionvalueid = ?`) during tracker import. Without a cached id list to reconcile against
+         the entity cache, this collection always loads via its own single
+         `WHERE optionsetid = ?` query instead, which is fast (single query, indexed FK). Entity-
+         level caching for Option/OptionSet themselves is unaffected and still applies. -->
     <bag name="options" cascade="all" order-by="sort_order">
-      <cache usage="read-write" />
       <key column="optionsetid" foreign-key="fk_optionsetmembers_optionsetid" />
       <one-to-many class="org.hisp.dhis.option.Option" />
     </bag>


### PR DESCRIPTION
## Summary
- Live Glowroot trace on a 2.41 dev server showed an intermittent N+1 during `/tracker` import: thousands of individual `SELECT ... FROM optionvalue WHERE optionvalueid = ?` in a single request.
- Root cause: a collection-cache-hit / entity-cache-miss combination. `OptionSet.options`' L2 collection cache can hold a cached list of option IDs while the individual `Option` entities' L2 cache has separately evicted (region-wide L2 eviction is not per-key). When that happens, Hibernate resolves each ID one at a time instead of re-running the plain `WHERE optionsetid = ?` collection query — which is fast (~1.4ms, indexed FK) and is what a second trace confirmed as the normal/fast path.
- Fix: remove only the `<cache>` on the `OptionSet.options` bag. With no cached id list to reconcile against the entity cache, the collection always loads via its own single query — there's no cached/uncached combination left to produce the N+1.
- Entity-level `<cache usage="read-write">` on `Option` and `OptionSet` themselves is left in place — it's unrelated to this mechanism and still useful for other lookup paths (e.g. resolving a many-to-one reference). An earlier version of this PR removed those too, conflating this fix with a separate, unvalidated idea (a service-layer replacement cache) that isn't part of this change.

## Test plan
- [x] `xmllint --noout` on the edited `.hbm.xml` file (well-formedness, no stray `--` in comments)
- [x] `dhis-service-core` + `dhis-test-integration` build cleanly with the new mapping
- [ ] CI test suite (local Postgres integration run was blocked by pre-existing environment state unrelated to this change — confirmed by reproducing the same failure on unmodified `2.41`)

🤖 AI Assisted