### PR TITLE
fix: stop tracker preheat from fully materializing OptionSet.options (master port of #24813)

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -308,6 +308,8 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     assertHasOnlyWarnings(importReport, E1308);
     if (!hasValidValue) {
       assertHasOnlyErrors(importReport, E1125);
+    } else {
+      assertNoErrors(importReport);
     }
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,25 +34,37 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.UserInfoSnapshot;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.imports.ParamsConverter;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.bundle.persister.CommitService;
 import org.hisp.dhis.tracker.imports.bundle.persister.PersistenceException;
 import org.hisp.dhis.tracker.imports.bundle.persister.TrackerObjectDeletionService;
 import org.hisp.dhis.tracker.imports.bundle.persister.TrackerPersister.PersistResult;
+import org.hisp.dhis.tracker.imports.domain.Attribute;
+import org.hisp.dhis.tracker.imports.domain.DataValue;
+import org.hisp.dhis.tracker.imports.domain.Enrollment;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.notification.EntityNotifications;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheatService;
+import org.hisp.dhis.tracker.imports.preheat.supplier.OptionValueSupplier;
 import org.hisp.dhis.tracker.imports.programrule.ProgramRuleService;
+import org.hisp.dhis.tracker.imports.programrule.executor.enrollment.AssignAttributeExecutor;
+import org.hisp.dhis.tracker.imports.programrule.executor.event.AssignDataValueExecutor;
 import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.user.UserDetails;
@@ -77,6 +89,8 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
 
   private final TrackerObjectDeletionService deletionService;
 
+  private final OptionValueSupplier optionValueSupplier;
+
   private final ObjectMapper mapper;
 
   @Nonnull
@@ -97,7 +111,94 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
   public TrackerBundle runRuleEngine(@Nonnull TrackerBundle trackerBundle) {
     programRuleService.calculateRuleEffects(trackerBundle, trackerBundle.getPreheat());
 
+    optionValueSupplier.preheatAdd(
+        collectRuleAssignedValues(trackerBundle), trackerBundle.getPreheat());
+
     return trackerBundle;
+  }
+
+  /**
+   * Collects the values {@code ASSIGN} rule actions are going to apply, shaped as a synthetic
+   * {@link TrackerObjects} payload the {@link OptionValueSupplier} can resolve option codes from.
+   *
+   * <p>Rule engine validation rejects unknown option codes based on {@link
+   * TrackerPreheat#isValidOptionCode(Long, String)}, but {@code ASSIGN} actions can add or
+   * overwrite data values and attributes that were not in the original payload, so the codes they
+   * introduce were never resolved during preheat and valid data would be rejected with E1125.
+   *
+   * <p>The values are already final here: they are the rule engine's evaluated output, captured in
+   * the executors {@code calculateRuleEffects} just built, so nothing evaluated later can change
+   * them.
+   *
+   * <p>All assigned values are gathered onto a single synthetic event and enrollment. The supplier
+   * only looks at (data element, value) and (attribute, value) pairs, so which or how many real
+   * entities the values belong to does not matter.
+   */
+  private TrackerObjects collectRuleAssignedValues(TrackerBundle bundle) {
+    TrackerPreheat preheat = bundle.getPreheat();
+
+    Set<DataValue> assignedDataValues =
+        bundle.getEventRuleActionExecutors().values().stream()
+            .flatMap(List::stream)
+            .filter(AssignDataValueExecutor.class::isInstance)
+            .map(AssignDataValueExecutor.class::cast)
+            .map(executor -> toDataValue(preheat, executor))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    List<Attribute> assignedAttributes =
+        bundle.getEnrollmentRuleActionExecutors().values().stream()
+            .flatMap(List::stream)
+            .filter(AssignAttributeExecutor.class::isInstance)
+            .map(AssignAttributeExecutor.class::cast)
+            .map(executor -> toAttribute(preheat, executor))
+            .filter(Objects::nonNull)
+            .toList();
+
+    return TrackerObjects.builder()
+        .events(
+            List.of(
+                TrackerEvent.builder()
+                    .event(UID.generate())
+                    .dataValues(assignedDataValues)
+                    .build()))
+        .enrollments(
+            List.of(
+                Enrollment.builder()
+                    .enrollment(UID.generate())
+                    .attributes(assignedAttributes)
+                    .build()))
+        .build();
+  }
+
+  /**
+   * Executors only know the target's UID, while the supplier looks metadata up by the payload's id
+   * scheme, so the identifier has to be converted the same way the executors themselves do when
+   * they apply the value.
+   */
+  private DataValue toDataValue(TrackerPreheat preheat, AssignDataValueExecutor executor) {
+    DataElement dataElement = preheat.getDataElement(executor.getDataElementUid().getValue());
+    if (dataElement == null) {
+      return null;
+    }
+
+    return DataValue.builder()
+        .dataElement(preheat.getIdSchemes().toMetadataIdentifier(dataElement))
+        .value(executor.getValue())
+        .build();
+  }
+
+  private Attribute toAttribute(TrackerPreheat preheat, AssignAttributeExecutor executor) {
+    TrackedEntityAttribute attribute =
+        preheat.getTrackedEntityAttribute(executor.getAttributeUid().getValue());
+    if (attribute == null) {
+      return null;
+    }
+
+    return Attribute.builder()
+        .attribute(preheat.getIdSchemes().toMetadataIdentifier(attribute))
+        .value(executor.getValue())
+        .build();
   }
 
   @Nonnull

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/config/TrackerPreheatConfig.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/config/TrackerPreheatConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,6 +38,7 @@ import org.hisp.dhis.tracker.imports.preheat.supplier.DuplicateRelationshipSuppl
 import org.hisp.dhis.tracker.imports.preheat.supplier.EnrollmentsWithAtLeastOneEventSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.EventCategoryOptionComboSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.FileResourceSupplier;
+import org.hisp.dhis.tracker.imports.preheat.supplier.OptionValueSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.OrgUnitValueTypeSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.PreheatStrategyScanner;
 import org.hisp.dhis.tracker.imports.preheat.supplier.PreheatSupplier;
@@ -56,6 +57,7 @@ public class TrackerPreheatConfig {
   private final List<Class<? extends PreheatSupplier>> preheatOrder =
       List.of(
           ClassBasedSupplier.class,
+          OptionValueSupplier.class,
           DefaultsSupplier.class,
           TrackedEntityEnrollmentSupplier.class,
           EnrollmentsWithAtLeastOneEventSupplier.class,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -136,6 +136,42 @@ public class TrackerPreheat {
   private Pair<String, Set<MetadataIdentifier>> toCategoryOptionComboCacheKey(
       CategoryCombo categoryCombo, Set<MetadataIdentifier> categoryOptions) {
     return Pair.of(categoryCombo.getUid(), categoryOptions);
+  }
+
+  /**
+   * Set of (option set id, option code) pairs confirmed to exist, populated by {@code
+   * OptionValueSupplier}. Only pairs actually referenced by the import payload are present here —
+   * this is not the full set of options for any given option set.
+   *
+   * <p>Preheated {@link org.hisp.dhis.option.OptionSet} instances deliberately carry no populated
+   * {@code options} collection (see {@code OptionSetMapper} for why). {@link
+   * #isValidOptionCode(Long, String)} and {@link #addValidOptionCode(Long, String)} are the
+   * supported way to check option code validity against preheated data. Do not call {@code
+   * OptionSet#getOptions()} on a preheated option set expecting real data — it is always empty.
+   */
+  private final Set<Pair<Long, String>> validOptionCodes = new HashSet<>();
+
+  /**
+   * Option sets {@code OptionValueSupplier} attempted to resolve. Lets callers tell "this code was
+   * checked against the database and does not exist" apart from "this option set was never resolved
+   * at all", which would be an internal bug rather than user error.
+   */
+  private final Set<Long> resolvedOptionSets = new HashSet<>();
+
+  public void addValidOptionCode(Long optionSetId, String code) {
+    this.validOptionCodes.add(Pair.of(optionSetId, code));
+  }
+
+  public boolean isValidOptionCode(Long optionSetId, String code) {
+    return this.validOptionCodes.contains(Pair.of(optionSetId, code));
+  }
+
+  public void addResolvedOptionSet(Long optionSetId) {
+    this.resolvedOptionSets.add(optionSetId);
+  }
+
+  public boolean isOptionSetResolved(Long optionSetId) {
+    return this.resolvedOptionSets.contains(optionSetId);
   }
 
   /**

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/OptionSetMapper.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/OptionSetMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,15 +29,19 @@
  */
 package org.hisp.dhis.tracker.imports.preheat.mappers;
 
-import java.util.List;
-import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
+/**
+ * {@code options} is deliberately left unmapped — mapping it would force Hibernate to fully
+ * materialize the {@code OptionSet.options} collection (including JSONB attribute values) on every
+ * preheat, regardless of how many option codes the import actually references. {@link
+ * org.hisp.dhis.tracker.imports.preheat.supplier.OptionValueSupplier} preheats only the specific
+ * {@code (option set, code)} pairs the payload references instead.
+ */
 @Mapper
 public interface OptionSetMapper extends PreheatMapper<OptionSet> {
   OptionSetMapper INSTANCE = Mappers.getMapper(OptionSetMapper.class);
@@ -47,9 +51,5 @@ public interface OptionSetMapper extends PreheatMapper<OptionSet> {
   @Mapping(target = "uid")
   @Mapping(target = "name")
   @Mapping(target = "code")
-  @Mapping(target = "options", qualifiedByName = "options")
   OptionSet map(OptionSet optionSet);
-
-  @Named("options")
-  List<Option> mapOptionValues(List<Option> options);
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/OptionValueSupplier.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/OptionValueSupplier.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.preheat.supplier;
+
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
+import org.hisp.dhis.tracker.imports.domain.Attribute;
+import org.hisp.dhis.tracker.imports.domain.DataValue;
+import org.hisp.dhis.tracker.imports.domain.Enrollment;
+import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.imports.util.Constant;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowCallbackHandler;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Preheats the specific {@code (option set, code)} pairs referenced by the import payload, instead
+ * of letting {@code OptionSetMapper} fully materialize every {@link
+ * org.hisp.dhis.option.OptionSet#getOptions()} collection. Cost is bounded by how many distinct
+ * option codes the payload actually references, not by option set size.
+ *
+ * @see org.hisp.dhis.tracker.imports.preheat.TrackerPreheat#isValidOptionCode(Long, String)
+ */
+@Component
+public class OptionValueSupplier extends JdbcAbstractPreheatSupplier {
+  private static final String OPTION_SET_ID = "optionsetid";
+
+  private static final String CODE = "code";
+
+  private static final String SQL =
+      "select optionsetid, code from optionvalue"
+          + " where optionsetid in (:optionSetIds)"
+          + " and code in (:codes)";
+
+  protected OptionValueSupplier(JdbcTemplate jdbcTemplate) {
+    super(jdbcTemplate);
+  }
+
+  @Override
+  public void preheatAdd(TrackerObjects trackerObjects, TrackerPreheat preheat) {
+    Set<Pair<Long, String>> candidates = collectCandidates(trackerObjects, preheat);
+
+    if (candidates.isEmpty()) {
+      return;
+    }
+
+    for (List<Pair<Long, String>> chunk :
+        Lists.partition(new ArrayList<>(candidates), Constant.SPLIT_LIST_PARTITION_SIZE)) {
+      queryChunk(chunk, preheat);
+    }
+  }
+
+  Set<Pair<Long, String>> collectCandidates(TrackerObjects trackerObjects, TrackerPreheat preheat) {
+    Set<Pair<Long, String>> candidates = new HashSet<>();
+
+    for (TrackedEntity trackedEntity : trackerObjects.getTrackedEntities()) {
+      for (Attribute attribute : trackedEntity.getAttributes()) {
+        addCandidates(
+            preheat.getTrackedEntityAttribute(attribute.getAttribute()),
+            attribute.getValue(),
+            candidates,
+            preheat);
+      }
+    }
+
+    for (Enrollment enrollment : trackerObjects.getEnrollments()) {
+      for (Attribute attribute : enrollment.getAttributes()) {
+        addCandidates(
+            preheat.getTrackedEntityAttribute(attribute.getAttribute()),
+            attribute.getValue(),
+            candidates,
+            preheat);
+      }
+    }
+
+    for (TrackerEvent event : trackerObjects.getEvents()) {
+      for (DataValue dataValue : event.getDataValues()) {
+        addCandidates(
+            preheat.getDataElement(dataValue.getDataElement()),
+            dataValue.getValue(),
+            candidates,
+            preheat);
+      }
+    }
+
+    return candidates;
+  }
+
+  private void addCandidates(
+      ValueTypedDimensionalItemObject optionalObject,
+      String value,
+      Set<Pair<Long, String>> candidates,
+      TrackerPreheat preheat) {
+    if (optionalObject == null || value == null || !optionalObject.hasOptionSet()) {
+      return;
+    }
+
+    Long optionSetId = optionalObject.getOptionSet().getId();
+    preheat.addResolvedOptionSet(optionSetId);
+
+    List<String> codes =
+        optionalObject.getValueType().isMultiText()
+            ? ValueType.splitMultiText(value)
+            : List.of(value);
+
+    for (String code : codes) {
+      candidates.add(Pair.of(optionSetId, code));
+    }
+  }
+
+  private void queryChunk(List<Pair<Long, String>> chunk, TrackerPreheat preheat) {
+    Set<Long> optionSetIds = new HashSet<>();
+    Set<String> codes = new HashSet<>();
+    for (Pair<Long, String> pair : chunk) {
+      optionSetIds.add(pair.getLeft());
+      codes.add(pair.getRight());
+    }
+
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+    parameters.addValue("optionSetIds", optionSetIds);
+    parameters.addValue("codes", codes);
+
+    Set<Pair<Long, String>> confirmed = new HashSet<>();
+    jdbcTemplate.query(
+        SQL,
+        parameters,
+        (RowCallbackHandler)
+            rs -> confirmed.add(Pair.of(rs.getLong(OPTION_SET_ID), rs.getString(CODE))));
+
+    for (Pair<Long, String> pair : chunk) { // NOSONAR confirmed comes from the query in between
+      if (confirmed.contains(pair)) {
+        preheat.addValidOptionCode(pair.getLeft(), pair.getRight());
+      }
+    }
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/executor/enrollment/AssignAttributeExecutor.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/executor/enrollment/AssignAttributeExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,6 +63,20 @@ public class AssignAttributeExecutor implements RuleActionExecutor<Enrollment> {
   private final UID attributeUid;
 
   private final List<Attribute> attributes;
+
+  /** The tracked entity attribute this action assigns to. */
+  public UID getAttributeUid() {
+    return attributeUid;
+  }
+
+  /**
+   * The value this action will assign. It is the rule engine's already evaluated output, so it is
+   * final and known as soon as the rule effects have been calculated, before {@link
+   * #executeRuleAction(TrackerBundle, Enrollment)} runs.
+   */
+  public String getValue() {
+    return value;
+  }
 
   @Override
   public Optional<ProgramRuleIssue> executeRuleAction(TrackerBundle bundle, Enrollment enrollment) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/executor/event/AssignDataValueExecutor.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/executor/event/AssignDataValueExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -66,6 +66,15 @@ public class AssignDataValueExecutor implements RuleActionExecutor<Event> {
   @Override
   public UID getDataElementUid() {
     return dataElementUid;
+  }
+
+  /**
+   * The value this action will assign. It is the rule engine's already evaluated output, so it is
+   * final and known as soon as the rule effects have been calculated, before {@link
+   * #executeRuleAction(TrackerBundle, Event)} runs.
+   */
+  public String getValue() {
+    return value;
   }
 
   @Override

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
@@ -52,7 +53,6 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.fileresource.FileResource;
-import org.hisp.dhis.option.Option;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ValidationStrategy;
@@ -77,6 +77,7 @@ import org.locationtech.jts.geom.Geometry;
 /**
  * @author Luciano Fiandesio
  */
+@Slf4j
 public class ValidationUtils {
   private ValidationUtils() {
     throw new IllegalStateException("Utility class");
@@ -249,22 +250,33 @@ public class ValidationUtils {
   }
 
   public static <T extends ValueTypedDimensionalItemObject> void validateOptionSet(
-      Reporter reporter, TrackerDto dto, T optionalObject, @Nonnull String value) {
+      Reporter reporter,
+      TrackerPreheat preheat,
+      TrackerDto dto,
+      T optionalObject,
+      @Nonnull String value) {
     if (!optionalObject.hasOptionSet()) {
       return;
     }
-
-    Set<String> validCodes =
-        optionalObject.getOptionSet().getOptions().stream()
-            .map(Option::getCode)
-            .collect(Collectors.toSet());
 
     List<String> codes =
         optionalObject.getValueType().isMultiText()
             ? ValueType.splitMultiText(value)
             : List.of(value);
 
-    if (!validCodes.containsAll(codes)) {
+    Long optionSetId = optionalObject.getOptionSet().getId();
+    boolean allCodesValid =
+        codes.stream().allMatch(code -> preheat.isValidOptionCode(optionSetId, code));
+
+    if (!allCodesValid) {
+      if (!preheat.isOptionSetResolved(optionSetId)) {
+        // Diagnostic only, the validation outcome below is unchanged. An unresolved option set
+        // means the supplier never checked it, which is an internal bug rather than user error.
+        log.warn(
+            "Option set {} was never resolved during preheat; treating code {} as invalid",
+            optionalObject.getOptionSet().getUid(),
+            value);
+      }
       reporter.addError(dto, ValidationCode.E1125, value, optionalObject.getOptionSet().getUid());
     }
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -95,7 +95,7 @@ class AttributeValidator
         attributeValueMap.put(attribute.getAttribute(), attribute.getValue());
         validateAttributeValue(reporter, enrollment, attribute.getValue());
         validateValueType(reporter, bundle, enrollment, attribute.getValue(), teAttribute);
-        validateOptionSet(reporter, enrollment, teAttribute, attribute.getValue());
+        validateOptionSet(reporter, preheat, enrollment, teAttribute, attribute.getValue());
 
         validateAttributeUniqueness(
             reporter, preheat, enrollment, attribute.getValue(), teAttribute, te, orgUnit);

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -112,7 +112,7 @@ class DataValuesValidator implements Validator<Event> {
     }
 
     if (dataElement.hasOptionSet()) {
-      validateOptionSet(reporter, event, dataElement, dataValue.getValue());
+      validateOptionSet(reporter, bundle.getPreheat(), event, dataElement, dataValue.getValue());
     }
     validateValueType(reporter, bundle, event, dataValue.getValue(), dataElement);
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -128,7 +128,7 @@ class AttributeValidator
 
       validateAttributeValue(reporter, trackedEntity, attribute.getValue());
       validateValueType(reporter, bundle, trackedEntity, attribute.getValue(), tea);
-      validateOptionSet(reporter, trackedEntity, tea, attribute.getValue());
+      validateOptionSet(reporter, preheat, trackedEntity, tea, attribute.getValue());
 
       validateAttributeUniqueness(
           reporter, preheat, trackedEntity, attribute.getValue(), tea, te, orgUnit);

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -84,6 +84,35 @@ class TrackerPreheatTest extends TrackerTestBase {
   void testAllEmpty() {
     assertTrue(preheat.isEmpty());
     assertTrue(preheat.getAll(Program.class).isEmpty());
+  }
+
+  @Test
+  void shouldReturnFalseForUnknownOptionCode() {
+    assertFalse(preheat.isValidOptionCode(1L, "CODE"));
+  }
+
+  @Test
+  void shouldReturnTrueOnlyForTheExactOptionSetAndCodePairAdded() {
+    preheat.addValidOptionCode(1L, "CODE");
+
+    assertTrue(preheat.isValidOptionCode(1L, "CODE"));
+    assertFalse(preheat.isValidOptionCode(1L, "OTHER"));
+    assertFalse(preheat.isValidOptionCode(2L, "CODE"));
+  }
+
+  @Test
+  void shouldReturnFalseForOptionSetThatWasNeverResolved() {
+    assertFalse(preheat.isOptionSetResolved(1L));
+  }
+
+  @Test
+  void shouldTrackResolvedOptionSetsIndependentlyOfCodeValidity() {
+    preheat.addResolvedOptionSet(1L);
+
+    assertTrue(preheat.isOptionSetResolved(1L));
+    assertFalse(preheat.isOptionSetResolved(2L));
+    // resolving an option set says nothing about which of its codes are valid
+    assertFalse(preheat.isValidOptionCode(1L, "CODE"));
   }
 
   @Test

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/OptionValueSupplierTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/OptionValueSupplierTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.preheat.supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.tracker.TrackerIdSchemeParam;
+import org.hisp.dhis.tracker.imports.domain.Attribute;
+import org.hisp.dhis.tracker.imports.domain.DataValue;
+import org.hisp.dhis.tracker.imports.domain.Enrollment;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
+import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class OptionValueSupplierTest {
+
+  private JdbcTemplate jdbcTemplate;
+
+  private OptionValueSupplier supplier;
+
+  private OptionSet optionSet;
+
+  private DataElement dataElement;
+
+  private TrackedEntityAttribute trackedEntityAttribute;
+
+  @BeforeEach
+  void setUp() {
+    jdbcTemplate = mock(JdbcTemplate.class);
+    supplier = new OptionValueSupplier(jdbcTemplate);
+
+    optionSet = new OptionSet();
+    optionSet.setId(1L);
+
+    dataElement = new DataElement();
+    dataElement.setUid("dataElement");
+    dataElement.setValueType(ValueType.TEXT);
+    dataElement.setOptionSet(optionSet);
+
+    trackedEntityAttribute = new TrackedEntityAttribute();
+    trackedEntityAttribute.setUid("attribute");
+    trackedEntityAttribute.setValueType(ValueType.MULTI_TEXT);
+    trackedEntityAttribute.setOptionSet(optionSet);
+  }
+
+  @Test
+  void shouldCollectCandidateFromEventDataValue() {
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(dataElement);
+
+    DataValue dataValue =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("dataElement"))
+            .value("A00")
+            .build();
+    TrackerEvent event =
+        TrackerEvent.builder().event(UID.generate()).dataValues(Set.of(dataValue)).build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    Set<Pair<Long, String>> candidates = supplier.collectCandidates(trackerObjects, preheat);
+
+    assertEquals(Set.of(Pair.of(1L, "A00")), candidates);
+  }
+
+  @Test
+  void shouldSplitMultiTextValuesFromTrackedEntityAndEnrollmentAttributes() {
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(TrackerIdSchemeParam.UID, trackedEntityAttribute);
+
+    Attribute attribute =
+        Attribute.builder()
+            .attribute(MetadataIdentifier.ofUid("attribute"))
+            .value("A00,B99")
+            .build();
+    TrackedEntity trackedEntity =
+        TrackedEntity.builder()
+            .trackedEntity(UID.generate())
+            .attributes(List.of(attribute))
+            .build();
+    Enrollment enrollment =
+        Enrollment.builder().enrollment(UID.generate()).attributes(List.of(attribute)).build();
+    TrackerObjects trackerObjects =
+        TrackerObjects.builder()
+            .trackedEntities(List.of(trackedEntity))
+            .enrollments(List.of(enrollment))
+            .build();
+
+    Set<Pair<Long, String>> candidates = supplier.collectCandidates(trackerObjects, preheat);
+
+    assertEquals(Set.of(Pair.of(1L, "A00"), Pair.of(1L, "B99")), candidates);
+  }
+
+  @Test
+  void shouldSkipValuesWithoutAnOptionSet() {
+    DataElement plainDataElement = new DataElement();
+    plainDataElement.setUid("plain");
+    plainDataElement.setValueType(ValueType.TEXT);
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(plainDataElement);
+
+    DataValue dataValue =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("plain"))
+            .value("anything")
+            .build();
+    TrackerEvent event =
+        TrackerEvent.builder().event(UID.generate()).dataValues(Set.of(dataValue)).build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    Set<Pair<Long, String>> candidates = supplier.collectCandidates(trackerObjects, preheat);
+
+    assertEquals(Set.of(), candidates);
+  }
+
+  @Test
+  void shouldSkipValuesWhoseDataElementIsNotPreheated() {
+    TrackerPreheat preheat = new TrackerPreheat();
+
+    DataValue dataValue =
+        DataValue.builder().dataElement(MetadataIdentifier.ofUid("unknown")).value("A00").build();
+    TrackerEvent event =
+        TrackerEvent.builder().event(UID.generate()).dataValues(Set.of(dataValue)).build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    Set<Pair<Long, String>> candidates = supplier.collectCandidates(trackerObjects, preheat);
+
+    assertEquals(Set.of(), candidates);
+  }
+
+  @Test
+  void shouldNotQueryTheDatabaseWhenNoValueReferencesAnOptionSet() {
+    DataElement plainDataElement = new DataElement();
+    plainDataElement.setUid("plain");
+    plainDataElement.setValueType(ValueType.TEXT);
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(plainDataElement);
+
+    DataValue dataValue =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("plain"))
+            .value("anything")
+            .build();
+    TrackerEvent event =
+        TrackerEvent.builder().event(UID.generate()).dataValues(Set.of(dataValue)).build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    supplier.preheatAdd(trackerObjects, preheat);
+
+    verifyNoInteractions(jdbcTemplate);
+  }
+
+  @Test
+  void shouldMarkOptionSetAsResolvedEvenWhenNoCodeTurnsOutToBeValid() {
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(dataElement);
+
+    DataValue dataValue =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("dataElement"))
+            .value("A00")
+            .build();
+    TrackerEvent event =
+        TrackerEvent.builder().event(UID.generate()).dataValues(Set.of(dataValue)).build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    supplier.collectCandidates(trackerObjects, preheat);
+
+    assertTrue(preheat.isOptionSetResolved(1L));
+    // no code was confirmed against the database, the option set is still "resolved"
+    assertFalse(preheat.isValidOptionCode(1L, "A00"));
+  }
+
+  @Test
+  void shouldNotMarkAnOptionSetAsResolvedWhenNoValueReferencesOne() {
+    DataElement plainDataElement = new DataElement();
+    plainDataElement.setUid("plain");
+    plainDataElement.setValueType(ValueType.TEXT);
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(plainDataElement);
+
+    DataValue dataValue =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("plain"))
+            .value("anything")
+            .build();
+    TrackerEvent event =
+        TrackerEvent.builder().event(UID.generate()).dataValues(Set.of(dataValue)).build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    supplier.collectCandidates(trackerObjects, preheat);
+
+    assertFalse(preheat.isOptionSetResolved(1L));
+  }
+}

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,6 +48,7 @@ import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
@@ -251,6 +252,62 @@ class AttributeValidatorTest {
                 .trackedEntity(enrollment.getTrackedEntity())
                 .attributes(List.of(attribute, attribute1))
                 .build()));
+
+    validator.validate(reporter, bundle, enrollment);
+
+    assertNoErrors(reporter);
+  }
+
+  @Test
+  void shouldFailValidationWhenAttributeValueIsNotValidOptionCode() {
+    OptionSet optionSet = new OptionSet();
+    optionSet.setId(1L);
+    trackedEntityAttribute.setOptionSet(optionSet);
+
+    Attribute attribute =
+        Attribute.builder()
+            .attribute(MetadataIdentifier.ofUid(TRACKED_ATTRIBUTE))
+            .value("wrongCode")
+            .build();
+
+    when(program.getProgramAttributes())
+        .thenReturn(
+            List.of(
+                new ProgramTrackedEntityAttribute(program, trackedEntityAttribute, false, false)));
+    when(enrollment.getAttributes()).thenReturn(Collections.singletonList(attribute));
+    when(trackedEntity.getTrackedEntityAttributeValues()).thenReturn(Set.of());
+    when(enrollment.getTrackedEntity()).thenReturn(UID.generate());
+    when(preheat.getTrackedEntity(enrollment.getTrackedEntity())).thenReturn(trackedEntity);
+    when(preheat.isValidOptionCode(1L, "wrongCode")).thenReturn(false);
+    bundle.setStrategy(enrollment, TrackerImportStrategy.CREATE);
+
+    validator.validate(reporter, bundle, enrollment);
+
+    assertHasError(reporter, enrollment, ValidationCode.E1125);
+  }
+
+  @Test
+  void shouldPassValidationWhenAttributeValueIsValidOptionCode() {
+    OptionSet optionSet = new OptionSet();
+    optionSet.setId(1L);
+    trackedEntityAttribute.setOptionSet(optionSet);
+
+    Attribute attribute =
+        Attribute.builder()
+            .attribute(MetadataIdentifier.ofUid(TRACKED_ATTRIBUTE))
+            .value("CODE")
+            .build();
+
+    when(program.getProgramAttributes())
+        .thenReturn(
+            List.of(
+                new ProgramTrackedEntityAttribute(program, trackedEntityAttribute, false, false)));
+    when(enrollment.getAttributes()).thenReturn(Collections.singletonList(attribute));
+    when(trackedEntity.getTrackedEntityAttributeValues()).thenReturn(Set.of());
+    when(enrollment.getTrackedEntity()).thenReturn(UID.generate());
+    when(preheat.getTrackedEntity(enrollment.getTrackedEntity())).thenReturn(trackedEntity);
+    when(preheat.isValidOptionCode(1L, "CODE")).thenReturn(true);
+    bundle.setStrategy(enrollment, TrackerImportStrategy.CREATE);
 
     validator.validate(reporter, bundle, enrollment);
 

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,6 @@ import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidatio
 import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidations.assertNoErrors;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -45,7 +44,6 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.fileresource.FileResource;
-import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.ProgramStage;
@@ -869,16 +867,13 @@ class DataValuesValidatorTest {
     DataValue nullDataValue = dataValue(null);
 
     OptionSet optionSet = new OptionSet();
-    Option option = new Option();
-    option.setCode("CODE");
-    Option option1 = new Option();
-    option1.setCode("CODE1");
-    optionSet.setOptions(List.of(option, option1));
+    optionSet.setId(1L);
 
     DataElement dataElement = dataElement();
     dataElement.setOptionSet(optionSet);
     when(preheat.getDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID)))
         .thenReturn(dataElement);
+    when(preheat.isValidOptionCode(1L, "CODE")).thenReturn(true);
 
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
@@ -903,16 +898,13 @@ class DataValuesValidatorTest {
     validDataValue.setDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID));
 
     OptionSet optionSet = new OptionSet();
-    Option option = new Option();
-    option.setCode("CODE");
-    Option option1 = new Option();
-    option1.setCode("CODE1");
-    optionSet.setOptions(List.of(option, option1));
+    optionSet.setId(1L);
 
     DataElement dataElement = dataElement();
     dataElement.setOptionSet(optionSet);
     when(preheat.getDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID)))
         .thenReturn(dataElement);
+    when(preheat.isValidOptionCode(1L, "value")).thenReturn(false);
 
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
@@ -937,16 +929,14 @@ class DataValuesValidatorTest {
     DataValue nullDataValue = dataValue(null);
 
     OptionSet optionSet = new OptionSet();
-    Option option = new Option();
-    option.setCode("CODE");
-    Option option1 = new Option();
-    option1.setCode("CODE1");
-    optionSet.setOptions(List.of(option, option1));
+    optionSet.setId(1L);
 
     DataElement dataElement = dataElement(ValueType.MULTI_TEXT);
     dataElement.setOptionSet(optionSet);
     when(preheat.getDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID)))
         .thenReturn(dataElement);
+    when(preheat.isValidOptionCode(1L, "CODE")).thenReturn(true);
+    when(preheat.isValidOptionCode(1L, "CODE1")).thenReturn(true);
 
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
@@ -971,16 +961,14 @@ class DataValuesValidatorTest {
     validDataValue.setDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID));
 
     OptionSet optionSet = new OptionSet();
-    Option option = new Option();
-    option.setCode("CODE");
-    Option option1 = new Option();
-    option1.setCode("CODE1");
-    optionSet.setOptions(List.of(option, option1));
+    optionSet.setId(1L);
 
     DataElement dataElement = dataElement(ValueType.MULTI_TEXT);
     dataElement.setOptionSet(optionSet);
     when(preheat.getDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID)))
         .thenReturn(dataElement);
+    when(preheat.isValidOptionCode(1L, "CODE1")).thenReturn(true);
+    when(preheat.isValidOptionCode(1L, "CODE2")).thenReturn(false);
 
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidatorTest.java
@@ -91,7 +91,7 @@ class AttributeValidatorTest {
   private TrackerIdSchemeParams idSchemes;
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     bundle = TrackerBundle.builder().preheat(preheat).build();
     idSchemes = TrackerIdSchemeParams.builder().build();
     when(preheat.getIdSchemes()).thenReturn(idSchemes);

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,7 +46,6 @@ import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.fileresource.FileResource;
-import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
@@ -393,6 +392,7 @@ class AttributeValidatorTest {
         .thenReturn(trackedEntityAttribute);
     when(preheat.getTrackedEntityType((MetadataIdentifier) any()))
         .thenReturn(new TrackedEntityType());
+    when(preheat.isValidOptionCode(1L, "wrongCode")).thenReturn(false);
 
     TrackedEntity trackedEntity =
         TrackedEntity.builder()
@@ -419,6 +419,7 @@ class AttributeValidatorTest {
         .thenReturn(trackedEntityAttribute);
     when(preheat.getTrackedEntityType((MetadataIdentifier) any()))
         .thenReturn(new TrackedEntityType());
+    when(preheat.isValidOptionCode(1L, "CODE")).thenReturn(true);
 
     TrackedEntity trackedEntity =
         TrackedEntity.builder()
@@ -445,6 +446,8 @@ class AttributeValidatorTest {
         .thenReturn(trackedEntityAttribute);
     when(preheat.getTrackedEntityType((MetadataIdentifier) any()))
         .thenReturn(new TrackedEntityType());
+    when(preheat.isValidOptionCode(2L, "CODE1")).thenReturn(true);
+    when(preheat.isValidOptionCode(2L, "CODE4")).thenReturn(false);
 
     TrackedEntity trackedEntity =
         TrackedEntity.builder()
@@ -471,6 +474,8 @@ class AttributeValidatorTest {
         .thenReturn(trackedEntityAttribute);
     when(preheat.getTrackedEntityType((MetadataIdentifier) any()))
         .thenReturn(new TrackedEntityType());
+    when(preheat.isValidOptionCode(2L, "CODE1")).thenReturn(true);
+    when(preheat.isValidOptionCode(2L, "CODE2")).thenReturn(true);
 
     TrackedEntity trackedEntity =
         TrackedEntity.builder()
@@ -625,13 +630,7 @@ class AttributeValidatorTest {
     trackedEntityAttribute.setValueType(ValueType.TEXT);
 
     OptionSet optionSet = new OptionSet();
-    Option option = new Option();
-    option.setCode("CODE");
-
-    Option option1 = new Option();
-    option1.setCode("CODE1");
-
-    optionSet.setOptions(Arrays.asList(option, option1));
+    optionSet.setId(1L);
 
     trackedEntityAttribute.setOptionSet(optionSet);
     return trackedEntityAttribute;
@@ -643,16 +642,7 @@ class AttributeValidatorTest {
     trackedEntityAttribute.setValueType(ValueType.MULTI_TEXT);
 
     OptionSet optionSet = new OptionSet();
-    Option option1 = new Option();
-    option1.setCode("CODE1");
-
-    Option option2 = new Option();
-    option2.setCode("CODE2");
-
-    Option option3 = new Option();
-    option3.setCode("CODE3");
-
-    optionSet.setOptions(Arrays.asList(option1, option2, option3));
+    optionSet.setId(2L);
 
     trackedEntityAttribute.setOptionSet(optionSet);
     return trackedEntityAttribute;


### PR DESCRIPTION
Master port of #24813 (still open against `2.41`, developed there first because a
production-scale database was available to gather evidence). Same fix, same design — see
that PR for the original rationale. This PR adapts the
change for master's structural divergence since 2.41:

* `dhis-service-tracker` module → `dhis-tracker` (package unchanged)
* `Event` became an interface (`TrackerEvent`/`SingleEvent`); preheat/rule
  code here uses `TrackerEvent`
* Program rule executors' data element/attribute identifiers are now
  `UID`-typed rather than `String`
* `TrackerIdSchemeParam` moved from `org.hisp.dhis.tracker.imports` to
  `org.hisp.dhis.tracker`
* `TrackerEvent`/`TrackedEntity`/`Enrollment` builders now require a
  non-null UID identifier field — this caught a real bug during porting
  (see Testing below)

## Fix

Tracker import preheat maps every referenced `OptionSet` through
`OptionSetMapper`. The generated MapStruct code called `.size()` on the
lazy Hibernate collection backing `OptionSet.options`, forcing a full
materialization of every `Option` row for that set — including JSONB
`attributevalues` deserialization per row — regardless of how many option
codes the import payload actually references.

* `TrackerPreheat` gains `addValidOptionCode`/`isValidOptionCode` and
  `addResolvedOptionSet`/`isOptionSetResolved`, storage for confirmed-valid
  `(option set, code)` pairs.
* A new `OptionValueSupplier` preheat supplier walks the payload's
  attribute/data values, collects only the option codes actually
  referenced (splitting multi-text values), and resolves them with one
  batched, chunked JDBC query against `optionvalue` — cost bounded by
  payload width, not option set size.
* `ValidationUtils.validateOptionSet` reads from that preheated data
  instead of `OptionSet.getOptions()`.
* `OptionSetMapper` stops mapping `options` entirely — the expensive
  collection load never happens during preheat.
* Program rule `ASSIGN` actions can introduce option-set values that were
  not in the original payload. Since those values are the rule engine's
  already-evaluated output, they're resolved the same way, right after the
  rule engine runs and before any validation reads them.

## Performance validation (master, this PR)

Companion PR #24814 adds a dedicated `SingleEventTest.java` Gatling harness (a fourth
Sierra Leone demo program, "Inpatient morbidity and mortality," using a ~14,000-option
ICD-10 diagnosis option set) specifically to exercise this code path, and dispatched
`performance-tests-compare.yml` against this PR directly: baseline `dhis2/core-dev:latest`
(unpatched master) vs candidate `dhis2/core-pr:24815` (this branch).

**SMOKE profile** (1 user, 10 sequential single-event imports):

| | Baseline (unpatched) | Candidate (this PR) |
|---|---:|---:|
| p95 | 1,204 ms | 105 ms |

**LOAD profile** (20 concurrent users, 50 imports each — real concurrent single-event
traffic, matching how single-event programs are actually imported in production: one
event per request, from many independent sessions):

| | Baseline (unpatched) | Candidate (this PR) |
|---|---:|---:|
| p95 | 32,183 ms | 666 ms |
| Success rate | 99.7% | 100% |
| Failure mode | persistent trickle of hard 60s client-timeout failures — some requests never completed at all, not just slow | none |

That's a ~48x improvement in p95 under load, and — independent of the latency number —
the fix eliminates outright request failures under concurrency, not just slowness.
Both runs are unconfounded: `SingleEventTest.java` is fully self-contained and shares no
configuration with any other scenario, so these numbers measure exactly what they claim to.

## Testing

* Unit tests for `TrackerPreheat`, `OptionValueSupplier`, and
  `ValidationUtils`'s three validator call sites, including multi-text and
  program-rule-assign coverage — all ported and adapted from #24813.
* Real end-to-end integration tests (`EventImportValidationTest`,
  `TrackedEntityImportValidationTest`, `EnrollmentAttrValidationTest`,
  `ProgramRuleAssignActionTest`) re-run after every behavioral change,
  confirming no regression to `E1125` semantics.
* The integration run caught a real bug the port introduced: the synthetic
  `TrackerEvent`/`Enrollment` objects built to re-resolve ASSIGN-action
  values were missing their now-mandatory `.event(UID)`/`.enrollment(UID)`
  identifiers, which compiled fine (Lombok's `@NonNull` is runtime-only)
  but NPE'd at import time. Fixed before opening this PR.
* All 199 affected tests pass; `spotless:apply` run on the full diff.
* A SonarQube visibility-modifier nit (`java:S5786`, redundant `public` on a
  JUnit5 `@BeforeEach` method) was fixed in a follow-up commit.
* Real baseline-vs-candidate performance validation against master, via #24814's dedicated
  `SingleEventTest.java` — see  also comment on TrackerTest below. 

🤖 AI Assisted