### PR TITLE
fix: add CORS to security-ignored loginConfig endpoint [DHIS2-21909]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/LoginConfigCorsTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/LoginConfigCorsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Set;
+import org.hisp.dhis.configuration.ConfigurationService;
+import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.webapi.filter.LoginConfigCorsFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Web test for CORS on the security-ignored {@code /api/**&#47;loginConfig} endpoint
+ * (DHIS2-21909): a whitelisted browser origin must receive CORS headers even though the Spring
+ * Security filter chain (and its CorsFilter) is skipped for this path.
+ *
+ * <p>The production servlet registration in {@code DhisWebApiWebAppInitializer#setupServlets} is
+ * not active in MockMvc, so the filter is added explicitly with its production {@code /api/*}
+ * mapping; the loginConfig path gate lives inside the filter itself. The end-to-end registration
+ * order is covered by manual verification against a running server.
+ *
+ * @author Morten Svanæs
+ */
+@Transactional
+class LoginConfigCorsTest extends H2ControllerIntegrationTestBase {
+
+  private static final String WHITELISTED_ORIGIN = "http://localhost:3000";
+
+  @Autowired private LoginConfigCorsFilter loginConfigCorsFilter;
+
+  @Autowired private ConfigurationService configurationService;
+
+  @BeforeEach
+  void setUpCors() {
+    mvc =
+        MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .addFilter(loginConfigCorsFilter, "/api/*")
+            .build();
+    configurationService.setCorsWhitelist(Set.of(WHITELISTED_ORIGIN));
+  }
+
+  @Test
+  void preflightOnLoginConfigReturnsCorsHeaders() throws Exception {
+    mvc.perform(
+            options("/api/loginConfig")
+                .header("Origin", WHITELISTED_ORIGIN)
+                .header("Access-Control-Request-Method", "GET"))
+        .andExpect(status().isNoContent())
+        .andExpect(header().string("Access-Control-Allow-Origin", WHITELISTED_ORIGIN))
+        .andExpect(header().string("Access-Control-Allow-Credentials", "true"))
+        .andExpect(header().string("Access-Control-Allow-Methods", "GET"));
+  }
+
+  @Test
+  void getLoginConfigWithWhitelistedOriginReturnsBodyAndCorsHeaders() throws Exception {
+    mvc.perform(get("/api/loginConfig").header("Origin", WHITELISTED_ORIGIN))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Access-Control-Allow-Origin", WHITELISTED_ORIGIN))
+        .andExpect(jsonPath("$.apiVersion").exists());
+  }
+
+  @Test
+  void getLoginConfigWithNonWhitelistedOriginReturnsNoCorsHeaders() throws Exception {
+    mvc.perform(get("/api/loginConfig").header("Origin", "http://evil.example"))
+        .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+  }
+
+  @Test
+  void otherApiPathIsNotTouchedByLoginConfigCorsFilter() throws Exception {
+    mvc.perform(get("/api/me").header("Origin", WHITELISTED_ORIGIN))
+        .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/LoginConfigCorsTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/LoginConfigCorsTest.java
@@ -46,9 +46,9 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Web test for CORS on the security-ignored {@code /api/**&#47;loginConfig} endpoint
- * (DHIS2-21909): a whitelisted browser origin must receive CORS headers even though the Spring
- * Security filter chain (and its CorsFilter) is skipped for this path.
+ * Web test for CORS on the security-ignored {@code /api/**&#47;loginConfig} endpoint (DHIS2-21909):
+ * a whitelisted browser origin must receive CORS headers even though the Spring Security filter
+ * chain (and its CorsFilter) is skipped for this path.
  *
  * <p>The production servlet registration in {@code DhisWebApiWebAppInitializer#setupServlets} is
  * not active in MockMvc, so the filter is added explicitly with its production {@code /api/*}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/LoginConfigCorsFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/LoginConfigCorsFilter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.hisp.dhis.webapi.security.AntPathRequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Servlet-level CORS for the security-ignored login bootstrap endpoint {@code
+ * /api/**&#47;loginConfig}.
+ *
+ * <p>The endpoint is excluded from the Spring Security filter chain via {@code web.ignoring()}
+ * (DHIS2-21909) so public login bootstrap never builds {@code UserDetails}. That also means the
+ * security-level {@link CorsFilter} never runs for it, and browser apps on foreign origins (e.g. a
+ * local app on {@code http://localhost:3000}) lose the {@code Access-Control-Allow-Origin} header
+ * even when whitelisted.
+ *
+ * <p>This filter fills that gap outside the security chain, scoped to loginConfig only via {@link
+ * #shouldNotFilter(HttpServletRequest)}. It delegates to a {@link CorsFilter} driven by the same
+ * {@link DhisCorsProcessor} and system CORS whitelist as the rest of the API, so preflight requests
+ * short-circuit with 204 and whitelist rules stay identical. All other paths are untouched,
+ * avoiding double CORS headers on endpoints served by the security chain.
+ *
+ * <p>Registered as a servlet filter before the security chain in {@code
+ * DhisWebApiWebAppInitializer#setupServlets}.
+ *
+ * @author Morten Svanæs
+ */
+@Component("loginConfigCorsFilter")
+public class LoginConfigCorsFilter extends OncePerRequestFilter {
+
+  /** Same Ant mid-pattern as the {@code web.ignoring()} matcher for loginConfig. */
+  private static final AntPathRequestMatcher LOGIN_CONFIG =
+      new AntPathRequestMatcher("/api/**/loginConfig");
+
+  private final CorsFilter corsFilter;
+
+  public LoginConfigCorsFilter(DhisCorsProcessor corsProcessor) {
+    CorsFilter delegate = new CorsFilter(new UrlBasedCorsConfigurationSource());
+    delegate.setCorsProcessor(corsProcessor);
+    this.corsFilter = delegate;
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return !LOGIN_CONFIG.matches(request);
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    corsFilter.doFilter(request, response, filterChain);
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
@@ -152,6 +152,14 @@ public class DhisWebApiWebAppInitializer implements WebApplicationInitializer {
             new DelegatingFilterProxy("legacyDhisWebLoginRedirectFilter"))
         .addMappingForUrlPatterns(null, false, "/dhis-web-login", "/dhis-web-login/*");
 
+    // CORS for the security-ignored loginConfig endpoint (DHIS2-21909): the path is excluded
+    // from the Spring Security filter chain, so the security-level CorsFilter never runs for
+    // it. Must be registered before springSecurityFilterChain; scoped to /api/**/loginConfig
+    // by the path gate in LoginConfigCorsFilter#shouldNotFilter.
+    context
+        .addFilter("loginConfigCorsFilter", new DelegatingFilterProxy("loginConfigCorsFilter"))
+        .addMappingForUrlPatterns(null, false, "/api/*");
+
     context
         .addFilter(
             "springSecurityFilterChain", new DelegatingFilterProxy("springSecurityFilterChain"))

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/LoginConfigCorsFilterTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/LoginConfigCorsFilterTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.hisp.dhis.configuration.ConfigurationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Unit test for {@link LoginConfigCorsFilter}: the security-ignored {@code /api/**&#47;loginConfig}
+ * endpoint must get CORS headers from the servlet-level filter (the Spring Security chain,
+ * including its CorsFilter, is skipped for this path), while all other paths pass through
+ * untouched.
+ *
+ * @author Morten Svanæs
+ */
+class LoginConfigCorsFilterTest {
+
+  private static final String WHITELISTED_ORIGIN = "http://localhost:3000";
+
+  private LoginConfigCorsFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    ConfigurationService configurationService = mock(ConfigurationService.class);
+    when(configurationService.isCorsWhitelisted(WHITELISTED_ORIGIN)).thenReturn(true);
+    filter = new LoginConfigCorsFilter(new DhisCorsProcessor(configurationService));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/api/loginConfig", "/api/40/loginConfig", "/api/41/loginConfig"})
+  void preflightOnLoginConfigShortCircuitsWithCorsHeaders(String path)
+      throws ServletException, IOException {
+    MockHttpServletRequest request = request("OPTIONS", path);
+    request.addHeader("Origin", WHITELISTED_ORIGIN);
+    request.addHeader("Access-Control-Request-Method", "GET");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    filter.doFilter(request, response, chain);
+
+    assertEquals(204, response.getStatus());
+    assertEquals(WHITELISTED_ORIGIN, response.getHeader("Access-Control-Allow-Origin"));
+    assertEquals("true", response.getHeader("Access-Control-Allow-Credentials"));
+    assertEquals("GET", response.getHeader("Access-Control-Allow-Methods"));
+    assertNull(chain.getRequest(), "preflight must short-circuit the filter chain");
+  }
+
+  @Test
+  void getWithWhitelistedOriginAddsCorsHeadersAndContinuesChain()
+      throws ServletException, IOException {
+    MockHttpServletRequest request = request("GET", "/api/loginConfig");
+    request.addHeader("Origin", WHITELISTED_ORIGIN);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    filter.doFilter(request, response, chain);
+
+    assertEquals(WHITELISTED_ORIGIN, response.getHeader("Access-Control-Allow-Origin"));
+    assertEquals("true", response.getHeader("Access-Control-Allow-Credentials"));
+    assertNotNull(chain.getRequest(), "actual request must continue down the filter chain");
+  }
+
+  @Test
+  void nonWhitelistedOriginGetsNoCorsHeadersAndStopsChain() throws ServletException, IOException {
+    MockHttpServletRequest request = request("GET", "/api/loginConfig");
+    request.addHeader("Origin", "http://evil.example");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    filter.doFilter(request, response, chain);
+
+    assertNull(response.getHeader("Access-Control-Allow-Origin"));
+    assertNull(chain.getRequest(), "rejected CORS request must not reach the endpoint");
+  }
+
+  @Test
+  void nonCorsRequestWithoutOriginPassesThroughUnchanged() throws ServletException, IOException {
+    MockHttpServletRequest request = request("GET", "/api/loginConfig");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    filter.doFilter(request, response, chain);
+
+    assertNull(response.getHeader("Access-Control-Allow-Origin"));
+    assertNotNull(chain.getRequest(), "non-CORS request must continue down the filter chain");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/api/auth/login", "/api/me", "/api/ping", "/api/40/auth/login"})
+  void otherApiPathsAreNotFiltered(String path) throws ServletException, IOException {
+    MockHttpServletRequest request = request("GET", path);
+    request.addHeader("Origin", WHITELISTED_ORIGIN);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    filter.doFilter(request, response, chain);
+
+    assertNull(
+        response.getHeader("Access-Control-Allow-Origin"),
+        "non-loginConfig paths must not get servlet-level CORS (security chain owns them)");
+    assertNotNull(chain.getRequest(), "non-loginConfig request must continue down the chain");
+  }
+
+  private static MockHttpServletRequest request(String method, String path) {
+    MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+    request.setServletPath(path);
+    request.setPathInfo(null);
+    return request;
+  }
+}


### PR DESCRIPTION
## Summary

PR #24636 moved `/api/**/loginConfig` to `web.ignoring()` so public login bootstrap never builds `UserDetails`. Side effect: the security-level `CorsFilter` no longer runs for that path, so whitelisted browser origins (e.g. a local app on `http://localhost:3000`) stopped getting `Access-Control-Allow-Origin`, breaking the app-platform LoginModal probe.

This registers a path-scoped servlet-level CORS filter for `/api/**/loginConfig` only, running before the security filter chain and driven by the same `DhisCorsProcessor` + system CORS whitelist as the rest of the API. The security ignore stays (no `UserDetails` on login bootstrap); all other paths are untouched, so no double CORS headers on endpoints served by the security chain.

## Changes

- New `LoginConfigCorsFilter` (`OncePerRequestFilter`, path gate in `shouldNotFilter`, delegates to `CorsFilter` + `DhisCorsProcessor`)
- Registered as `DelegatingFilterProxy` before `springSecurityFilterChain` in `DhisWebApiWebAppInitializer` (REQUEST dispatch only)
- Unit test covering preflight/actual/rejected/non-CORS requests and the path gate (versioned + unversioned paths)
- H2 web test with real `ConfigurationService` whitelist (filter added to MockMvc explicitly; production registration is not active in MockMvc)

## Verification

Against a running server (fresh DB, whitelist `http://localhost:3000`): preflight `OPTIONS /api/loginConfig` → 204 + ACAO/credentials/allow-methods; anonymous `GET` → 200 + body + ACAO; versioned `/api/42/loginConfig` OK; non-whitelisted origin gets no ACAO; `GET /api/me` emits exactly one ACAO (no double header).

Backport note: needed wherever #24636 landed (v44+).

AI Assisted