### PR TITLE
chore: Migrate scheduleWithFixedDelay to use Duration

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
@@ -112,10 +112,6 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.locationtech.jts</groupId>
       <artifactId>jts-core</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/monitoring/DefaultMonitoringService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/monitoring/DefaultMonitoringService.java
@@ -30,6 +30,8 @@
 package org.hisp.dhis.dxf2.monitoring;
 
 import jakarta.annotation.PostConstruct;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -41,8 +43,6 @@ import org.hisp.dhis.setting.SystemSettingsService;
 import org.hisp.dhis.system.SystemInfo;
 import org.hisp.dhis.system.SystemService;
 import org.hisp.dhis.system.util.HttpHeadersBuilder;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeConstants;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -60,9 +60,9 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 @Service("org.hisp.dhis.dxf2.monitoring.MonitoringService")
 public class DefaultMonitoringService implements MonitoringService {
-  private static final int PUSH_INTERVAL = DateTimeConstants.MILLIS_PER_MINUTE * 5;
+  private static final Duration PUSH_INTERVAL = Duration.ofMinutes(5);
 
-  private static final int PUSH_INITIAL_DELAY = DateTimeConstants.MILLIS_PER_SECOND * 30;
+  private static final Duration PUSH_INITIAL_DELAY = Duration.ofSeconds(30);
 
   private final SystemService systemService;
 
@@ -76,7 +76,7 @@ public class DefaultMonitoringService implements MonitoringService {
 
   @PostConstruct
   public void init() {
-    Date date = new DateTime().plus(PUSH_INITIAL_DELAY).toDate();
+    Instant date = Instant.now().plus(PUSH_INITIAL_DELAY);
 
     String url = config.getProperty(ConfigurationKey.SYSTEM_MONITORING_URL);
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/pdfform/PdfDataEntryFormUtil.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/pdfform/PdfDataEntryFormUtil.java
@@ -205,7 +205,6 @@ public class PdfDataEntryFormUtil {
 
         // Loop Through the Fields and get data.
 
-        @SuppressWarnings("unchecked")
         Set<String> fldNames = form.getAllFields().keySet();
 
         for (String fldName : fldNames) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramStageWorkingListObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramStageWorkingListObjectBundleHookTest.java
@@ -43,6 +43,7 @@ import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -63,7 +64,6 @@ import org.hisp.dhis.programstageworkinglist.ProgramStageWorkingList;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentityfilter.AttributeValueFilter;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -106,28 +106,28 @@ class ProgramStageWorkingListObjectBundleHookTest {
         ProgramStageQueryCriteria.builder()
             .enrolledAt(
                 createDatePeriod(
-                    DateTime.now().minusDays(1).toDate(),
-                    DateTime.now().plusDays(1).toDate(),
+                    Date.from(ZonedDateTime.now().minusDays(1).toInstant()),
+                    Date.from(ZonedDateTime.now().plusDays(1).toInstant()),
                     DatePeriodType.ABSOLUTE))
             .enrollmentOccurredAt(
                 createDatePeriod(
-                    DateTime.now().minusDays(1).toDate(),
-                    DateTime.now().plusDays(1).toDate(),
+                    Date.from(ZonedDateTime.now().minusDays(1).toInstant()),
+                    Date.from(ZonedDateTime.now().plusDays(1).toInstant()),
                     DatePeriodType.RELATIVE))
             .eventCreatedAt(
                 createDatePeriod(
-                    DateTime.now().minusDays(1).toDate(),
-                    DateTime.now().plusDays(1).toDate(),
+                    Date.from(ZonedDateTime.now().minusDays(1).toInstant()),
+                    Date.from(ZonedDateTime.now().plusDays(1).toInstant()),
                     DatePeriodType.ABSOLUTE))
             .eventOccurredAt(
                 createDatePeriod(
-                    DateTime.now().minusDays(1).toDate(),
-                    DateTime.now().plusDays(1).toDate(),
+                    Date.from(ZonedDateTime.now().minusDays(1).toInstant()),
+                    Date.from(ZonedDateTime.now().plusDays(1).toInstant()),
                     DatePeriodType.ABSOLUTE))
             .eventScheduledAt(
                 createDatePeriod(
-                    DateTime.now().minusDays(1).toDate(),
-                    DateTime.now().plusDays(1).toDate(),
+                    Date.from(ZonedDateTime.now().minusDays(1).toInstant()),
+                    Date.from(ZonedDateTime.now().plusDays(1).toInstant()),
                     DatePeriodType.RELATIVE))
             .assignedUsers(Collections.singleton("User"))
             .assignedUserMode(AssignedUserSelectionMode.PROVIDED)

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramStageWorkingListObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramStageWorkingListObjectBundleHookTest.java
@@ -89,7 +89,7 @@ class ProgramStageWorkingListObjectBundleHookTest {
   private ProgramStageWorkingList programStageWorkingList;
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     workingListHook =
         new ProgramStageWorkingListObjectBundleHook(
             dataElementService, organisationUnitService, attributeService);

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/FakeRedisTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/FakeRedisTest.java
@@ -92,7 +92,6 @@ class FakeRedisTest {
   }
 
   @Test
-  @SuppressWarnings("DataFlowIssue")
   void testDelete_NonExistingHasNoEffect() {
     BoundZSetOperations<String, String> set1 = redis.boundZSetOps("empty:s");
     assertEquals(0L, set1.zCard());
@@ -106,7 +105,6 @@ class FakeRedisTest {
   }
 
   @Test
-  @SuppressWarnings("DataFlowIssue")
   void testDelete_byKey() {
     BoundZSetOperations<String, String> set1 = redis.boundZSetOps("my:set");
     set1.add("val", 42);
@@ -148,7 +146,6 @@ class FakeRedisTest {
   }
 
   @Test
-  @SuppressWarnings("DataFlowIssue")
   void testRange() {
     BoundZSetOperations<String, String> set1 = redis.boundZSetOps("my:set");
     set1.add("1", 1);
@@ -165,7 +162,6 @@ class FakeRedisTest {
   }
 
   @Test
-  @SuppressWarnings("DataFlowIssue")
   void testReverseRange() {
     BoundZSetOperations<String, String> set1 = redis.boundZSetOps("my:set");
     set1.add("1", 1);
@@ -180,7 +176,6 @@ class FakeRedisTest {
   }
 
   @Test
-  @SuppressWarnings("DataFlowIssue")
   void testRemoveRange() {
     BoundZSetOperations<String, String> set1 = redis.boundZSetOps("my:set");
     set1.add("1", 1);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceQueryModifiersTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceQueryModifiersTest.java
@@ -54,7 +54,6 @@ import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
@@ -106,8 +105,6 @@ class AnalyticsServiceQueryModifiersTest extends PostgresIntegrationTestBase {
   @Autowired private AnalyticsService analyticsService;
 
   @Autowired private IndicatorService indicatorService;
-
-  @Autowired private ConfigurationService configurationService;
 
   private Period jan;
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -76,7 +76,6 @@ import org.hisp.dhis.datavalue.DataDumpService;
 import org.hisp.dhis.datavalue.DataEntryGroup;
 import org.hisp.dhis.datavalue.DataEntryInput;
 import org.hisp.dhis.datavalue.DataEntryValue;
-import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.expression.Expression;
@@ -203,8 +202,6 @@ class AnalyticsServiceTest extends PostgresIntegrationTestBase {
   @Autowired private DataElementService dataElementService;
 
   @Autowired private CategoryService categoryService;
-
-  @Autowired private DataValueService dataValueService;
 
   @Autowired private OrganisationUnitService organisationUnitService;
 


### PR DESCRIPTION
Migrates deprecated use of Spring scheduler `scheduleWithFixedDelay` method to use `Duration`. Removes unused test dependencies.