### PR TITLE
fix: declare synchronized entity classes on native writes DHIS2-21963 [42]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueTrimStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueTrimStore.java
@@ -87,8 +87,7 @@ public class HibernateDataValueTrimStore extends HibernateGenericStore<DataValue
           AND de.zeroissignificant = false
           AND dv.dataelementid = de.dataelementid
           AND (dv.value IS NULL OR dv.value = '')""";
-    return getSession()
-        .createNativeQuery(sql)
+    return nativeSynchronizedQuery(sql)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(1000))
         .executeUpdate();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
@@ -155,6 +155,6 @@ public class HibernateEventStore extends SoftDeleteHibernateObjectStore<Event>
         """
             .formatted(coc, cocs.stream().map(String::valueOf).collect(Collectors.joining(",")));
 
-    entityManager.createNativeQuery(sql).executeUpdate();
+    nativeSynchronizedQuery(sql).executeUpdate();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
@@ -50,6 +50,7 @@ import org.hibernate.Transaction;
 import org.hibernate.query.NativeQuery;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
+import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.hibernate.jsonb.type.JsonJobParametersType;
 import org.hisp.dhis.security.acl.AclService;
 import org.springframework.context.ApplicationEventPublisher;
@@ -385,7 +386,10 @@ public class HibernateJobConfigurationStore
         and (schedulingtype != 'ONCE_ASAP' or lastfinished is null)
         """;
     return runWriteInStatelessSession(
-            q -> q.createNativeQuery(sql).setParameter("id", jobId.getValue()).executeUpdate())
+            q ->
+                nativeSynchronizedQuery(q, sql)
+                    .setParameter("id", jobId.getValue())
+                    .executeUpdate())
         > 0;
   }
 
@@ -413,7 +417,10 @@ public class HibernateJobConfigurationStore
         )
         """;
     return runWriteInStatelessSession(
-            q -> q.createNativeQuery(sql).setParameter("id", jobId.getValue()).executeUpdate())
+            q ->
+                nativeSynchronizedQuery(q, sql)
+                    .setParameter("id", jobId.getValue())
+                    .executeUpdate())
         > 0;
   }
 
@@ -444,7 +451,10 @@ public class HibernateJobConfigurationStore
           )
         """;
     return runWriteInStatelessSession(
-            q -> q.createNativeQuery(sql).setParameter("id", jobId.getValue()).executeUpdate())
+            q ->
+                nativeSynchronizedQuery(q, sql)
+                    .setParameter("id", jobId.getValue())
+                    .executeUpdate())
         > 0;
   }
 
@@ -475,7 +485,7 @@ public class HibernateJobConfigurationStore
         """;
     return runWriteInStatelessSession(
             q ->
-                q.createNativeQuery(sql)
+                nativeSynchronizedQuery(q, sql)
                     .setParameter("id", jobId.getValue())
                     .setParameter("status", status.name())
                     .executeUpdate())
@@ -503,7 +513,7 @@ public class HibernateJobConfigurationStore
           or lastexecuted < (select lastexecuted from jobconfiguration where queuename = :queue and queueposition = 0 limit 1))
         """;
     return runWriteInStatelessSession(
-            q -> q.createNativeQuery(sql).setParameter("queue", queue).executeUpdate())
+            q -> nativeSynchronizedQuery(q, sql).setParameter("queue", queue).executeUpdate())
         > 0;
   }
 
@@ -521,7 +531,7 @@ public class HibernateJobConfigurationStore
         """;
     runWriteInStatelessSession(
         q ->
-            q.createNativeQuery(sql)
+            nativeSynchronizedQuery(q, sql)
                 .setParameter("id", jobId.getValue())
                 .setParameter("json", progressJson)
                 .setParameter("errors", errorCodes)
@@ -539,7 +549,7 @@ public class HibernateJobConfigurationStore
         where jobstatus = 'SCHEDULED'
         and enabled = false
         """;
-    return runWriteInStatelessSession(q -> q.createNativeQuery(sql).executeUpdate());
+    return runWriteInStatelessSession(q -> nativeSynchronizedQuery(q, sql).executeUpdate());
   }
 
   @Override
@@ -557,7 +567,7 @@ public class HibernateJobConfigurationStore
     int deletedCount =
         runWriteInStatelessSession(
             q ->
-                q.createNativeQuery(sql)
+                nativeSynchronizedQuery(q, sql)
                     .setLockOptions(new LockOptions(LockMode.PESSIMISTIC_WRITE).setTimeOut(2000))
                     .setParameter("ttl", max(1, ttlMinutes))
                     .executeUpdate());
@@ -575,6 +585,7 @@ public class HibernateJobConfigurationStore
     runWriteInStatelessSession(
         q ->
             q.createNativeQuery(sql2)
+                .addSynchronizedEntityClass(FileResource.class)
                 .setLockOptions(new LockOptions(LockMode.PESSIMISTIC_WRITE).setTimeOut(2000))
                 .executeUpdate());
     return deletedCount;
@@ -606,7 +617,7 @@ public class HibernateJobConfigurationStore
         """;
     return runWriteInStatelessSession(
         q ->
-            q.createNativeQuery(sql)
+            nativeSynchronizedQuery(q, sql)
                 .setParameter("timeout", max(1, timeoutMinutes))
                 .executeUpdate());
   }
@@ -637,7 +648,10 @@ public class HibernateJobConfigurationStore
         and now() > jobconfiguration.lastalive + interval '1 minute'
       """;
     return runWriteInStatelessSession(
-            q -> q.createNativeQuery(sql).setParameter("id", jobId.getValue()).executeUpdate())
+            q ->
+                nativeSynchronizedQuery(q, sql)
+                    .setParameter("id", jobId.getValue())
+                    .executeUpdate())
         > 0;
   }
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/HibernateNativeStore.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/HibernateNativeStore.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Session;
+import org.hibernate.StatelessSession;
 import org.hibernate.metamodel.spi.MetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.SingleTableEntityPersister;
@@ -97,8 +98,22 @@ public abstract class HibernateNativeStore<T> {
    * current class of the store. Use this to avoid all Hibernate second level caches from being
    * invalidated.
    *
-   * <p>Be aware that it is only correct to use this if and only if the only table touched by the
-   * native query is the one table belonging to the store.
+   * <p>Every native write triggers a cache cleanup driven only by its declared query spaces (the
+   * tables it affects). Declare none and Hibernate reads that as "unknown" and evicts
+   * <em>every</em> entity and collection region, so always declare, even when this entity is not
+   * cached.
+   *
+   * <p>Correct only when the sole table this statement <em>writes</em> is the store's own; tables
+   * merely read by a join or subquery need no declaration. Otherwise call {@code
+   * addSynchronizedEntityClass} directly, once per entity written.
+   *
+   * <p>Beware collection tables. An entity's query spaces are its own table(s) only, never the
+   * tables of the collections it owns, so declaring the owner does <em>not</em> evict its cached
+   * collections. Hibernate resolves collection regions through {@code
+   * getCollectionRolesByEntityParticipant}, which is keyed by the collection's <em>element</em>
+   * entity. So for a write against a join or child table, declare the entity on the far side of the
+   * association: {@code categories_categoryoptions} needs {@code CategoryOption}, not {@code
+   * Category}.
    *
    * @param sql the SQL query to execute
    * @return the {@link NativeQuery} instance
@@ -106,6 +121,17 @@ public abstract class HibernateNativeStore<T> {
   @SuppressWarnings("rawtypes")
   protected NativeQuery nativeSynchronizedQuery(@Language("SQL") String sql) {
     return getSession().createNativeQuery(sql).addSynchronizedEntityClass(getClazz());
+  }
+
+  /**
+   * Same as {@link #nativeSynchronizedQuery(String)} but on a {@link StatelessSession}, which is a
+   * different session from the store's own. Pass the session that opened the surrounding
+   * transaction, otherwise the query runs outside it.
+   */
+  @SuppressWarnings("rawtypes")
+  protected NativeQuery nativeSynchronizedQuery(
+      StatelessSession session, @Language("SQL") String sql) {
+    return session.createNativeQuery(sql).addSynchronizedEntityClass(getClazz());
   }
 
   /**

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
@@ -121,16 +121,17 @@ class HibernateQueryCacheTest extends PostgresIntegrationTestBase {
   void testHouseKeepingJobWithCache() {
     setUpData();
     createSelectQuery(10);
-    assertEquals(9, sessionFactory.getStatistics().getQueryCacheHitCount());
+    long queryCacheHitCountBefore = sessionFactory.getStatistics().getQueryCacheHitCount();
+    assertEquals(9, queryCacheHitCountBefore);
     housekeepingJob.execute(null, JobProgress.noop());
     createSelectQuery(1);
     assertEquals(
-        9,
+        10,
         sessionFactory
             .getStatistics()
             .getCacheRegionStatistics(OptionSet.class.getName())
             .getHitCount());
-    assertTrue(sessionFactory.getStatistics().getQueryCacheHitCount() > 10);
+    assertTrue(sessionFactory.getStatistics().getQueryCacheHitCount() > queryCacheHitCountBefore);
   }
 
   private void createSelectQuery(int numberOfQueries) {


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/24803

Reduced to 4 of the original 15 files. Most call sites do not exist on 2.42: the category, data set, data approval, program indicator and user merge methods came later, `HibernatePeriodStore` still saves through the session rather than native SQL, and two stores are absent entirely. `HibernateEventStore` here is the predecessor of the two tracker event stores the original touched.

A scan for `createNativeQuery(...).executeUpdate()` without an `addSynchronized*` returns nothing on this branch.

`HibernateQueryCacheTest.testHouseKeepingJobWithCache` asserted the buggy behaviour, expecting the `OptionSet` region to still be cold after the housekeeping job. It now survives, so the following query hits. Master and 2.43 already expect this from [#23154](https://github.com/dhis2/dhis2-core/pull/23154), which is not on 2.42, so that one-line adjustment is carried here as a separate commit.
