### PR TITLE
perf: project program stage data elements in preheat (2.41)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/config/TrackerPreheatConfig.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/config/TrackerPreheatConfig.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.tracker.imports.preheat.supplier.PreheatStrategyScanner;
 import org.hisp.dhis.tracker.imports.preheat.supplier.PreheatSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.ProgramOrgUnitsSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.ProgramOwnerSupplier;
+import org.hisp.dhis.tracker.imports.preheat.supplier.ProgramStageDataElementsSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.TrackedEntityEnrollmentSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.UniqueAttributesSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.UserSupplier;
@@ -61,6 +62,7 @@ public class TrackerPreheatConfig {
           EnrollmentsWithAtLeastOneEventSupplier.class,
           EventProgramStageMapSupplier.class,
           ProgramOrgUnitsSupplier.class,
+          ProgramStageDataElementsSupplier.class,
           ProgramOwnerSupplier.class,
           UniqueAttributesSupplier.class,
           UserSupplier.class,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/ProgramStageDataElements.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/ProgramStageDataElements.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.preheat;
+
+import java.util.Set;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+
+/**
+ * Data elements of a program stage, projected instead of loaded as entities.
+ *
+ * <p>These replace walking {@link org.hisp.dhis.program.ProgramStage#getProgramStageDataElements()}
+ * on a preheated stage, which is no longer mapped. A program can have thousands of data elements
+ * while an event references a handful, so loading them all as entities dominated preheat on wide
+ * programs. Only the data elements needed to answer the validations are projected: the compulsory
+ * ones, plus those referenced by the payload or by program rules. See {@link
+ * org.hisp.dhis.tracker.imports.preheat.supplier.ProgramStageDataElementsSupplier}.
+ *
+ * @param compulsory identifiers of the compulsory data elements, used to report a missing mandatory
+ *     value
+ * @param members identifiers of the projected data elements, used to check that a payload data
+ *     element belongs to the stage
+ * @param memberUids uids of the projected data elements. Program rules only know uids, so this is
+ *     kept separately from {@code members} which is in the requested idScheme
+ */
+public record ProgramStageDataElements(
+    Set<MetadataIdentifier> compulsory, Set<MetadataIdentifier> members, Set<UID> memberUids) {
+
+  public static final ProgramStageDataElements EMPTY =
+      new ProgramStageDataElements(Set.of(), Set.of(), Set.of());
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
@@ -45,6 +45,7 @@ import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -53,6 +54,7 @@ import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.note.Note;
@@ -277,6 +279,36 @@ public class TrackerPreheat {
    * payload.
    */
   @Getter @Setter private Map<String, List<String>> programWithOrgUnitsMap;
+
+  /**
+   * Data elements of a program stage, projected instead of loaded as entities. Keyed by program
+   * stage uid.
+   *
+   * <p>These replace walking {@link
+   * org.hisp.dhis.program.ProgramStage#getProgramStageDataElements()} on a preheated stage, which
+   * is no longer mapped. A program can have thousands of data elements while an event references a
+   * handful, so loading them all as entities is the dominant cost of preheat on wide programs.
+   *
+   * <p>Only the data elements needed to answer the validations are projected: the compulsory ones,
+   * plus those referenced by the payload or by program rules. See {@link
+   * org.hisp.dhis.tracker.imports.preheat.supplier.ProgramStageDataElementsSupplier}.
+   */
+  private final Map<UID, ProgramStageDataElements> programStageDataElements = new HashMap<>();
+
+  public void putProgramStageDataElements(
+      @Nonnull UID programStage, @Nonnull ProgramStageDataElements des) {
+    programStageDataElements.put(programStage, des);
+  }
+
+  /**
+   * Returns the projected data elements of the given program stage, never null. An unknown stage
+   * yields empty sets, matching the previous behaviour of a stage with no data elements.
+   */
+  @Nonnull
+  public ProgramStageDataElements getProgramStageDataElements(@Nonnull ProgramStage programStage) {
+    return programStageDataElements.getOrDefault(
+        UID.of(programStage), ProgramStageDataElements.EMPTY);
+  }
 
   public TrackerPreheat() {}
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramStageMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramStageMapper.java
@@ -56,7 +56,11 @@ public interface ProgramStageMapper extends PreheatMapper<ProgramStage> {
   @Mapping(target = "program", qualifiedByName = "program")
   @Mapping(target = "repeatable")
   @Mapping(target = "referral")
-  @Mapping(target = "programStageDataElements")
+  // programStageDataElements is deliberately not mapped. It is the widest association on a program
+  // stage and mapping it initialized one DataElement entity per element. The data elements the
+  // import actually needs are projected by ProgramStageDataElementsSupplier instead. Read them
+  // through TrackerPreheat#getProgramStageDataElements, as the association is empty on a preheated
+  // stage.
   @Mapping(target = "enableUserAssignment")
   @Mapping(target = "validationStrategy")
   @Mapping(target = "featureType")

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/ProgramStageDataElementsSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/ProgramStageDataElementsSupplier.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.preheat.supplier;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.imports.TrackerIdSchemeParam;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.tracker.imports.preheat.ProgramStageDataElements;
+import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Projects the data elements of the preheated program stages instead of loading them as entities.
+ *
+ * <p>A program stage can have thousands of data elements while an event references a handful.
+ * Mapping the {@code programStageDataElements} association initialized every one of them, which
+ * dominated preheat on wide programs. Only three things are asked of that association during import
+ * and all of them need an identifier and nothing else:
+ *
+ * <ul>
+ *   <li>the compulsory data elements, to report a missing mandatory value (E1303, E1076)
+ *   <li>whether a payload data element belongs to the stage (E1305)
+ *   <li>whether a program rule effect targets a data element of the stage
+ * </ul>
+ *
+ * <p>The last two are membership tests whose probes are known up front, so a data element that
+ * neither the payload nor the rules mention cannot change their outcome and does not need to be
+ * fetched. What is loaded is therefore bounded by the compulsory count plus the payload and rule
+ * width, rather than by the width of the program.
+ *
+ * <p>Data elements referenced by the payload or by program rules are loaded as full entities
+ * elsewhere, as validation needs their value type and option set. This supplier does not replace
+ * that, it only avoids loading the rest of the stage.
+ */
+@Component
+public class ProgramStageDataElementsSupplier extends JdbcAbstractPreheatSupplier {
+
+  /**
+   * The two branches are unioned rather than combined with {@code or}. An {@code or} spanning both
+   * tables cannot be served by an index, so Postgres reads every row of the stage and of {@code
+   * dataelement} and filters afterwards. Split, the second branch uses {@code dataelement_uid_key}.
+   *
+   * <p>The attribute value, if any, is extracted server-side with the {@code jsonb} {@code ->>}
+   * operator rather than deserialized on the client: {@code attributevalues} is stored as {@code
+   * {"<attributeUid>": {"value": "...", ...}}}, mirroring {@link
+   * org.hisp.dhis.hibernate.jsonb.type.JsonAttributeValueBinaryType}.
+   */
+  private static final String SQL =
+      """
+      select psde.programstageid, psde.compulsory, de.uid, de.code, de.name,
+             de.attributevalues -> :attributeUid ->> 'value' as attributevalue
+      from programstagedataelement psde
+      join dataelement de on de.dataelementid = psde.dataelementid
+      where psde.programstageid in (:stageIds)
+        and psde.compulsory
+      union
+      select psde.programstageid, psde.compulsory, de.uid, de.code, de.name,
+             de.attributevalues -> :attributeUid ->> 'value' as attributevalue
+      from programstagedataelement psde
+      join dataelement de on de.dataelementid = psde.dataelementid
+      where psde.programstageid in (:stageIds)
+        and de.uid in (:dataElementUids)
+      """;
+
+  protected ProgramStageDataElementsSupplier(JdbcTemplate jdbcTemplate) {
+    super(jdbcTemplate);
+  }
+
+  @Override
+  public void preheatAdd(TrackerObjects trackerObjects, TrackerPreheat preheat) {
+    // Stages named by the payload, plus the stages of every preheated program. An event in an
+    // event program does not carry a program stage, EventProgramStageMapSupplier derives it from
+    // the program, but that runs after preheat. Projecting the program's stages as well means the
+    // derived stage is covered. Without this E1305 rejects every data value of such an event.
+    Map<Long, ProgramStage> stagesById =
+        Stream.concat(
+                preheat.getAll(ProgramStage.class).stream(),
+                preheat.getAll(Program.class).stream()
+                    .map(Program::getProgramStages)
+                    .filter(Objects::nonNull)
+                    .flatMap(Collection::stream))
+            .collect(Collectors.toMap(IdentifiableObject::getId, ps -> ps, (a, b) -> a));
+
+    if (stagesById.isEmpty()) {
+      return;
+    }
+
+    // Data elements of the payload and of the program rules. Both are already preheated, so
+    // reading their uids costs nothing. Program rules only ever refer to data elements by uid.
+    Set<String> dataElementUids =
+        preheat.getAll(DataElement.class).stream()
+            .map(IdentifiableObject::getUid)
+            .collect(Collectors.toSet());
+
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+    parameters.addValue("stageIds", stagesById.keySet());
+    // An empty in () list is not valid SQL. These values are only ever compared against, so a
+    // value that cannot be a uid keeps the predicate well formed and matches nothing.
+    parameters.addValue(
+        "dataElementUids", dataElementUids.isEmpty() ? Set.of("") : dataElementUids);
+
+    TrackerIdSchemeParam idScheme = preheat.getIdSchemes().getDataElementIdScheme();
+    // Only read when idScheme is ATTRIBUTE, but the query always needs a bound value for the
+    // named parameter to be well formed.
+    parameters.addValue(
+        "attributeUid", idScheme.getAttributeUid() == null ? "" : idScheme.getAttributeUid());
+
+    Map<Long, Set<MetadataIdentifier>> compulsory = new HashMap<>();
+    Map<Long, Set<MetadataIdentifier>> members = new HashMap<>();
+    Map<Long, Set<UID>> memberUids = new HashMap<>();
+
+    jdbcTemplate.query(
+        SQL,
+        parameters,
+        rs -> {
+          long stageId = rs.getLong("programstageid");
+          MetadataIdentifier identifier = toMetadataIdentifier(idScheme, rs);
+
+          members.computeIfAbsent(stageId, k -> new HashSet<>()).add(identifier);
+          memberUids
+              .computeIfAbsent(stageId, k -> new HashSet<>())
+              .add(UID.of(rs.getString("uid")));
+          if (rs.getBoolean("compulsory")) {
+            compulsory.computeIfAbsent(stageId, k -> new HashSet<>()).add(identifier);
+          }
+        });
+
+    stagesById.forEach(
+        (stageId, programStage) ->
+            preheat.putProgramStageDataElements(
+                UID.of(programStage),
+                new ProgramStageDataElements(
+                    compulsory.getOrDefault(stageId, Set.of()),
+                    members.getOrDefault(stageId, Set.of()),
+                    memberUids.getOrDefault(stageId, Set.of()))));
+  }
+
+  /**
+   * Builds the identifier in the requested idScheme from the projected columns, mirroring {@link
+   * TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)} without needing the entity.
+   */
+  private static MetadataIdentifier toMetadataIdentifier(
+      TrackerIdSchemeParam idScheme, ResultSet rs) throws SQLException {
+    return switch (idScheme.getIdScheme()) {
+      case UID -> idScheme.toMetadataIdentifier(rs.getString("uid"));
+      case CODE -> idScheme.toMetadataIdentifier(rs.getString("code"));
+      case NAME -> idScheme.toMetadataIdentifier(rs.getString("name"));
+      case ATTRIBUTE -> idScheme.toMetadataIdentifier(rs.getString("attributevalue"));
+    };
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleActionEventMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleActionEventMapper.java
@@ -36,7 +36,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.programrule.ProgramRuleActionType;
 import org.hisp.dhis.rules.models.RuleAction;
@@ -84,11 +84,11 @@ class RuleActionEventMapper {
       return List.of();
     }
 
-    // Pre-build the set of data element UIDs for this program stage so that
-    // isDataElementPartOfProgramStage does not stream over the collection per effect.
+    // Data elements of the stage, projected by ProgramStageDataElementsSupplier. Rules refer to
+    // data elements by uid, so the uid set is the one to probe.
     Set<String> stageDataElementUids =
-        programStage.getDataElements().stream()
-            .map(IdentifiableObject::getUid)
+        bundle.getPreheat().getProgramStageDataElements(programStage).memberUids().stream()
+            .map(UID::getValue)
             .collect(Collectors.toSet());
 
     return ruleEffects.getRuleEffects().stream()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
@@ -37,6 +37,7 @@ import static org.hisp.dhis.tracker.imports.validation.validator.TrackerImporter
 
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -116,7 +117,9 @@ public class ValidationUtils {
   }
 
   public static List<MetadataIdentifier> validateDeletionMandatoryDataValue(
-      Event event, ProgramStage programStage, List<MetadataIdentifier> mandatoryDataElements) {
+      Event event,
+      ProgramStage programStage,
+      Collection<MetadataIdentifier> mandatoryDataElements) {
     if (!needsToValidateDataValues(event, programStage)) {
       return List.of();
     }
@@ -134,7 +137,7 @@ public class ValidationUtils {
       TrackerBundle bundle,
       Event event,
       ProgramStage programStage,
-      List<MetadataIdentifier> mandatoryDataElements) {
+      Collection<MetadataIdentifier> mandatoryDataElements) {
     if (!needsToValidateDataValues(event, programStage)) {
       return List.of();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidator.java
@@ -36,14 +36,12 @@ import static org.hisp.dhis.tracker.imports.validation.validator.ValidationUtils
 import static org.hisp.dhis.tracker.imports.validation.validator.ValidationUtils.validateOptionSet;
 import static org.hisp.dhis.tracker.imports.validation.validator.ValidationUtils.validateValueType;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.domain.Event;
@@ -84,11 +82,8 @@ class DataValuesValidator implements Validator<Event> {
 
   private void validateMandatoryDataValues(
       Reporter reporter, TrackerBundle bundle, Event event, ProgramStage programStage) {
-    final List<MetadataIdentifier> mandatoryDataElements =
-        programStage.getProgramStageDataElements().stream()
-            .filter(ProgramStageDataElement::isCompulsory)
-            .map(de -> bundle.getPreheat().getIdSchemes().toMetadataIdentifier(de.getDataElement()))
-            .toList();
+    final Set<MetadataIdentifier> mandatoryDataElements =
+        bundle.getPreheat().getProgramStageDataElements(programStage).compulsory();
 
     validateMandatoryDataValue(bundle, event, programStage, mandatoryDataElements)
         .forEach(de -> reporter.addError(event, E1303, de));
@@ -119,9 +114,7 @@ class DataValuesValidator implements Validator<Event> {
       Reporter reporter, TrackerBundle bundle, Event event, ProgramStage programStage) {
     TrackerPreheat preheat = bundle.getPreheat();
     final Set<MetadataIdentifier> dataElements =
-        programStage.getProgramStageDataElements().stream()
-            .map(de -> preheat.getIdSchemes().toMetadataIdentifier(de.getDataElement()))
-            .collect(Collectors.toSet());
+        preheat.getProgramStageDataElements(programStage).members();
 
     Set<MetadataIdentifier> payloadDataElements =
         event.getDataValues().stream().map(DataValue::getDataElement).collect(Collectors.toSet());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramStageMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramStageMapperTest.java
@@ -31,10 +31,9 @@ import static org.hisp.dhis.tracker.imports.preheat.mappers.AttributeCreator.att
 import static org.hisp.dhis.tracker.imports.preheat.mappers.AttributeCreator.attributeValues;
 import static org.hisp.dhis.tracker.imports.preheat.mappers.AttributeCreator.setIdSchemeFields;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Optional;
 import java.util.Set;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.Program;
@@ -89,15 +88,9 @@ class ProgramStageMapperTest {
     assertContainsOnly(
         Set.of(attributeValue("m0GpPuMUfFW", "yellow")), mapped.getProgram().getAttributeValues());
 
-    Optional<ProgramStageDataElement> actual =
-        mapped.getProgramStageDataElements().stream().findFirst();
-    assertTrue(actual.isPresent());
-    ProgramStageDataElement value = actual.get();
-    assertEquals("khBzbxTLo8k", value.getDataElement().getUid());
-    assertEquals("clouds", value.getDataElement().getName());
-    assertEquals("orange", value.getDataElement().getCode());
-    assertContainsOnly(
-        Set.of(attributeValue("m0GpPuMUfFW", "purple")),
-        value.getDataElement().getAttributeValues());
+    // programStageDataElements is deliberately not mapped, as initializing it loaded one
+    // DataElement entity per element. ProgramStageDataElementsSupplier projects what the import
+    // needs instead.
+    assertIsEmpty(mapped.getProgramStageDataElements());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.imports.validation.validator.event;
 import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidations.assertHasError;
 import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidations.assertNoErrors;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -37,6 +38,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
@@ -55,6 +57,7 @@ import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.preheat.ProgramStageDataElements;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
@@ -135,6 +138,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         Event.builder()
@@ -156,6 +160,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setCreatedAt(null);
@@ -179,6 +184,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setUpdatedAt(null);
@@ -202,6 +208,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         Event.builder()
@@ -236,6 +243,7 @@ class DataValuesValidatorTest {
     programStage.setProgramStageDataElements(
         Set.of(mandatoryStageElement1, mandatoryStageElement2));
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         Event.builder()
@@ -271,6 +279,7 @@ class DataValuesValidatorTest {
     programStage.setProgramStageDataElements(
         Set.of(mandatoryStageElement1, mandatoryStageElement2));
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         Event.builder()
@@ -308,6 +317,7 @@ class DataValuesValidatorTest {
     programStage.setProgramStageDataElements(
         Set.of(mandatoryStageElement1, mandatoryStageElement2));
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
     when(preheat.getEvent(eventUid))
         .thenReturn(event(eventUid, savedStatus, Set.of("MANDATORY_DE", dataElementUid)));
 
@@ -348,6 +358,7 @@ class DataValuesValidatorTest {
     programStage.setProgramStageDataElements(
         Set.of(mandatoryStageElement1, mandatoryStageElement2));
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
     when(preheat.getEvent(eventUid)).thenReturn(event(eventUid, savedStatus));
 
     Event event =
@@ -382,6 +393,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement, true);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue dataValue = dataValue();
     dataValue.setDataElement(MetadataIdentifier.ofCode("DE_424050"));
@@ -416,6 +428,7 @@ class DataValuesValidatorTest {
     mandatoryStageElement1.setCompulsory(true);
     programStage.setProgramStageDataElements(Set.of(mandatoryStageElement1));
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue notPresentDataValue = dataValue();
     notPresentDataValue.setDataElement(MetadataIdentifier.ofUid("de_not_present_in_program_stage"));
@@ -451,6 +464,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue dataValue = dataValue();
     dataValue.setDataElement(MetadataIdentifier.ofCode("DE_424050"));
@@ -478,6 +492,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         Event.builder()
@@ -504,6 +519,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement, false);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -528,6 +544,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement, true);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -554,6 +571,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_UPDATE_AND_INSERT);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -581,6 +599,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_UPDATE_AND_INSERT);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
     when(preheat.getEvent(eventUid)).thenReturn(new org.hisp.dhis.program.Event());
 
     DataValue validDataValue = dataValue();
@@ -608,6 +627,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_UPDATE_AND_INSERT);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -634,6 +654,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_COMPLETE);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -659,6 +680,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_COMPLETE);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -684,6 +706,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement, true);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue("1");
@@ -709,6 +732,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement, true);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue("1");
@@ -734,6 +758,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement, true);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue("1");
@@ -759,6 +784,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement, false);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -783,6 +809,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     FileResource fileResource = new FileResource();
     fileResource.setAssigned(true);
@@ -820,6 +847,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     FileResource fileResource = new FileResource();
     fileResource.setAssigned(true);
@@ -898,6 +926,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         Event.builder()
@@ -930,6 +959,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         Event.builder()
@@ -963,6 +993,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         Event.builder()
@@ -995,6 +1026,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         Event.builder()
@@ -1020,6 +1052,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         Event.builder()
@@ -1048,6 +1081,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         Event.builder()
@@ -1069,6 +1103,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement());
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setDataElement(MetadataIdentifier.ofUid(dataElementUid));
@@ -1153,6 +1188,37 @@ class DataValuesValidatorTest {
         new ProgramStageDataElement(programStage, dataElement);
     programStageDataElement.setCompulsory(compulsory);
     return Set.of(programStageDataElement);
+  }
+
+  /**
+   * Stubs the projected data elements of the given stage from its {@code programStageDataElements},
+   * which is what {@link
+   * org.hisp.dhis.tracker.imports.preheat.supplier.ProgramStageDataElementsSupplier} produces at
+   * runtime. The association itself is not mapped into the preheat anymore, so the validator reads
+   * the projection instead.
+   */
+  private void stubProgramStageDataElements(ProgramStage programStage) {
+    Set<ProgramStageDataElement> psdes = programStage.getProgramStageDataElements();
+    // read the idScheme off the mock, as the supplier does, so tests overriding it are honoured.
+    // build the value before stubbing, calling a mock inside thenReturn nests the stubbing.
+    TrackerIdSchemeParams schemes = preheat.getIdSchemes();
+    ProgramStageDataElements projected =
+        new ProgramStageDataElements(
+            psdes.stream()
+                .filter(ProgramStageDataElement::isCompulsory)
+                .map(psde -> schemes.toMetadataIdentifier(psde.getDataElement()))
+                .collect(Collectors.toSet()),
+            psdes.stream()
+                .map(psde -> schemes.toMetadataIdentifier(psde.getDataElement()))
+                .collect(Collectors.toSet()),
+            psdes.stream()
+                .map(psde -> psde.getDataElement().getUid())
+                // this test uses placeholder uids like MANDATORY_DE that UID.of rejects. The uid
+                // set only matters to the program rule mapper, which these tests do not exercise.
+                .filter(CodeGenerator::isValidUid)
+                .map(UID::of)
+                .collect(Collectors.toSet()));
+    lenient().when(preheat.getProgramStageDataElements(programStage)).thenReturn(projected);
   }
 
   private OrganisationUnit organisationUnit() {


### PR DESCRIPTION
2.41 port of #24773 (`perf: project program stage data elements in preheat`, psde-projection-master, Ivo/@teleivo).

## Why this applies to 2.41 too

A program stage can have thousands of data elements while an event references only a handful. Mapping the `programStageDataElements` association during tracker import preheat initialized one `DataElement` entity per element — the widest association on a program stage — which dominates preheat time on wide programs and, per the L2 investigation this stack is part of ([[l2-cache-region-lock-not-per-key-ivo-pr24773]]), serializes those loads through Hibernate's per-region `READ_WRITE` lock. That mechanism is independent of Ehcache2 vs Ehcache3, so it applies to 2.41 the same way it does to master.

## What changed

- `programStageDataElements` is no longer mapped by `ProgramStageMapper` — the association is empty on a preheated stage.
- New `ProgramStageDataElementsSupplier` projects only what import validation and program rules actually need — the compulsory data elements (E1303/E1076), plus those referenced by the payload or by program rules (E1305 / rule-effect membership) — via a single raw-JDBC query per import, split as a `union` (not `or`) so Postgres can use `dataelement_uid_key` on the payload/rule branch.
- `TrackerPreheat` gains `ProgramStageDataElements` storage (`compulsory`/`members`/`memberUids`), read by `DataValuesValidator` and `RuleActionEventMapper` instead of walking the (now-empty) entity association.

## What's ported vs. adapted for 2.41

**Ported as-is:** the projection model, the supplier's query shape and union-vs-or rationale, and all call-site changes (`ProgramStageMapper`, `TrackerPreheat`, `RuleActionEventMapper`, `ValidationUtils`, `DataValuesValidator`) — same 8 main + 2 test files as master's diff.

**Adapted for 2.41's older codebase:**
- Module is `dhis-service-tracker` (under `dhis-services/`), not a standalone `dhis-tracker` module — 2.41 predates that split. Package structure (`org.hisp.dhis.tracker.imports.*`) is otherwise identical.
- `javax.annotation.Nonnull`, not `jakarta.annotation.Nonnull`.
- No `AttributeValues` JSON-map helper class yet (that's a 2.42+ addition) — 2.41 still stores `attributevalues` as jsonb shaped `{"<attrUid>": {"value": "...", ...}}` via `JsonAttributeValueBinaryType`. The ATTRIBUTE-idScheme case extracts the value server-side with `de.attributevalues -> :attributeUid ->> 'value'` instead of deserializing client-side.
- Test file uses `Event.builder()`/`domain.Event`, not `TrackerEvent.builder()`/`domain.TrackerEvent` — 2.41 predates the tracker/single-event domain split.
- `UID.isValid(String)` doesn't exist in 2.41's `UID` — the test helper filtering placeholder uids (`MANDATORY_DE`) uses `CodeGenerator.isValidUid(String)` instead.

## Testing

- `mvn compile` / `test-compile` clean for `dhis-service-tracker`.
- Full `preheat.**`, `programrule.**`, `validation.validator.**` package test trees: **558 tests, 0 failures** across 77 classes.
- `spotless:apply` then `spotless:check` clean.
- Hand-verified the new supplier's SQL against a real 2.41 schema/dataset (local Postgres 14, Sierra Leone 2.41 dev DB): the union query returns the correct compulsory + payload/rule-referenced data elements, and `EXPLAIN` confirms the payload/rule branch uses `dataelement_uid_key` as intended — no `Seq Scan` on `dataelement`.

Related: #24773, #24815, #24827.

🤖 AI Assisted