### PR TITLE
fix: Doris SQL for aggregate subexpression queries [DHIS2-21793]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/subexpression/SubexpressionDimensionItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/subexpression/SubexpressionDimensionItem.java
@@ -80,9 +80,10 @@ public class SubexpressionDimensionItem extends BaseDimensionalItemObject {
   }
 
   /**
-   * Gets a quoted SQL column name for a data element uid and optionally a category option combo
+   * Gets an unquoted SQL column name for a data element uid and optionally a category option combo
    * uid. These column names are generated in the SQL fragment for each item and referenced in the
-   * SQL fragment for the subexpression as a whole.
+   * SQL fragment for the subexpression as a whole. The caller quotes the name using the active SQL
+   * dialect.
    *
    * <p>If there is an aggregation type override in the query modifiers, its name is appended to the
    * end of the column name. This is needed in case the same item appears in the same subexpression
@@ -90,6 +91,9 @@ public class SubexpressionDimensionItem extends BaseDimensionalItemObject {
    */
   public static String getItemColumnName(
       String deUid, String cocUid, String aocUid, QueryModifiers mods) {
+    // Both combos contribute an underscore when either is present, so a data element with only an
+    // attribute option combo is "de__aoc", keeping it distinct from one with only a category
+    // option combo ("de_coc").
     String separator = (isEmpty(cocUid) && isEmpty(aocUid)) ? "" : "_";
 
     String coc = isEmpty(cocUid) ? "" : cocUid;
@@ -106,7 +110,7 @@ public class SubexpressionDimensionItem extends BaseDimensionalItemObject {
             ? "_agg_" + mods.getAggregationType().name()
             : "";
 
-    return "\"" + deUid + separator + coc + aoc + periodOffsetMod + aggregationMod + "\"";
+    return deUid + separator + coc + aoc + periodOffsetMod + aggregationMod;
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/subexpression/SubexpressionDimenstionItemTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/subexpression/SubexpressionDimenstionItemTest.java
@@ -70,53 +70,53 @@ class SubexpressionDimenstionItemTest {
   @Test
   void testGetItemColumnName() {
     // Test for coc and aoc = null when missing
-    assertEquals("\"de\"", getItemColumnName("de", null, null, null));
-    assertEquals("\"de_co\"", getItemColumnName("de", "co", null, null));
-    assertEquals("\"de_co_ao\"", getItemColumnName("de", "co", "ao", null));
-    assertEquals("\"de__ao\"", getItemColumnName("de", null, "ao", null));
+    assertEquals("de", getItemColumnName("de", null, null, null));
+    assertEquals("de_co", getItemColumnName("de", "co", null, null));
+    assertEquals("de_co_ao", getItemColumnName("de", "co", "ao", null));
+    assertEquals("de__ao", getItemColumnName("de", null, "ao", null));
   }
 
   @Test
   void testGetItemColumnNameWithAggregationType() {
     QueryModifiers mods = QueryModifiers.builder().aggregationType(MAX).build();
 
-    assertEquals("\"de_agg_MAX\"", getItemColumnName("de", "", "", mods));
-    assertEquals("\"de_co_agg_MAX\"", getItemColumnName("de", "co", "", mods));
-    assertEquals("\"de_co_ao_agg_MAX\"", getItemColumnName("de", "co", "ao", mods));
-    assertEquals("\"de__ao_agg_MAX\"", getItemColumnName("de", "", "ao", mods));
+    assertEquals("de_agg_MAX", getItemColumnName("de", "", "", mods));
+    assertEquals("de_co_agg_MAX", getItemColumnName("de", "co", "", mods));
+    assertEquals("de_co_ao_agg_MAX", getItemColumnName("de", "co", "ao", mods));
+    assertEquals("de__ao_agg_MAX", getItemColumnName("de", "", "ao", mods));
   }
 
   @Test
   void testGetItemColumnNameWithPeriodOffset() {
     QueryModifiers mods = QueryModifiers.builder().periodOffset(-2).build();
 
-    assertEquals("\"de_minus_2\"", getItemColumnName("de", "", "", mods));
-    assertEquals("\"de_co_minus_2\"", getItemColumnName("de", "co", "", mods));
-    assertEquals("\"de_co_ao_minus_2\"", getItemColumnName("de", "co", "ao", mods));
-    assertEquals("\"de__ao_minus_2\"", getItemColumnName("de", "", "ao", mods));
+    assertEquals("de_minus_2", getItemColumnName("de", "", "", mods));
+    assertEquals("de_co_minus_2", getItemColumnName("de", "co", "", mods));
+    assertEquals("de_co_ao_minus_2", getItemColumnName("de", "co", "ao", mods));
+    assertEquals("de__ao_minus_2", getItemColumnName("de", "", "ao", mods));
 
     mods = QueryModifiers.builder().periodOffset(3).build();
 
-    assertEquals("\"de_plus_3\"", getItemColumnName("de", "", "", mods));
-    assertEquals("\"de_co_plus_3\"", getItemColumnName("de", "co", "", mods));
-    assertEquals("\"de_co_ao_plus_3\"", getItemColumnName("de", "co", "ao", mods));
-    assertEquals("\"de__ao_plus_3\"", getItemColumnName("de", "", "ao", mods));
+    assertEquals("de_plus_3", getItemColumnName("de", "", "", mods));
+    assertEquals("de_co_plus_3", getItemColumnName("de", "co", "", mods));
+    assertEquals("de_co_ao_plus_3", getItemColumnName("de", "co", "ao", mods));
+    assertEquals("de__ao_plus_3", getItemColumnName("de", "", "ao", mods));
   }
 
   @Test
   void testGetItemColumnNameWithPeriodOffsetAndAggregationType() {
     QueryModifiers mods = QueryModifiers.builder().periodOffset(-1).aggregationType(SUM).build();
 
-    assertEquals("\"de_minus_1_agg_SUM\"", getItemColumnName("de", "", "", mods));
-    assertEquals("\"de_co_minus_1_agg_SUM\"", getItemColumnName("de", "co", "", mods));
-    assertEquals("\"de_co_ao_minus_1_agg_SUM\"", getItemColumnName("de", "co", "ao", mods));
-    assertEquals("\"de__ao_minus_1_agg_SUM\"", getItemColumnName("de", "", "ao", mods));
+    assertEquals("de_minus_1_agg_SUM", getItemColumnName("de", "", "", mods));
+    assertEquals("de_co_minus_1_agg_SUM", getItemColumnName("de", "co", "", mods));
+    assertEquals("de_co_ao_minus_1_agg_SUM", getItemColumnName("de", "co", "ao", mods));
+    assertEquals("de__ao_minus_1_agg_SUM", getItemColumnName("de", "", "ao", mods));
 
     mods = QueryModifiers.builder().periodOffset(1).aggregationType(COUNT).build();
 
-    assertEquals("\"de_plus_1_agg_COUNT\"", getItemColumnName("de", "", "", mods));
-    assertEquals("\"de_co_plus_1_agg_COUNT\"", getItemColumnName("de", "co", "", mods));
-    assertEquals("\"de_co_ao_plus_1_agg_COUNT\"", getItemColumnName("de", "co", "ao", mods));
-    assertEquals("\"de__ao_plus_1_agg_COUNT\"", getItemColumnName("de", "", "ao", mods));
+    assertEquals("de_plus_1_agg_COUNT", getItemColumnName("de", "", "", mods));
+    assertEquals("de_co_plus_1_agg_COUNT", getItemColumnName("de", "co", "", mods));
+    assertEquals("de_co_ao_plus_1_agg_COUNT", getItemColumnName("de", "co", "ao", mods));
+    assertEquals("de__ao_plus_1_agg_COUNT", getItemColumnName("de", "", "ao", mods));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
@@ -308,7 +308,7 @@ public class JdbcAnalyticsManager implements AnalyticsManager {
    */
   private String getSqlQuery(DataQueryParams params, AnalyticsTableType tableType) {
     if (params.hasSubexpressions()) {
-      return new JdbcSubexpressionQueryGenerator(this, params, tableType).getSql();
+      return new JdbcSubexpressionQueryGenerator(this, sqlBuilder, params, tableType).getSql();
     }
 
     StringBuilder builder = new StringBuilder();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
@@ -51,10 +51,7 @@ import static org.hisp.dhis.analytics.data.SubexpressionPeriodOffsetUtils.joinPe
 import static org.hisp.dhis.common.DimensionConstants.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionConstants.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.collection.CollectionUtils.addUnique;
-import static org.hisp.dhis.parser.expression.ParserUtils.castSql;
 import static org.hisp.dhis.subexpression.SubexpressionDimensionItem.getItemColumnName;
-import static org.hisp.dhis.system.util.SqlUtils.quote;
-import static org.hisp.dhis.system.util.SqlUtils.singleQuote;
 
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -69,6 +66,7 @@ import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
+import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.subexpression.SubexpressionDimensionItem;
 
 /**
@@ -121,9 +119,11 @@ import org.hisp.dhis.subexpression.SubexpressionDimensionItem;
  *              sum(case when dx = 'A2VfEfPflHV' and shift.delta = 0 then value else null end) as "A2VfEfPflHV",
  *              sum(case when dx = 'A2VfEfPflHV' and shift.delta = -1 then value else null end) as "A2VfEfPflHV_minus_1"
  *       from analytics
- *       join (values(-1,'202309','202308'),(-1,'202310','202309'),
- *                   (0,'202309','202309'),(0,'202310','202310'))
- *              as shift (delta, reportperiod, dataperiod) on dataperiod = monthly
+ *       join (select -1 as delta, '202309' as reportperiod, '202308' as dataperiod
+ *             union all select -1, '202310', '202309'
+ *             union all select 0, '202309', '202309'
+ *             union all select 0, '202310', '202310')
+ *              as shift on dataperiod = monthly
  *       where monthly in ('202308', '202309', '202310')
  *       and dx in ('A2VfEfPflHV') // (greatly improves performance)
  *       group by uidlevel2, monthly, ou) as ax
@@ -136,6 +136,9 @@ import org.hisp.dhis.subexpression.SubexpressionDimensionItem;
 public class JdbcSubexpressionQueryGenerator {
   /** {@link JdbcAnalyticsManager} for callbacks. */
   private final JdbcAnalyticsManager jam;
+
+  /** SQL builder for the configured analytics database. */
+  private final SqlBuilder sqlBuilder;
 
   /** Query parameters. */
   private final DataQueryParams params;
@@ -153,8 +156,12 @@ public class JdbcSubexpressionQueryGenerator {
   private final boolean hasPeriodOffsets;
 
   public JdbcSubexpressionQueryGenerator(
-      JdbcAnalyticsManager jam, DataQueryParams params, AnalyticsTableType tableType) {
+      JdbcAnalyticsManager jam,
+      SqlBuilder sqlBuilder,
+      DataQueryParams params,
+      AnalyticsTableType tableType) {
     this.jam = jam;
+    this.sqlBuilder = sqlBuilder;
     this.params = params;
     this.tableType = tableType;
     this.paramsWithoutData =
@@ -190,7 +197,10 @@ public class JdbcSubexpressionQueryGenerator {
     String dimensions =
         jam.getCommaDelimitedQuotedDimensionColumns(paramsWithoutData.getDimensions());
 
-    String data = singleQuote(subex.getDimensionItemWithQueryModsId()) + " as " + quote(DX);
+    String data =
+        sqlBuilder.singleQuote(subex.getDimensionItemWithQueryModsId())
+            + " as "
+            + sqlBuilder.quote(DX);
 
     String aggregate = getHighLevelAggregateFunction();
 
@@ -198,10 +208,12 @@ public class JdbcSubexpressionQueryGenerator {
 
     // Dimensions can be empty if the query is a Single Value query.
     if (StringUtils.isBlank(dimensions)) {
-      return String.format("select %s,%s(%s) as %s ", data, aggregate, value, quote(VALUE));
+      return String.format(
+          "select %s,%s(%s) as %s ", data, aggregate, value, sqlBuilder.quote(VALUE));
     } else {
       return String.format(
-          "select %s,%s,%s(%s) as %s ", dimensions, data, aggregate, value, quote(VALUE));
+          "select %s,%s,%s(%s) as %s ",
+          dimensions, data, aggregate, value, sqlBuilder.quote(VALUE));
     }
   }
 
@@ -211,7 +223,7 @@ public class JdbcSubexpressionQueryGenerator {
 
     String fromSub = "from " + jam.getFromSourceClause(params) + " as " + ANALYTICS_TBL_ALIAS + " ";
 
-    String joinSub = (hasPeriodOffsets) ? joinPeriodOffsetValues(params) : "";
+    String joinSub = (hasPeriodOffsets) ? joinPeriodOffsetValues(params, sqlBuilder) : "";
 
     String whereSub = getWhereSubquery();
 
@@ -251,7 +263,7 @@ public class JdbcSubexpressionQueryGenerator {
         jam.getCommaDelimitedQuotedDimensionColumns(paramsWithoutData.getNonPeriodDimensions());
     return SHIFT
         + "."
-        + REPORTPERIOD
+        + sqlBuilder.quote(REPORTPERIOD)
         + " as "
         + paramsWithoutData.getPeriodType().toLowerCase()
         + (nonPeriodDimensions.isEmpty() ? "" : "," + nonPeriodDimensions);
@@ -270,7 +282,7 @@ public class JdbcSubexpressionQueryGenerator {
       sql += "and ";
     }
 
-    sql += quote(ANALYTICS_TBL_ALIAS, DX) + " in (" + getSubexpressionDataElementList() + ") ";
+    sql += sqlBuilder.quoteAx(DX) + " in (" + getSubexpressionDataElementList() + ") ";
 
     return sql;
   }
@@ -284,10 +296,10 @@ public class JdbcSubexpressionQueryGenerator {
 
     List<String> cols = jam.getQuotedDimensionColumns(groupByParams.getDimensions());
 
-    addUnique(cols, quote(ANALYTICS_TBL_ALIAS, OU));
+    addUnique(cols, sqlBuilder.quoteAx(OU));
 
     if (hasPeriodOffsets) {
-      cols.add(SHIFT + "." + REPORTPERIOD);
+      cols.add(SHIFT + "." + sqlBuilder.quote(REPORTPERIOD));
     }
 
     return " group by " + join(",", cols);
@@ -322,9 +334,9 @@ public class JdbcSubexpressionQueryGenerator {
 
   /** Gets the data element UID from a data element or data element operand. */
   private String getQuotedDataElementUid(DimensionalItemObject item) {
-    return "'"
-        + ((item instanceof DataElementOperand deo) ? deo.getDataElement().getUid() : item.getUid())
-        + "'";
+    String uid =
+        (item instanceof DataElementOperand deo) ? deo.getDataElement().getUid() : item.getUid();
+    return sqlBuilder.singleQuote(uid);
   }
 
   /**
@@ -348,36 +360,32 @@ public class JdbcSubexpressionQueryGenerator {
     String fun = getLowLevelAggregateFunction(dataElement);
 
     String conditional =
-        quote(ANALYTICS_TBL_ALIAS, DX)
+        sqlBuilder.quoteAx(DX)
             + "='"
             + deUid
             + "'"
-            + (isEmpty(cocUid)
-                ? ""
-                : " and " + quote(ANALYTICS_TBL_ALIAS, CO) + "='" + cocUid + "'")
-            + (isEmpty(aocUid)
-                ? ""
-                : " and " + quote(ANALYTICS_TBL_ALIAS, AO) + "='" + aocUid + "'")
+            + (isEmpty(cocUid) ? "" : " and " + sqlBuilder.quoteAx(CO) + "='" + cocUid + "'")
+            + (isEmpty(aocUid) ? "" : " and " + sqlBuilder.quoteAx(AO) + "='" + aocUid + "'")
             + (hasPeriodOffsets
-                ? " and " + SHIFT + "." + DELTA + " = " + item.getPeriodOffset()
+                ? " and " + SHIFT + "." + sqlBuilder.quote(DELTA) + " = " + item.getPeriodOffset()
                 : "");
 
-    String value = quote(dataElement.getValueColumn());
+    String value = sqlBuilder.quote(dataElement.getValueColumn());
 
     DataType dataType = fromValueType(dataElement.getValueType());
     if (dataType == BOOLEAN) {
       dataType = NUMERIC; // Booleans are always aggregated as numeric in subex.
     }
-    String cast = castSql("", dataType);
+    String castValue = sqlBuilder.cast(value, dataType);
 
-    String column = getItemColumnName(deUid, cocUid, aocUid, dataElement.getQueryMods());
+    String column =
+        sqlBuilder.quote(getItemColumnName(deUid, cocUid, aocUid, dataElement.getQueryMods()));
 
     return fun
         + "(case when "
         + conditional
         + " then "
-        + value
-        + cast
+        + castValue
         + " else null end)"
         + " as "
         + column;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/SubexpressionPeriodOffsetUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/SubexpressionPeriodOffsetUtils.java
@@ -33,7 +33,6 @@ import static java.lang.String.format;
 import static org.hisp.dhis.analytics.util.PeriodOffsetUtils.shiftPeriod;
 import static org.hisp.dhis.common.DimensionConstants.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionConstants.PERIOD_DIM_ID;
-import static org.hisp.dhis.system.util.SqlUtils.quote;
 
 import java.util.HashSet;
 import java.util.List;
@@ -44,7 +43,7 @@ import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.commons.util.TextUtils;
+import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.period.PeriodDimension;
 
@@ -65,53 +64,75 @@ public class SubexpressionPeriodOffsetUtils {
 
   static final String SHIFT = "shift";
 
-  static final String DELTA = quote("delta");
+  static final String DELTA = "delta";
 
-  static final String REPORTPERIOD = quote("reportperiod");
+  static final String REPORTPERIOD = "reportperiod";
 
-  private static final String DATAPERIOD = quote("dataperiod");
+  private static final String DATAPERIOD = "dataperiod";
 
   /**
    * For {@link DataQueryParams} containing a subexpression with periodOffsets, joins an inline
    * value table that maps the reporting periods to data periods, for each distinct periodOffset
    * value.
    *
+   * <p>The inline table is built from selects combined with union all rather than from a values
+   * list. For the join and the surrounding query to refer to the columns of a values list, it needs
+   * a column alias list such as "as shift (delta, reportperiod, dataperiod)", which Doris does not
+   * support.
+   *
    * <p>For example, for periods '202309' and '202310' and periods offsets -1 and 0, this would
    * generate:
    *
    * <pre>
-   *       join (values(-1,'202309','202308'),(-1,'202310','202309'),
-   *                   (0,'202309','202309'),(0,'202310','202310'))
-   *       as shift (delta, reportperiod, dataperiod) on dataperiod = "monthly"
+   *       join (select -1 as "delta", '202309' as "reportperiod", '202308' as "dataperiod"
+   *             union all select -1, '202310', '202309'
+   *             union all select 0, '202309', '202309'
+   *             union all select 0, '202310', '202310')
+   *       as shift on "dataperiod" = "monthly"
    * </pre>
    *
    * @param params parameters with reporting periods
+   * @param sqlBuilder SQL builder for the configured analytics database
    * @return a join clause to an inline table to map reporting periods to data periods
    */
-  protected static String joinPeriodOffsetValues(DataQueryParams params) {
+  protected static String joinPeriodOffsetValues(DataQueryParams params, SqlBuilder sqlBuilder) {
     List<PeriodDimension> reportPeriods = getReportPeriods(params);
     List<Integer> periodOffsets = getPeriodOffsets(params);
 
-    StringBuilder sb = new StringBuilder(" join (values");
+    StringBuilder sb = new StringBuilder(" join (");
+    boolean namesColumns = true;
 
     for (Integer delta : periodOffsets) {
       for (PeriodDimension reportPeriod : reportPeriods) {
         PeriodDimension dataPeriod = shiftPeriod(reportPeriod, delta);
-        sb.append(
-            format("(%s,'%s','%s'),", delta, reportPeriod.getIsoDate(), dataPeriod.getIsoDate()));
+
+        // Only the first select names the columns, the others follow its column order.
+        if (namesColumns) {
+          sb.append(
+              format(
+                  "select %s as %s, '%s' as %s, '%s' as %s",
+                  delta,
+                  sqlBuilder.quote(DELTA),
+                  reportPeriod.getIsoDate(),
+                  sqlBuilder.quote(REPORTPERIOD),
+                  dataPeriod.getIsoDate(),
+                  sqlBuilder.quote(DATAPERIOD)));
+          namesColumns = false;
+        } else {
+          sb.append(
+              format(
+                  " union all select %s, '%s', '%s'",
+                  delta, reportPeriod.getIsoDate(), dataPeriod.getIsoDate()));
+        }
       }
     }
 
-    TextUtils.removeLastComma(sb)
-        .append(
-            format(
-                ") as %s (%s, %s, %s) on %s = %s",
-                SHIFT,
-                DELTA,
-                REPORTPERIOD,
-                DATAPERIOD,
-                DATAPERIOD,
-                quote(params.getPeriodType().toLowerCase())));
+    sb.append(
+        format(
+            ") as %s on %s = %s",
+            SHIFT,
+            sqlBuilder.quote(DATAPERIOD),
+            sqlBuilder.quote(params.getPeriodType().toLowerCase())));
 
     return sb.toString();
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGeneratorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGeneratorTest.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.QueryModifiers;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
+import org.hisp.dhis.db.sql.DorisSqlBuilder;
 import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.db.sql.SqlBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -119,11 +120,12 @@ class JdbcSubexpressionQueryGeneratorTest {
 
     List<DimensionalItemObject> items = List.of(deA, deoA, deoB, deoC, deE);
 
-    String deACol = getItemColumnName(deA.getUid(), null, null, null);
-    String deoACol = getItemColumnName(deB.getUid(), cocA.getUid(), null, null);
-    String deoBCol = getItemColumnName(deC.getUid(), cocB.getUid(), cocC.getUid(), null);
-    String deoCCol = getItemColumnName(deD.getUid(), null, cocD.getUid(), null);
-    String deECol = getItemColumnName(deE.getUid(), null, null, queryModsMin);
+    String deACol = sqlBuilder.quote(getItemColumnName(deA.getUid(), null, null, null));
+    String deoACol = sqlBuilder.quote(getItemColumnName(deB.getUid(), cocA.getUid(), null, null));
+    String deoBCol =
+        sqlBuilder.quote(getItemColumnName(deC.getUid(), cocB.getUid(), cocC.getUid(), null));
+    String deoCCol = sqlBuilder.quote(getItemColumnName(deD.getUid(), null, cocD.getUid(), null));
+    String deECol = sqlBuilder.quote(getItemColumnName(deE.getUid(), null, null, queryModsMin));
 
     String subexSql = deACol + "*(" + deoACol + "+" + deoBCol + ")+" + deoCCol + "-" + deECol;
 
@@ -145,7 +147,7 @@ class JdbcSubexpressionQueryGeneratorTest {
             .build();
 
     JdbcSubexpressionQueryGenerator target =
-        new JdbcSubexpressionQueryGenerator(manager, params, DATA_VALUE);
+        new JdbcSubexpressionQueryGenerator(manager, sqlBuilder, params, DATA_VALUE);
 
     String expected =
         "select ax.\"pe\",'subexprxUID' as \"dx\","
@@ -206,7 +208,7 @@ class JdbcSubexpressionQueryGeneratorTest {
             .build();
 
     JdbcSubexpressionQueryGenerator target =
-        new JdbcSubexpressionQueryGenerator(manager, params, DATA_VALUE);
+        new JdbcSubexpressionQueryGenerator(manager, sqlBuilder, params, DATA_VALUE);
 
     String expected =
         """
@@ -222,14 +224,9 @@ class JdbcSubexpressionQueryGeneratorTest {
             from \
             analytics as ax  \
             join (\
-            values(-1,\
-            '202305',\
-            '202304'),\
-            (0,\
-            '202305',\
-            '202305')) as shift ("delta", \
-            "reportperiod", \
-            "dataperiod") on \
+            select -1 as "delta", '202305' as "reportperiod", '202304' as "dataperiod" \
+            union all select 0, '202305', '202305'\
+            ) as shift on \
             "dataperiod" = "monthly"\
             where ax."monthly" in ('202304', '202305') \
             and ( ax."pe" in ('202305') ) \
@@ -275,11 +272,12 @@ class JdbcSubexpressionQueryGeneratorTest {
 
     List<DimensionalItemObject> items = List.of(deA, deoA, deoB, deoC, deE);
 
-    String deACol = getItemColumnName(deA.getUid(), null, null, null);
-    String deoACol = getItemColumnName(deB.getUid(), cocA.getUid(), null, null);
-    String deoBCol = getItemColumnName(deC.getUid(), cocB.getUid(), cocC.getUid(), null);
-    String deoCCol = getItemColumnName(deD.getUid(), null, cocD.getUid(), null);
-    String deECol = getItemColumnName(deE.getUid(), null, null, queryModsMin);
+    String deACol = sqlBuilder.quote(getItemColumnName(deA.getUid(), null, null, null));
+    String deoACol = sqlBuilder.quote(getItemColumnName(deB.getUid(), cocA.getUid(), null, null));
+    String deoBCol =
+        sqlBuilder.quote(getItemColumnName(deC.getUid(), cocB.getUid(), cocC.getUid(), null));
+    String deoCCol = sqlBuilder.quote(getItemColumnName(deD.getUid(), null, cocD.getUid(), null));
+    String deECol = sqlBuilder.quote(getItemColumnName(deE.getUid(), null, null, queryModsMin));
 
     String subexSql = deACol + "*(" + deoACol + "+" + deoBCol + ")+" + deoCCol + "-" + deECol;
 
@@ -301,7 +299,7 @@ class JdbcSubexpressionQueryGeneratorTest {
             .build();
 
     JdbcSubexpressionQueryGenerator target =
-        new JdbcSubexpressionQueryGenerator(manager, params, DATA_VALUE);
+        new JdbcSubexpressionQueryGenerator(manager, sqlBuilder, params, DATA_VALUE);
 
     String expected =
         "select 'subexprxUID' as \"dx\","
@@ -318,6 +316,63 @@ class JdbcSubexpressionQueryGeneratorTest {
             + "and ax.\"dx\" in ('deabcdefghA','deabcdefghB','deabcdefghC','deabcdefghD','deabcdefghE')  "
             + "group by ax.\"monthly\",ax.\"ou\") as ax "
             + "where \"deabcdefghA\"*(\"deabcdefghB_cuabcdefghA\"+\"deabcdefghC_cuabcdefghB_cuabcdefghC\")+\"deabcdefghD__cuabcdefghD\"-\"deabcdefghE_agg_MIN\" is not null ";
+
+    String actual = anonymize(target.getSql());
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testGetSqlWithDoris() {
+    SqlBuilder dorisSqlBuilder = new DorisSqlBuilder("dhis2", "driver");
+    JdbcAnalyticsManager dorisManager =
+        new JdbcAnalyticsManager(queryPlanner, jdbcTemplate, executionPlanStore, dorisSqlBuilder);
+
+    OrganisationUnit ouA = createOrganisationUnit('A');
+    PeriodDimension peA = PeriodDimension.of(createPeriod("202305"));
+    DataElement deA = createDataElement('A');
+    DataElement deB = createDataElement('B');
+    CategoryOptionCombo cocA = createCategoryOptionCombo('A');
+    CategoryOptionCombo aocA = createCategoryOptionCombo('B');
+    DataElementOperand deoA = new DataElementOperand(deB, cocA, aocA);
+
+    String deAColumn = dorisSqlBuilder.quote(getItemColumnName(deA.getUid(), null, null, null));
+    String deoAColumn =
+        dorisSqlBuilder.quote(getItemColumnName(deB.getUid(), cocA.getUid(), aocA.getUid(), null));
+    SubexpressionDimensionItem subex =
+        new SubexpressionDimensionItem(deAColumn + "+" + deoAColumn, List.of(deA, deoA), null);
+
+    DataQueryParams params =
+        DataQueryParams.newBuilder()
+            .withDataType(DataType.NUMERIC)
+            .withTableName("analytics")
+            .withAggregationType(AnalyticsAggregationType.SUM)
+            .addDimension(
+                new BaseDimensionalObject(DATA_X_DIM_ID, DimensionType.DATA_X, getList(subex)))
+            .addFilter(
+                new BaseDimensionalObject(
+                    ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, getList(ouA)))
+            .addDimension(
+                new BaseDimensionalObject(PERIOD_DIM_ID, DimensionType.PERIOD, getList(peA)))
+            .withPeriodType("monthly")
+            .build();
+
+    JdbcSubexpressionQueryGenerator target =
+        new JdbcSubexpressionQueryGenerator(dorisManager, dorisSqlBuilder, params, DATA_VALUE);
+
+    String expected =
+        "select ax.`pe`,'subexprxUID' as `dx`,"
+            + "sum(`deabcdefghA`+`deabcdefghB_cuabcdefghA_cuabcdefghB`) as `value` "
+            + "from (select ax.`pe`, "
+            + "sum(case when ax.`dx`='deabcdefghA' then CAST(`value` AS DECIMAL) else null end) as `deabcdefghA`,"
+            + "sum(case when ax.`dx`='deabcdefghB' and ax.`co`='cuabcdefghA' and ax.`ao`='cuabcdefghB' then CAST(`value` AS DECIMAL) else null end) as `deabcdefghB_cuabcdefghA_cuabcdefghB` "
+            + "from analytics as ax "
+            + "where ax.`monthly` in ('202305') "
+            + "and ( ax.`ou` in ('ouabcdefghA') ) "
+            + "and ax.`dx` in ('deabcdefghA','deabcdefghB')  "
+            + "group by ax.`monthly`,ax.`ou`) as ax "
+            + "where `deabcdefghA`+`deabcdefghB_cuabcdefghA_cuabcdefghB` is not null "
+            + "group by ax.`pe` ";
 
     String actual = anonymize(target.getSql());
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/SubexpressionPeriodOffsetUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/SubexpressionPeriodOffsetUtilsTest.java
@@ -46,6 +46,8 @@ import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.QueryModifiers;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.db.sql.DorisSqlBuilder;
+import org.hisp.dhis.db.sql.PostgreSqlBuilder;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodDimension;
 import org.hisp.dhis.subexpression.SubexpressionDimensionItem;
@@ -87,14 +89,35 @@ class SubexpressionPeriodOffsetUtilsTest {
 
   @Test
   void testJoinPeriodOffsetValues() {
-    String result = SubexpressionPeriodOffsetUtils.joinPeriodOffsetValues(params);
+    String result =
+        SubexpressionPeriodOffsetUtils.joinPeriodOffsetValues(params, new PostgreSqlBuilder());
     String expected =
-        " join (values"
-            + "(-2,'202309','202307'),(-2,'202310','202308'),"
-            + "(-1,'202309','202308'),(-1,'202310','202309'),"
-            + "(0,'202309','202309'),(0,'202310','202310'),"
-            + "(1,'202309','202310'),(1,'202310','202311'))"
-            + " as shift (\"delta\", \"reportperiod\", \"dataperiod\") on \"dataperiod\" = \"monthly\"";
+        " join (select -2 as \"delta\", '202309' as \"reportperiod\", '202307' as \"dataperiod\""
+            + " union all select -2, '202310', '202308'"
+            + " union all select -1, '202309', '202308'"
+            + " union all select -1, '202310', '202309'"
+            + " union all select 0, '202309', '202309'"
+            + " union all select 0, '202310', '202310'"
+            + " union all select 1, '202309', '202310'"
+            + " union all select 1, '202310', '202311'"
+            + ") as shift on \"dataperiod\" = \"monthly\"";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testJoinPeriodOffsetValuesWithDoris() {
+    String result =
+        SubexpressionPeriodOffsetUtils.joinPeriodOffsetValues(params, new DorisSqlBuilder("", ""));
+    String expected =
+        " join (select -2 as `delta`, '202309' as `reportperiod`, '202307' as `dataperiod`"
+            + " union all select -2, '202310', '202308'"
+            + " union all select -1, '202309', '202308'"
+            + " union all select -1, '202310', '202309'"
+            + " union all select 0, '202309', '202309'"
+            + " union all select 0, '202310', '202310'"
+            + " union all select 1, '202309', '202310'"
+            + " union all select 1, '202310', '202311'"
+            + ") as shift on `dataperiod` = `monthly`";
     assertEquals(expected, result);
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperand.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperand.java
@@ -36,7 +36,6 @@ import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.analytics.DataType.fromValueType;
 import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT;
 import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT_OPERAND;
-import static org.hisp.dhis.parser.expression.ParserUtils.castSql;
 import static org.hisp.dhis.parser.expression.ParserUtils.replaceSqlNull;
 import static org.hisp.dhis.subexpression.SubexpressionDimensionItem.getItemColumnName;
 
@@ -80,7 +79,10 @@ public class DimItemDataElementAndOperand extends DimensionalItem {
     String cocUid = (ctx.uid1 == null) ? null : ctx.uid1.getText();
     String aocUid = (ctx.uid2 == null) ? null : ctx.uid2.getText();
 
-    String column = getItemColumnName(deUid, cocUid, aocUid, visitor.getState().getQueryMods());
+    String column =
+        visitor
+            .getSqlBuilder()
+            .quote(getItemColumnName(deUid, cocUid, aocUid, visitor.getState().getQueryMods()));
 
     if (visitor.getState().isReplaceNulls()) {
       column = replaceDataElementNulls(column, deUid, visitor);
@@ -130,7 +132,7 @@ public class DimItemDataElementAndOperand extends DimensionalItem {
     DataType dataType = fromValueType(dataElement.getValueType());
     if (dataType == BOOLEAN) {
       if (BOOLEAN == visitor.getParams().getDataType()) {
-        column = castSql(column, BOOLEAN);
+        column = visitor.getSqlBuilder().cast(column, BOOLEAN);
       } else {
         dataType = NUMERIC;
       }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperandTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperandTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.expression.dataitem;
+
+import static org.hisp.dhis.analytics.DataType.BOOLEAN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.antlr.v4.runtime.CommonToken;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.db.sql.DorisSqlBuilder;
+import org.hisp.dhis.db.sql.PostgreSqlBuilder;
+import org.hisp.dhis.db.sql.SqlBuilder;
+import org.hisp.dhis.expression.ExpressionParams;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+import org.junit.jupiter.api.Test;
+
+class DimItemDataElementAndOperandTest {
+  private static final String DE_UID = "deabcdefghA";
+
+  private final DimItemDataElementAndOperand subject = new DimItemDataElementAndOperand();
+
+  @Test
+  void getSqlQuotesSubexpressionColumnForPostgres() {
+    assertEquals("\"deabcdefghA\"", subject.getSql(context(), visitor(new PostgreSqlBuilder())));
+  }
+
+  @Test
+  void getSqlQuotesSubexpressionColumnForDoris() {
+    assertEquals("`deabcdefghA`", subject.getSql(context(), visitor(new DorisSqlBuilder("", ""))));
+  }
+
+  @Test
+  void getSqlCastsBooleanSubexpressionColumnForDoris() {
+    SqlBuilder sqlBuilder = new DorisSqlBuilder("", "");
+    CommonExpressionVisitor visitor = visitor(sqlBuilder);
+    visitor.getState().setReplaceNulls(true);
+
+    DataElement dataElement = new DataElement();
+    dataElement.setUid(DE_UID);
+    dataElement.setValueType(ValueType.BOOLEAN);
+    when(visitor.getIdObjectManager().get(DataElement.class, DE_UID)).thenReturn(dataElement);
+    visitor.setParams(ExpressionParams.builder().dataType(BOOLEAN).build());
+
+    assertEquals(
+        "coalesce(CAST(`deabcdefghA` AS DECIMAL) != 0,false)", subject.getSql(context(), visitor));
+  }
+
+  private CommonExpressionVisitor visitor(SqlBuilder sqlBuilder) {
+    CommonExpressionVisitor visitor =
+        CommonExpressionVisitor.builder()
+            .idObjectManager(mock(IdentifiableObjectManager.class))
+            .sqlBuilder(sqlBuilder)
+            .build();
+    visitor.getState().setReplaceNulls(false);
+    return visitor;
+  }
+
+  private ExprContext context() {
+    ExprContext context = new ExprContext(null, 0);
+    context.uid0 = new CommonToken(0, DE_UID);
+    return context;
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
@@ -266,20 +266,4 @@ public class ParserUtils {
           case TEXT -> ",'')";
         };
   }
-
-  /**
-   * Generate SQL to cast an analytics value to a data type.
-   *
-   * @param column SQL column to cast
-   * @param dataType data type to cast to
-   * @return a coalesce statement casting the column
-   */
-  public static String castSql(String column, DataType dataType) {
-    return column
-        + switch (dataType) {
-          case NUMERIC -> "::numeric";
-          case BOOLEAN -> "::numeric!=0";
-          case TEXT -> "::text";
-        };
-  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv15AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv15AutoTest.java
@@ -50,7 +50,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIf;
 
 /** Groups e2e tests for "/analytics" aggregate endpoint. */
 public class AnalyticsQueryDv15AutoTest extends AnalyticsApiTest {
@@ -62,7 +61,6 @@ public class AnalyticsQueryDv15AutoTest extends AnalyticsApiTest {
   }
 
   @Test
-  @EnabledIf(value = "isPostgres", disabledReason = "subExpressions are only supported in Postgres")
   public void subExpressionIndicator() throws JSONException {
 
     // Given
@@ -137,7 +135,6 @@ public class AnalyticsQueryDv15AutoTest extends AnalyticsApiTest {
   }
 
   @Test
-  @EnabledIf(value = "isPostgres", disabledReason = "subExpressions are only supported in Postgres")
   @DependsOn(
       files = {"ind-subexpression-no-offset.json"},
       delete = true)

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceQueryModifiersTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceQueryModifiersTest.java
@@ -440,6 +440,17 @@ class AnalyticsServiceQueryModifiersTest extends PostgresIntegrationTestBase {
     assertEquals(expected, result);
   }
 
+  @Test
+  void testPeriodOffsetSubExpression() {
+    expected =
+        List.of("inabcdefghA-202201-1.0", "inabcdefghA-202202-3.0", "inabcdefghA-202203-5.0");
+
+    result =
+        query("subExpression(#{deabcdefghA} + #{deabcdefghA}.periodOffset(-1))", jan, feb, mar);
+
+    assertEquals(expected, result);
+  }
+
   @AfterAll
   void cleanUpRefs() {
     cleanPeriodTypes();


### PR DESCRIPTION
### The problem

Aggregate analytics queries for indicators containing `subExpression(...)` generated
PostgreSQL-specific SQL even when Apache Doris was the configured analytics database, so every query using `subExpression ` failed on Doris. 

Only `/api/analytics` is affected: event, enrollment and tracked-entity analytics use different code.

There are two separate problems:

**1. The generated SQL mixed dialects.** Dimension columns were quoted correctly, but the
subexpression pivot columns and value casts were not:

```sql
select ax.`uidlevel1`,
  sum(case when ax."dx" = 'hpYA6Hhu0GF' then "value"::numeric else null end) as "hpYA6Hhu0GF"
from analytics as ax
```

**2. The `periodOffset` inline table used a syntax Doris does not implement.** This issue was not in the original ticket and was only found by running the reported query against a real Doris instance after fixing
defect 1.

### Fix for issue #1 

`JdbcSubexpressionQueryGenerator` now receives the `SqlBuilder` that `JdbcAnalyticsManager` already
holds, and every identifier, literal and cast goes through it (`quote`, `quoteAx`, `singleQuote`,
`cast`). The Doris output now is:

```sql
sum(case when ax.`dx`='deabcdefghA' then CAST(`value` AS DECIMAL) else null end) as `deabcdefghA`
```

### Fix for isse #2

When a subexpression contains a `periodOffset`, the query joins a small inline table mapping each reporting period to the data period the value must come from. That table was built as a PostgreSQL `VALUES` list with a derived-table column alias list:

```sql
-- before
join (values(-1,'202309','202308'),(-1,'202310','202309'),
             (0,'202309','202309'),(0,'202310','202310'))
  as shift (delta, reportperiod, dataperiod) on dataperiod = monthly
```

```sql
-- after
join (select -1 as delta, '202309' as reportperiod, '202308' as dataperiod
      union all select -1, '202310', '202309'
      union all select  0, '202309', '202309'
      union all select  0, '202310', '202310')
  as shift on dataperiod = monthly
```

Doris accepts `as shift` (the inline table) but rejects the column list (`shift (delta, reportperiod, dataperiod)`), therefore the column names have to come from *inside* the
table instead of being attached to it from outside (using `shitf`). Using `select ... union all` does that.

## Reviewer note

@maikelarabori a couple of considerations:

- The generated sql for `periodOffset` and subexpressions has been now modified on both Postgres and Doris. In other words, we no longer use `shift (delta, reportperiod, dataperiod)` but always use `union all`.
- This fix does not work for clickhouse (see failing tests). I recommend that we open a separate ticket and do a separate fix.
