### PR TITLE
fix: declare synchronized entity classes on native writes DHIS2-21963 [41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueTrimStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueTrimStore.java
@@ -84,8 +84,7 @@ public class HibernateDataValueTrimStore extends HibernateGenericStore<DataValue
                   AND de.zeroissignificant = false
                   AND dv.dataelementid = de.dataelementid
                   AND (dv.value IS NULL OR dv.value = '')""";
-    return getSession()
-        .createNativeQuery(sql)
+    return nativeSynchronizedQuery(sql)
         .setLockOptions(new LockOptions(PESSIMISTIC_WRITE).setTimeOut(1000))
         .executeUpdate();
   }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.query.NativeQuery;
 import org.hisp.dhis.dxf2.deprecated.tracker.event.EventCommentStore;
 import org.hisp.dhis.dxf2.deprecated.tracker.event.EventStore;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.context.WorkContext;
@@ -143,6 +144,8 @@ public class DefaultEventPersistenceService implements EventPersistenceService {
 
       entityManager
           .createNativeQuery(query)
+          .unwrap(NativeQuery.class)
+          .addSynchronizedEntityClass(Event.class)
           .setParameter("event", event.getEvent())
           .setParameter(
               "lastupdatedbyuserinfo",
@@ -173,6 +176,8 @@ public class DefaultEventPersistenceService implements EventPersistenceService {
 
       entityManager
           .createNativeQuery(query)
+          .unwrap(NativeQuery.class)
+          .addSynchronizedEntityClass(Event.class)
           .setParameter("event", event.getEvent())
           .setParameter("de", deUid)
           .setParameter(

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/HibernateNativeStore.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/HibernateNativeStore.java
@@ -94,8 +94,22 @@ public abstract class HibernateNativeStore<T> {
    * current class of the store. Use this to avoid all Hibernate second level caches from being
    * invalidated.
    *
-   * <p>Be aware that it is only correct to use this if and only if the only table touched by the
-   * native query is the one table belonging to the store.
+   * <p>Every native write triggers a cache cleanup driven only by its declared query spaces (the
+   * tables it affects). Declare none and Hibernate reads that as "unknown" and evicts
+   * <em>every</em> entity and collection region, so always declare, even when this entity is not
+   * cached.
+   *
+   * <p>Correct only when the sole table this statement <em>writes</em> is the store's own; tables
+   * merely read by a join or subquery need no declaration. Otherwise call {@code
+   * addSynchronizedEntityClass} directly, once per entity written.
+   *
+   * <p>Beware collection tables. An entity's query spaces are its own table(s) only, never the
+   * tables of the collections it owns, so declaring the owner does <em>not</em> evict its cached
+   * collections. Hibernate resolves collection regions through {@code
+   * getCollectionRolesByEntityParticipant}, which is keyed by the collection's <em>element</em>
+   * entity. So for a write against a join or child table, declare the entity on the far side of the
+   * association: {@code categories_categoryoptions} needs {@code CategoryOption}, not {@code
+   * Category}.
    *
    * @param sql the SQL query to execute
    * @return the {@link NativeQuery} instance


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/24803

Lower impact than [43](https://github.com/dhis2/dhis2-core/pull/24845) and [42](https://github.com/dhis2/dhis2-core/pull/24847). There the headline symptom was every L2 entity region being wiped every 20s, because the housekeeping job drives unsynchronized writes in `HibernateJobConfigurationStore`. On 2.41 that store already routes every write through `nativeSynchronizedQuery`, so the 20s wipe does not exist here. It was introduced after 2.41, when the store was rewritten onto stateless sessions and the rewrite dropped those calls.

What is left on 2.41 wipes just as thoroughly but rarely: the data value trim store runs daily at 1am, and the deprecated tracker event import wipes once per event data value written. So expect no steady state change on an idle instance, unlike 42 and 43.

A scan for `createNativeQuery(...).executeUpdate()` without an `addSynchronized*` returns nothing on this branch.

Applied directly rather than cherry-picked, since only the trim store and the javadoc have counterparts here. The stateless session helper is omitted as 2.41 has no stateless writes, and `HibernateQueryCacheTest` needs no change since it already expects the cache to survive.
