### PR TITLE
fix: Load tracked entity attributes for event-only imports in rule engine validation [DHIS2-21961] 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/DefaultProgramRuleService.java
@@ -411,7 +411,7 @@ class DefaultProgramRuleService implements ProgramRuleService {
             .map(attributes -> RuleEngineMapper.mapAttributes(preheat, attributes))
             .orElse(Collections.emptyList());
 
-    TrackedEntity trackedEntity = preheat.getTrackedEntity(teUid);
+    TrackedEntity trackedEntity = getTrackedEntity(enrollmentUid, teUid, preheat);
     if (trackedEntity == null) {
       return Stream.concat(
               payloadTrackedEntityAttributes.stream(), payloadProgramAttributes.stream())
@@ -435,6 +435,22 @@ class DefaultProgramRuleService implements ProgramRuleService {
                 payloadTrackedEntityAttributes.stream(), payloadProgramAttributes.stream()),
             dbAttributesNotPresentInPayload)
         .toList();
+  }
+
+  // Resolve the tracked entity holding the attribute values saved in the DB.
+  // Tracked entities are only preheated when they are referenced by the payload. Payloads
+  // containing just events (like the one the Capture app sends when completing an event) do not
+  // reference any tracked entity, so fall back to the tracked entity of the saved enrollment, which
+  // is preheated for every payload event and already carries its attribute values.
+  private static TrackedEntity getTrackedEntity(
+      UID enrollmentUid, UID teUid, TrackerPreheat preheat) {
+    TrackedEntity trackedEntity = preheat.getTrackedEntity(teUid);
+    if (trackedEntity != null) {
+      return trackedEntity;
+    }
+
+    Enrollment enrollment = preheat.getEnrollment(enrollmentUid);
+    return enrollment == null ? null : enrollment.getTrackedEntity();
   }
 
   // Fetch all saved events for the given enrollments in a single DB query and group by enrollment.

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleTest.java
@@ -412,6 +412,59 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
   }
 
   @Test
+  void shouldNotImportEventWhenAnErrorIsTriggeredByATeaValueSavedInDbAndPayloadHasOnlyTheEvent()
+      throws IOException {
+    ImportReport report =
+        trackerImportService.importTracker(
+            new TrackerImportParams(),
+            testSetup.fromJson("tracker/programrule/te_with_attribute_enrollment.json"));
+    assertNoErrors(report);
+
+    errorProgramRuleWithD2HasValue();
+    report =
+        trackerImportService.importTracker(
+            new TrackerImportParams(), testSetup.fromJson("tracker/programrule/event.json"));
+
+    assertHasOnlyErrors(report, E1300);
+  }
+
+  @Test
+  void shouldImportCompletedEventWhenOnCompleteErrorRuleIsNotTriggeredBecauseTeaSavedInDbHasValue()
+      throws IOException {
+    ImportReport report =
+        trackerImportService.importTracker(
+            new TrackerImportParams(),
+            testSetup.fromJson("tracker/programrule/te_with_attribute_enrollment.json"));
+    assertNoErrors(report);
+
+    onCompleteErrorProgramRuleWhenTeaHasNoValue();
+    report =
+        trackerImportService.importTracker(
+            new TrackerImportParams(),
+            testSetup.fromJson("tracker/programrule/completed_event.json"));
+
+    assertNoErrors(report);
+  }
+
+  @Test
+  void shouldNotImportCompletedEventWhenOnCompleteErrorRuleIsTriggeredBecauseTeaHasNoValue()
+      throws IOException {
+    ImportReport report =
+        trackerImportService.importTracker(
+            new TrackerImportParams(),
+            testSetup.fromJson("tracker/programrule/te_enrollment.json"));
+    assertNoErrors(report);
+
+    onCompleteErrorProgramRuleWhenTeaHasNoValue();
+    report =
+        trackerImportService.importTracker(
+            new TrackerImportParams(),
+            testSetup.fromJson("tracker/programrule/completed_event.json"));
+
+    assertHasOnlyErrors(report, E1300);
+  }
+
+  @Test
   void shouldImportWithNoWarningsWhenDataElementHasNoValue() throws IOException {
     showErrorWhenVariableHasValueRule();
     TrackerObjects trackerObjects =
@@ -579,6 +632,17 @@ class ProgramRuleTest extends PostgresIntegrationTestBase {
     programRuleService.addProgramRule(programRule);
     ProgramRuleAction programRuleAction =
         createProgramRuleAction(programRule, SHOWERROR, null, null);
+    programRuleActionService.addProgramRuleAction(programRuleAction);
+    programRule.getProgramRuleActions().add(programRuleAction);
+    programRuleService.updateProgramRule(programRule);
+  }
+
+  private void onCompleteErrorProgramRuleWhenTeaHasNoValue() {
+    ProgramRule programRule =
+        createProgramRule('O', program, null, "!d2:hasValue(#{ProgramRuleVariableB})");
+    programRuleService.addProgramRule(programRule);
+    ProgramRuleAction programRuleAction =
+        createProgramRuleAction(programRule, ProgramRuleActionType.ERRORONCOMPLETE, null, null);
     programRuleActionService.addProgramRuleAction(programRuleAction);
     programRule.getProgramRuleActions().add(programRuleAction);
     programRuleService.updateProgramRule(programRule);

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/te_with_attribute_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/te_with_attribute_enrollment.json
@@ -1,0 +1,92 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [
+    {
+      "trackedEntity": "IOR1AXXl24H",
+      "trackedEntityType": {
+        "idScheme": "UID",
+        "identifier": "ja8NY4PW7Xm"
+      },
+      "createdAtClient": "2020-02-20T10:09:21.844",
+      "updatedAtClient": "2020-02-20T11:09:21.844",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [
+        {
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "dIVt4l5vIOa"
+          },
+          "storedBy": "admin",
+          "value": "Tom"
+        }
+      ],
+      "enrollments": []
+    }
+  ],
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "createdAtClient": "2018-01-25T13:48:13.363",
+      "updatedAtClient": "2018-01-25T17:48:13.363",
+      "trackedEntity": "IOR1AXXl24H",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "BFcipDERJnf"
+      },
+      "status": "ACTIVE",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2019-03-28T12:05:00.000",
+      "occurredAt": "2019-03-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": []
+    }
+  ],
+  "events": [],
+  "relationships": [],
+  "username": "system-process"
+}


### PR DESCRIPTION
## Summary

Program rules referencing tracked entity attributes (TEAs) evaluated them as
null when the import payload contained only events — the payload the Capture
app sends when completing an event. This caused ERROR_ON_COMPLETE and
assign-when-empty rules to fire incorrectly, blocking event completion
(regression from 2.40, introduced with the new rule engine integration).

## Cause

Tracked entities are only preheated when referenced by the payload. Event-only
payloads reference no tracked entity, so `getAttributes` found nothing in the
preheat and built the `RuleEnrollment` with an empty attribute list.

## Fix

When the tracked entity is not in the preheat, fall back to the tracked entity
of the preheated saved enrollment, which already carries its attribute values.
Attribute loading is still skipped when rules don't reference TEAs.

## Tests

Integration tests covering: TEA value visible to rules on event-only import,
completed event passing an on-complete rule when the TEA has a value, and the
inverse control (rule still fires when the TEA is empty).

Jira: https://dhis2.atlassian.net/browse/DHIS2-21961


Obviously AI-assisted