### PR TITLE
fix: resolve tracked entity audit values on the caller thread [DHIS2-21964]

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/audit/TrackedEntityAuditConcurrencyTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/audit/TrackedEntityAuditConcurrencyTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.audit;
+
+import static org.awaitility.Awaitility.await;
+import static org.hisp.dhis.audit.AuditOperationType.READ;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.hisp.dhis.trackedentity.TrackedEntityAuditQueryParams;
+import org.hisp.dhis.tracker.TestSetup;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Guards against silently losing tracked entity audits under concurrent reads.
+ *
+ * <p>The audit write is asynchronous. If the audit values are resolved on the async thread instead
+ * of the caller thread, the entity handed across the boundary can be a proxy whose Hibernate
+ * session has already been closed; dereferencing it throws LazyInitializationException, which the
+ * async uncaught-exception handler swallows. The read then succeeds while its audit record is
+ * silently dropped. That failed on roughly 84% of reads before the values were resolved on the
+ * caller thread.
+ *
+ * <p>Deliberately NOT {@code @Transactional}: the worker threads must see committed setup data and
+ * drive their own service-level transactions, which is what creates the contention.
+ *
+ * @author Morten Svanæs
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+class TrackedEntityAuditConcurrencyTest extends PostgresIntegrationTestBase {
+
+  @Autowired private EnrollmentService enrollmentService;
+  @Autowired private TrackedEntityAuditService auditService;
+  @Autowired private TestSetup testSetup;
+
+  private static final int THREADS = 8;
+  private static final int READS_PER_THREAD = 5;
+  private static final int EXPECTED_AUDITS = THREADS * READS_PER_THREAD;
+
+  private final UID program = UID.of("BFcipDERJnf");
+  private final UID trackedEntity = UID.of("QS6w44flWAf");
+
+  private UserDetails importUser;
+  private TrackedEntityAuditQueryParams params;
+
+  @BeforeAll
+  void setUp() throws IOException {
+    testSetup.importMetadata();
+    User user = userService.getUser("tTgjgobT1oS");
+    injectSecurityContextUser(user);
+    testSetup.importTrackerData();
+
+    importUser = UserDetails.fromUser(userService.getUser("tTgjgobT1oS"));
+    params = new TrackedEntityAuditQueryParams();
+    params.setTrackedEntities(List.of(trackedEntity.getValue()));
+    params.setAuditTypes(List.of(READ));
+  }
+
+  @Test
+  void shouldNotLoseAuditsWhenReadingConcurrently() throws Exception {
+    int countBefore = auditService.getTrackedEntityAuditsCount(params);
+
+    EnrollmentOperationParams operationParams =
+        EnrollmentOperationParams.builder()
+            .program(program)
+            .trackedEntities(Set.of(trackedEntity))
+            .build();
+
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(THREADS);
+    List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+    try {
+      for (int i = 0; i < THREADS; i++) {
+        pool.submit(
+            () -> {
+              try {
+                injectSecurityContextNoSettings(importUser);
+                start.await();
+                for (int n = 0; n < READS_PER_THREAD; n++) {
+                  enrollmentService.findEnrollments(operationParams);
+                }
+              } catch (Throwable t) {
+                failures.add(t);
+              } finally {
+                done.countDown();
+              }
+            });
+      }
+
+      start.countDown();
+      assertTrue(done.await(2, TimeUnit.MINUTES), "concurrent reads did not finish in time");
+    } finally {
+      pool.shutdownNow();
+    }
+
+    assertEquals(List.of(), failures, "concurrent reads failed");
+
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    countBefore + EXPECTED_AUDITS,
+                    auditService.getTrackedEntityAuditsCount(params),
+                    "every concurrent read must produce exactly one audit record"));
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/audit/AsyncTrackedEntityAuditWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/audit/AsyncTrackedEntityAuditWriter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.audit;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Writes tracked entity audit records on a separate thread.
+ *
+ * <p>This deliberately accepts only fully-resolved, immutable {@link TrackedEntityAudit} values.
+ * Passing a managed or proxied entity across the {@code @Async} boundary is a thread-safety bug:
+ * the caller's Hibernate session is not thread-safe and is usually already closed by the time the
+ * async thread runs, so dereferencing a lazy association here throws {@code
+ * LazyInitializationException} (silently, since the exception is swallowed by the async
+ * uncaught-exception handler) and can corrupt the caller's connection state. Resolve everything on
+ * the caller thread; hand values here.
+ *
+ * <p>Split into its own bean rather than an {@code @Async} method on the service because Spring
+ * applies {@code @Async} through a proxy, so a self-invocation would not be asynchronous.
+ *
+ * @author Morten Svanæs
+ */
+@Component
+@RequiredArgsConstructor
+public class AsyncTrackedEntityAuditWriter {
+
+  private final TrackedEntityAuditStore trackedEntityAuditStore;
+
+  @Async
+  @Transactional
+  public void addTrackedEntityAudits(@Nonnull List<TrackedEntityAudit> audits) {
+    if (audits.isEmpty()) {
+      return;
+    }
+    if (audits.size() == 1) {
+      trackedEntityAuditStore.addTrackedEntityAudit(audits.get(0));
+    } else {
+      trackedEntityAuditStore.addTrackedEntityAudit(audits);
+    }
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/audit/AsyncTrackedEntityAuditWriter.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/audit/AsyncTrackedEntityAuditWriter.java
@@ -34,6 +34,7 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -50,6 +51,14 @@ import org.springframework.transaction.annotation.Transactional;
  * <p>Split into its own bean rather than an {@code @Async} method on the service because Spring
  * applies {@code @Async} through a proxy, so a self-invocation would not be asynchronous.
  *
+ * <p>The insert uses {@code REQUIRES_NEW}: on a fresh async thread there is no transaction to join,
+ * so this is identical to the default today, but it pins the intended contract. If this task ever
+ * runs on the submitting thread instead (for example a future bounded executor whose rejection
+ * policy runs tasks inline), the default {@code REQUIRED} would join the caller's read-only
+ * transaction, the insert would fail, and the failure would mark the caller's transaction
+ * rollback-only, breaking the user's request. The audit insert must always run in its own write
+ * transaction, wherever it executes.
+ *
  * @author Morten Svanæs
  */
 @Component
@@ -59,7 +68,7 @@ public class AsyncTrackedEntityAuditWriter {
   private final TrackedEntityAuditStore trackedEntityAuditStore;
 
   @Async
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void addTrackedEntityAudits(@Nonnull List<TrackedEntityAudit> audits) {
     if (audits.isEmpty()) {
       return;

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/audit/DefaultTrackedEntityAuditService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/audit/DefaultTrackedEntityAuditService.java
@@ -34,12 +34,12 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.audit.AuditOperationType;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.NonTransactional;
 import org.hisp.dhis.trackedentity.TrackedEntityAuditQueryParams;
 import org.hisp.dhis.tracker.acl.TrackerAccessManager;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,28 +55,36 @@ public class DefaultTrackedEntityAuditService implements TrackedEntityAuditServi
 
   private final TrackerAccessManager trackerAccessManager;
 
-  @Override
-  @Async
-  @Transactional
-  public void addTrackedEntityAudit(
-      AuditOperationType type, String username, TrackedEntity trackedEntity) {
-    if (username != null
-        && trackedEntity != null
-        && trackedEntity.getTrackedEntityType() != null
-        && trackedEntity.getTrackedEntityType().isAllowAuditLog()) {
-      TrackedEntityAudit trackedEntityAudit =
-          new TrackedEntityAudit(trackedEntity.getUid(), username, type);
-      trackedEntityAuditStore.addTrackedEntityAudit(trackedEntityAudit);
-    }
-  }
+  private final AsyncTrackedEntityAuditWriter asyncTrackedEntityAuditWriter;
 
   @Override
-  @Async
-  @Transactional
+  @NonTransactional
+  public void addTrackedEntityAudit(
+      AuditOperationType type, String username, TrackedEntity trackedEntity) {
+    if (username == null || trackedEntity == null) {
+      return;
+    }
+    addTrackedEntityAudit(type, username, List.of(trackedEntity));
+  }
+
+  /**
+   * Resolves the audit values on the CALLER thread, where the Hibernate session that owns these
+   * entities is still open and single-threaded, then hands immutable values to the async writer.
+   * Dereferencing {@code getTrackedEntityType()} on the async thread instead is a race: the entity
+   * may be a proxy whose session has been closed, which throws LazyInitializationException that the
+   * async uncaught-exception handler swallows - silently losing the audit record.
+   */
+  @Override
+  @NonTransactional
   public void addTrackedEntityAudit(
       AuditOperationType type, String username, @Nonnull List<TrackedEntity> trackedEntities) {
+    if (username == null) {
+      return;
+    }
+
     List<TrackedEntityAudit> audits =
         trackedEntities.stream()
+            .filter(te -> te != null && te.getTrackedEntityType() != null)
             .filter(te -> te.getTrackedEntityType().isAllowAuditLog())
             .map(te -> new TrackedEntityAudit(te.getUid(), username, type))
             .toList();
@@ -85,7 +93,7 @@ public class DefaultTrackedEntityAuditService implements TrackedEntityAuditServi
       return;
     }
 
-    trackedEntityAuditStore.addTrackedEntityAudit(audits);
+    asyncTrackedEntityAuditWriter.addTrackedEntityAudits(audits);
   }
 
   @Override


### PR DESCRIPTION
## What

Tracked entity audit records are **silently dropped under concurrent reads**. The audit write is `@Async` and the caller passed a managed `TrackedEntity` across that boundary; the async thread then evaluated `getTrackedEntityType().isAllowAuditLog()`. A Hibernate session is not thread-safe and is normally already closed by then, so that throws `LazyInitializationException: could not initialize proxy [TrackedEntityType#N] - no Session`. `SimpleAsyncUncaughtExceptionHandler` swallows it, so the read returns 200 while its audit row is lost.

The association is mapped `FetchType.EAGER`, which is why this isn't visible from reading the code — at runtime it is still a proxy, and it only fails under concurrency.

## Measured

16-thread integration harness against Postgres, **default pool size (80)**, 960 concurrent reads:

| build | audits written | LazyInitEx | read-only / connection errors |
|---|---|---|---|
| master, L2 cache on | **152 / 960** | 717 | 0 |
| master, L2 cache off | **0 / 960** | 455 | 62 |
| this PR, cache on | **960 / 960** | 0 | 0 |
| this PR, cache off | **960 / 960** | 0 | 0 |

So on master today, with the cache on and nothing unusual configured, ~84% of concurrent reads lose their audit record with no error surfaced anywhere.

The same cross-thread session access also corrupts the caller's connection state when the L2 cache is off, producing `Cannot change transaction read-only property in the middle of a transaction` and `This statement has been closed`. That is the flakiness integration tests hit whenever they run genuinely cache-off, and it has been blocking recommending the second-level-cache off-switch as a diagnostic.

## How

Resolve the uid and `isAllowAuditLog()` on the **caller** thread, where the owning session is open, and hand only immutable `TrackedEntityAudit` values to a small dedicated `@Async` writer bean. The writer is a separate bean because Spring applies `@Async` through a proxy, so a self-invocation would run synchronously.

**Transaction propagation, added 2026-08-12:** the writer's insert uses `@Transactional(propagation = REQUIRES_NEW)`, not the default `REQUIRED`. Today this changes nothing: the task runs on a fresh async thread that has no transaction to join, so `REQUIRED` would create a new one anyway, and all tests pass identically. The explicit propagation pins the intended contract for any future execution context. If this task ever runs on the submitting thread instead (for example a bounded executor, DHIS2-21958, whose rejection policy runs tasks inline under saturation), the default would join the caller's read-only transaction: the audit INSERT would fail with "cannot execute INSERT in a read-only transaction", and that failure would mark the caller's transaction rollback-only, failing the user's request. Immutable payloads make the task session-safe; `REQUIRES_NEW` makes it transaction-safe. The audit insert must always run in its own write transaction, wherever it executes.

## Test

`TrackedEntityAuditConcurrencyTest` asserts every concurrent read produces exactly one audit record. Verified it actually catches the bug: with the fix reverted it fails `expected: <40> but was: <0>`.

## Not in scope

DHIS2-21958 (`@Async` has no configured executor, so `SimpleAsyncTaskExecutor` spawns an unbounded thread per call) is a separate defect and is deliberately not addressed here. Worth noting the ordering: a bounded executor with a queue would delay the async task further, which would have made this audit loss *worse*, so this correctness fix wants to land first or together.

JIRA: [DHIS2-21964](https://dhis2.atlassian.net/browse/DHIS2-21964)

AI Assisted


[DHIS2-21964]: https://dhis2.atlassian.net/browse/DHIS2-21964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ