### PR TITLE
fix: quote item column in enrollment aggregate base CTE [DHIS2-21650]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -874,7 +874,7 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
       QueryItem queryItem = queryItemsByUid.get(column);
 
       if (queryItem != null) {
-        sb.addColumnIfNotExist(column);
+        sb.addColumnIfNotExist(quote(column));
       }
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerCteTest.java
@@ -111,6 +111,7 @@ import org.hisp.dhis.setting.SystemSettings;
 import org.hisp.dhis.setting.SystemSettingsService;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.test.random.BeanRandomizer;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -423,6 +424,41 @@ class EnrollmentAnalyticsManagerCteTest extends EventAnalyticsTest {
     assertThat(generatedSql, containsString("\"n1rtSHYf6O6\" in ('ImspTQPwCqd')"));
     assertThat(baseCteSql, containsString("inner join latest_events_" + programStage.getUid()));
     assertThat(baseCteSql, not(containsString("and \"n1rtSHYf6O6\" in ('ImspTQPwCqd')")));
+  }
+
+  @Test
+  void verifyAggregateEnrollmentAttributeFilterProjectsQuotedColumnInBaseCte() {
+    String attributeUid = "lZGmxYbs97q";
+    TrackedEntityAttribute attribute =
+        org.hisp.dhis.test.TestBase.createTrackedEntityAttribute('A', ValueType.TEXT);
+    attribute.setUid(attributeUid);
+
+    QueryItem queryItem =
+        new QueryItem(attribute, programA, null, ValueType.TEXT, AggregationType.NONE, null);
+    queryItem.setProgram(programA);
+    queryItem.addFilter(new QueryFilter(IN, "ABC"));
+
+    EventQueryParams.Builder params = createRequestParamsBuilder();
+    params.withEndpointAction(AGGREGATE);
+    params.addItemFilter(queryItem);
+
+    ListGrid grid = new ListGrid();
+    grid.addHeader(new GridHeader("value", "Value", ValueType.NUMBER, false, false));
+
+    subject.getEnrollments(params.build(), grid, 10000);
+    verify(jdbcTemplate).queryForRowSet(sql.capture());
+
+    String generatedSql = noEof(sql.getValue());
+    String baseCteSql =
+        generatedSql.substring(
+            generatedSql.indexOf("enrollment_aggr_base as ("),
+            generatedSql.indexOf("select count(eb.enrollment) as value"));
+
+    assertThat(baseCteSql, containsString("ax.\"" + attributeUid + "\" in ('ABC')"));
+    // The filtered column is projected so the propagated where clause can resolve it. Postgres
+    // folds unquoted identifiers to lower case, so the mixed-case UID must be quoted.
+    assertThat(baseCteSql, containsString("\"" + attributeUid + "\" from analytics_enrollment"));
+    assertThat(baseCteSql, not(containsString(", " + attributeUid + " from")));
   }
 
   @Test


### PR DESCRIPTION
## Summary

`/api/analytics/enrollments/aggregate/{program}` returned HTTP 409 for any request with a `filter=` on a program attribute:

```
ERROR: column "lzgmxybs97q" does not exist
Hint: Perhaps you meant to reference the column "ax.lZGmxYbs97q".   (SqlState 42703, E7145)
```

## Root cause

The filtered column was added to the `enrollment_aggr_base` select list without quotes. PostgreSQL lower-cases unquoted identifiers, so the mixed-case attribute UID no longer matched the column:

```
select ax.enrollment as enrollment, uidlevel1, lZGmxYbs97q   -- unquoted -> error: 42703
from analytics_enrollment_iphinat79uw as ax
where ... and ax."lZGmxYbs97q" in ('ABC')                    -- quoted, ok
```
