### PR TITLE
fix: port optionset preheat N+1 fix to 2.42 (#24850)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/DefaultTrackerBundleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,13 +37,18 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.Session;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.UserInfoSnapshot;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.ParamsConverter;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
@@ -51,13 +56,20 @@ import org.hisp.dhis.tracker.imports.bundle.persister.CommitService;
 import org.hisp.dhis.tracker.imports.bundle.persister.PersistenceException;
 import org.hisp.dhis.tracker.imports.bundle.persister.TrackerObjectDeletionService;
 import org.hisp.dhis.tracker.imports.bundle.persister.TrackerPersister;
+import org.hisp.dhis.tracker.imports.domain.Attribute;
+import org.hisp.dhis.tracker.imports.domain.DataValue;
+import org.hisp.dhis.tracker.imports.domain.Enrollment;
+import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.job.TrackerNotificationDataBundle;
 import org.hisp.dhis.tracker.imports.notification.NotificationHandlerService;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheatService;
+import org.hisp.dhis.tracker.imports.preheat.supplier.OptionValueSupplier;
 import org.hisp.dhis.tracker.imports.programrule.ProgramRuleService;
+import org.hisp.dhis.tracker.imports.programrule.executor.enrollment.AssignAttributeExecutor;
+import org.hisp.dhis.tracker.imports.programrule.executor.event.AssignDataValueExecutor;
 import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.user.UserDetails;
@@ -83,6 +95,8 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
   private final ProgramRuleService programRuleService;
 
   private final TrackerObjectDeletionService deletionService;
+
+  private final OptionValueSupplier optionValueSupplier;
 
   private final ObjectMapper mapper;
 
@@ -111,7 +125,90 @@ public class DefaultTrackerBundleService implements TrackerBundleService {
   public TrackerBundle runRuleEngine(@Nonnull TrackerBundle trackerBundle) {
     programRuleService.calculateRuleEffects(trackerBundle, trackerBundle.getPreheat());
 
+    optionValueSupplier.preheatAdd(
+        collectRuleAssignedValues(trackerBundle), trackerBundle.getPreheat());
+
     return trackerBundle;
+  }
+
+  /**
+   * Collects the values {@code ASSIGN} rule actions are going to apply, shaped as a synthetic
+   * {@link TrackerObjects} payload the {@link OptionValueSupplier} can resolve option codes from.
+   *
+   * <p>Rule engine validation rejects unknown option codes based on {@link
+   * TrackerPreheat#isValidOptionCode(Long, String)}, but {@code ASSIGN} actions can add or
+   * overwrite data values and attributes that were not in the original payload, so the codes they
+   * introduce were never resolved during preheat and valid data would be rejected with E1125.
+   *
+   * <p>The values are already final here: they are the rule engine's evaluated output, captured in
+   * the executors {@code calculateRuleEffects} just built, so nothing evaluated later can change
+   * them.
+   *
+   * <p>All assigned values are gathered onto a single synthetic event and enrollment. The supplier
+   * only looks at (data element, value) and (attribute, value) pairs, so which or how many real
+   * entities the values belong to does not matter.
+   */
+  private TrackerObjects collectRuleAssignedValues(TrackerBundle bundle) {
+    TrackerPreheat preheat = bundle.getPreheat();
+
+    Set<DataValue> assignedDataValues =
+        bundle.getEventRuleActionExecutors().values().stream()
+            .flatMap(List::stream)
+            .filter(AssignDataValueExecutor.class::isInstance)
+            .map(AssignDataValueExecutor.class::cast)
+            .map(executor -> toDataValue(preheat, executor))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    List<Attribute> assignedAttributes =
+        bundle.getEnrollmentRuleActionExecutors().values().stream()
+            .flatMap(List::stream)
+            .filter(AssignAttributeExecutor.class::isInstance)
+            .map(AssignAttributeExecutor.class::cast)
+            .map(executor -> toAttribute(preheat, executor))
+            .filter(Objects::nonNull)
+            .toList();
+
+    return TrackerObjects.builder()
+        .events(
+            List.of(Event.builder().event(UID.generate()).dataValues(assignedDataValues).build()))
+        .enrollments(
+            List.of(
+                Enrollment.builder()
+                    .enrollment(UID.generate())
+                    .attributes(assignedAttributes)
+                    .build()))
+        .build();
+  }
+
+  /**
+   * Executors only know the target's UID, while the supplier looks metadata up by the payload's id
+   * scheme, so the identifier has to be converted the same way the executors themselves do when
+   * they apply the value.
+   */
+  private DataValue toDataValue(TrackerPreheat preheat, AssignDataValueExecutor executor) {
+    DataElement dataElement = preheat.getDataElement(executor.getDataElementUid().getValue());
+    if (dataElement == null) {
+      return null;
+    }
+
+    return DataValue.builder()
+        .dataElement(preheat.getIdSchemes().toMetadataIdentifier(dataElement))
+        .value(executor.getValue())
+        .build();
+  }
+
+  private Attribute toAttribute(TrackerPreheat preheat, AssignAttributeExecutor executor) {
+    TrackedEntityAttribute attribute =
+        preheat.getTrackedEntityAttribute(executor.getAttributeUid().getValue());
+    if (attribute == null) {
+      return null;
+    }
+
+    return Attribute.builder()
+        .attribute(preheat.getIdSchemes().toMetadataIdentifier(attribute))
+        .value(executor.getValue())
+        .build();
   }
 
   @Nonnull

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/config/TrackerPreheatConfig.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/config/TrackerPreheatConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,7 @@ import org.hisp.dhis.tracker.imports.preheat.supplier.EventCategoryOptionComboSu
 import org.hisp.dhis.tracker.imports.preheat.supplier.EventProgramEnrollmentSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.EventProgramStageMapSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.FileResourceSupplier;
+import org.hisp.dhis.tracker.imports.preheat.supplier.OptionValueSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.OrgUnitValueTypeSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.PreheatStrategyScanner;
 import org.hisp.dhis.tracker.imports.preheat.supplier.PreheatSupplier;
@@ -57,6 +58,7 @@ public class TrackerPreheatConfig {
   private final List<Class<? extends PreheatSupplier>> preheatOrder =
       List.of(
           ClassBasedSupplier.class,
+          OptionValueSupplier.class,
           DefaultsSupplier.class,
           TrackedEntityEnrollmentSupplier.class,
           EventProgramEnrollmentSupplier.class,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -135,6 +135,42 @@ public class TrackerPreheat {
   private Pair<String, Set<MetadataIdentifier>> toCategoryOptionComboCacheKey(
       CategoryCombo categoryCombo, Set<MetadataIdentifier> categoryOptions) {
     return Pair.of(categoryCombo.getUid(), categoryOptions);
+  }
+
+  /**
+   * Set of (option set id, option code) pairs confirmed to exist, populated by {@code
+   * OptionValueSupplier}. Only pairs actually referenced by the import payload are present here —
+   * this is not the full set of options for any given option set.
+   *
+   * <p>Preheated {@link org.hisp.dhis.option.OptionSet} instances deliberately carry no populated
+   * {@code options} collection (see {@code OptionSetMapper} for why). {@link
+   * #isValidOptionCode(Long, String)} and {@link #addValidOptionCode(Long, String)} are the
+   * supported way to check option code validity against preheated data. Do not call {@code
+   * OptionSet#getOptions()} on a preheated option set expecting real data — it is always empty.
+   */
+  private final Set<Pair<Long, String>> validOptionCodes = new HashSet<>();
+
+  /**
+   * Option sets {@code OptionValueSupplier} attempted to resolve. Lets callers tell "this code was
+   * checked against the database and does not exist" apart from "this option set was never resolved
+   * at all", which would be an internal bug rather than user error.
+   */
+  private final Set<Long> resolvedOptionSets = new HashSet<>();
+
+  public void addValidOptionCode(Long optionSetId, String code) {
+    this.validOptionCodes.add(Pair.of(optionSetId, code));
+  }
+
+  public boolean isValidOptionCode(Long optionSetId, String code) {
+    return this.validOptionCodes.contains(Pair.of(optionSetId, code));
+  }
+
+  public void addResolvedOptionSet(Long optionSetId) {
+    this.resolvedOptionSets.add(optionSetId);
+  }
+
+  public boolean isOptionSetResolved(Long optionSetId) {
+    return this.resolvedOptionSets.contains(optionSetId);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/OptionSetMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/OptionSetMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,15 +29,19 @@
  */
 package org.hisp.dhis.tracker.imports.preheat.mappers;
 
-import java.util.List;
-import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
+/**
+ * {@code options} is deliberately left unmapped — mapping it would force Hibernate to fully
+ * materialize the {@code OptionSet.options} collection (including JSONB attribute values) on every
+ * preheat, regardless of how many option codes the import actually references. {@link
+ * org.hisp.dhis.tracker.imports.preheat.supplier.OptionValueSupplier} preheats only the specific
+ * {@code (option set, code)} pairs the payload references instead.
+ */
 @Mapper(uses = DebugMapper.class)
 public interface OptionSetMapper extends PreheatMapper<OptionSet> {
   OptionSetMapper INSTANCE = Mappers.getMapper(OptionSetMapper.class);
@@ -47,9 +51,5 @@ public interface OptionSetMapper extends PreheatMapper<OptionSet> {
   @Mapping(target = "uid")
   @Mapping(target = "name")
   @Mapping(target = "code")
-  @Mapping(target = "options", qualifiedByName = "options")
   OptionSet map(OptionSet optionSet);
-
-  @Named("options")
-  List<Option> mapOptionValues(List<Option> options);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/OptionValueSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/OptionValueSupplier.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.preheat.supplier;
+
+import com.google.common.collect.Lists;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
+import org.hisp.dhis.tracker.imports.domain.Attribute;
+import org.hisp.dhis.tracker.imports.domain.DataValue;
+import org.hisp.dhis.tracker.imports.domain.Enrollment;
+import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.imports.util.Constant;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Preheats the specific {@code (option set, code)} pairs referenced by the import payload, instead
+ * of letting {@code OptionSetMapper} fully materialize every {@link
+ * org.hisp.dhis.option.OptionSet#getOptions()} collection. Cost is bounded by how many distinct
+ * option codes the payload actually references, not by option set size.
+ *
+ * @see org.hisp.dhis.tracker.imports.preheat.TrackerPreheat#isValidOptionCode(Long, String)
+ */
+@Component
+public class OptionValueSupplier extends JdbcAbstractPreheatSupplier {
+  private static final String OPTION_SET_ID = "optionsetid";
+
+  private static final String CODE = "code";
+
+  // Parallel-array unnest join: each optionsetid/code pair is matched positionally, so the two
+  // arrays are built directly from the (deduplicated) candidate list, not from independently
+  // deduplicated per-column sets. This gives an exact pair match sargable via
+  // optionvalue_unique_optionsetid_and_code, instead of the IN (...) AND IN (...) cross-product
+  // that the query planner can fall back to filtering in memory once cardinality grows.
+  private static final String SQL =
+      "select o.optionsetid, o.code"
+          + " from optionvalue o"
+          + " join unnest(?::bigint[], ?::text[]) as t(optionsetid, code)"
+          + "   on o.optionsetid = t.optionsetid and o.code = t.code";
+
+  protected OptionValueSupplier(JdbcTemplate jdbcTemplate) {
+    super(jdbcTemplate);
+  }
+
+  @Override
+  public void preheatAdd(TrackerObjects trackerObjects, TrackerPreheat preheat) {
+    Set<Pair<Long, String>> candidates = collectCandidates(trackerObjects, preheat);
+
+    if (candidates.isEmpty()) {
+      return;
+    }
+
+    for (List<Pair<Long, String>> chunk :
+        Lists.partition(new ArrayList<>(candidates), Constant.SPLIT_LIST_PARTITION_SIZE)) {
+      queryChunk(chunk, preheat);
+    }
+  }
+
+  Set<Pair<Long, String>> collectCandidates(TrackerObjects trackerObjects, TrackerPreheat preheat) {
+    Set<Pair<Long, String>> candidates = new HashSet<>();
+
+    for (TrackedEntity trackedEntity : trackerObjects.getTrackedEntities()) {
+      for (Attribute attribute : trackedEntity.getAttributes()) {
+        addCandidates(
+            preheat.getTrackedEntityAttribute(attribute.getAttribute()),
+            attribute.getValue(),
+            candidates,
+            preheat);
+      }
+    }
+
+    for (Enrollment enrollment : trackerObjects.getEnrollments()) {
+      for (Attribute attribute : enrollment.getAttributes()) {
+        addCandidates(
+            preheat.getTrackedEntityAttribute(attribute.getAttribute()),
+            attribute.getValue(),
+            candidates,
+            preheat);
+      }
+    }
+
+    for (Event event : trackerObjects.getEvents()) {
+      for (DataValue dataValue : event.getDataValues()) {
+        addCandidates(
+            preheat.getDataElement(dataValue.getDataElement()),
+            dataValue.getValue(),
+            candidates,
+            preheat);
+      }
+    }
+
+    return candidates;
+  }
+
+  private void addCandidates(
+      ValueTypedDimensionalItemObject optionalObject,
+      String value,
+      Set<Pair<Long, String>> candidates,
+      TrackerPreheat preheat) {
+    if (optionalObject == null || value == null || !optionalObject.hasOptionSet()) {
+      return;
+    }
+
+    Long optionSetId = optionalObject.getOptionSet().getId();
+    preheat.addResolvedOptionSet(optionSetId);
+
+    List<String> codes =
+        optionalObject.getValueType().isMultiText()
+            ? ValueType.splitMultiText(value)
+            : List.of(value);
+
+    for (String code : codes) {
+      candidates.add(Pair.of(optionSetId, code));
+    }
+  }
+
+  private void queryChunk(List<Pair<Long, String>> chunk, TrackerPreheat preheat) {
+    Long[] optionSetIds = new Long[chunk.size()];
+    String[] codes = new String[chunk.size()];
+    for (int i = 0; i < chunk.size(); i++) {
+      optionSetIds[i] = chunk.get(i).getLeft();
+      codes[i] = chunk.get(i).getRight();
+    }
+
+    Set<Pair<Long, String>> confirmed = new HashSet<>();
+    jdbcTemplate
+        .getJdbcOperations()
+        .execute(
+            (ConnectionCallback<Void>)
+                connection -> {
+                  try (PreparedStatement ps = connection.prepareStatement(SQL)) {
+                    ps.setArray(1, connection.createArrayOf("bigint", optionSetIds));
+                    ps.setArray(2, connection.createArrayOf("text", codes));
+                    try (ResultSet rs = ps.executeQuery()) {
+                      while (rs.next()) {
+                        confirmed.add(Pair.of(rs.getLong(OPTION_SET_ID), rs.getString(CODE)));
+                      }
+                    }
+                  }
+                  return null;
+                });
+
+    for (Pair<Long, String> pair : chunk) { // NOSONAR confirmed comes from the query in between
+      if (confirmed.contains(pair)) {
+        preheat.addValidOptionCode(pair.getLeft(), pair.getRight());
+      }
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/executor/enrollment/AssignAttributeExecutor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/executor/enrollment/AssignAttributeExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,6 +63,20 @@ public class AssignAttributeExecutor implements RuleActionExecutor<Enrollment> {
   private final UID attributeUid;
 
   private final List<Attribute> attributes;
+
+  /** The tracked entity attribute this action assigns to. */
+  public UID getAttributeUid() {
+    return attributeUid;
+  }
+
+  /**
+   * The value this action will assign. It is the rule engine's already evaluated output, so it is
+   * final and known as soon as the rule effects have been calculated, before {@link
+   * #executeRuleAction(TrackerBundle, Enrollment)} runs.
+   */
+  public String getValue() {
+    return value;
+  }
 
   @Override
   public Optional<ProgramRuleIssue> executeRuleAction(TrackerBundle bundle, Enrollment enrollment) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/executor/event/AssignDataValueExecutor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/executor/event/AssignDataValueExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -66,6 +66,15 @@ public class AssignDataValueExecutor implements RuleActionExecutor<Event> {
   @Override
   public UID getDataElementUid() {
     return dataElementUid;
+  }
+
+  /**
+   * The value this action will assign. It is the rule engine's already evaluated output, so it is
+   * final and known as soon as the rule effects have been calculated, before {@link
+   * #executeRuleAction(TrackerBundle, Event)} runs.
+   */
+  public String getValue() {
+    return value;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
@@ -51,7 +52,6 @@ import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.fileresource.FileResource;
-import org.hisp.dhis.option.Option;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ValidationStrategy;
@@ -76,6 +76,7 @@ import org.locationtech.jts.geom.Geometry;
 /**
  * @author Luciano Fiandesio
  */
+@Slf4j
 public class ValidationUtils {
   private ValidationUtils() {
     throw new IllegalStateException("Utility class");
@@ -230,22 +231,33 @@ public class ValidationUtils {
   }
 
   public static <T extends ValueTypedDimensionalItemObject> void validateOptionSet(
-      Reporter reporter, TrackerDto dto, T optionalObject, @Nonnull String value) {
+      Reporter reporter,
+      TrackerPreheat preheat,
+      TrackerDto dto,
+      T optionalObject,
+      @Nonnull String value) {
     if (!optionalObject.hasOptionSet()) {
       return;
     }
-
-    Set<String> validCodes =
-        optionalObject.getOptionSet().getOptions().stream()
-            .map(Option::getCode)
-            .collect(Collectors.toSet());
 
     List<String> codes =
         optionalObject.getValueType().isMultiText()
             ? ValueType.splitMultiText(value)
             : List.of(value);
 
-    if (!validCodes.containsAll(codes)) {
+    Long optionSetId = optionalObject.getOptionSet().getId();
+    boolean allCodesValid =
+        codes.stream().allMatch(code -> preheat.isValidOptionCode(optionSetId, code));
+
+    if (!allCodesValid) {
+      if (!preheat.isOptionSetResolved(optionSetId)) {
+        // Diagnostic only, the validation outcome below is unchanged. An unresolved option set
+        // means the supplier never checked it, which is an internal bug rather than user error.
+        log.warn(
+            "Option set {} was never resolved during preheat; treating code {} as invalid",
+            optionalObject.getOptionSet().getUid(),
+            value);
+      }
       reporter.addError(dto, ValidationCode.E1125, value, optionalObject.getOptionSet().getUid());
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -100,7 +100,7 @@ class AttributeValidator
         attributeValueMap.put(attribute.getAttribute(), attribute.getValue());
         validateAttributeValue(reporter, enrollment, teAttribute, attribute.getValue());
         validateValueType(reporter, bundle, enrollment, attribute.getValue(), teAttribute);
-        validateOptionSet(reporter, enrollment, teAttribute, attribute.getValue());
+        validateOptionSet(reporter, preheat, enrollment, teAttribute, attribute.getValue());
 
         validateAttributeUniqueness(
             reporter, preheat, enrollment, attribute.getValue(), teAttribute, te, orgUnit);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -112,7 +112,7 @@ class DataValuesValidator implements Validator<Event> {
     }
 
     if (dataElement.hasOptionSet()) {
-      validateOptionSet(reporter, event, dataElement, dataValue.getValue());
+      validateOptionSet(reporter, bundle.getPreheat(), event, dataElement, dataValue.getValue());
     }
     validateValueType(reporter, bundle, event, dataValue.getValue(), dataElement);
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -133,7 +133,7 @@ class AttributeValidator
 
       validateAttributeValue(reporter, trackedEntity, tea, attribute.getValue());
       validateValueType(reporter, bundle, trackedEntity, attribute.getValue(), tea);
-      validateOptionSet(reporter, trackedEntity, tea, attribute.getValue());
+      validateOptionSet(reporter, preheat, trackedEntity, tea, attribute.getValue());
 
       validateAttributeUniqueness(
           reporter, preheat, trackedEntity, attribute.getValue(), tea, te, orgUnit);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -83,6 +83,35 @@ class TrackerPreheatTest extends TestBase {
   void testAllEmpty() {
     assertTrue(preheat.isEmpty());
     assertTrue(preheat.getAll(Program.class).isEmpty());
+  }
+
+  @Test
+  void shouldReturnFalseForUnknownOptionCode() {
+    assertFalse(preheat.isValidOptionCode(1L, "CODE"));
+  }
+
+  @Test
+  void shouldReturnTrueOnlyForTheExactOptionSetAndCodePairAdded() {
+    preheat.addValidOptionCode(1L, "CODE");
+
+    assertTrue(preheat.isValidOptionCode(1L, "CODE"));
+    assertFalse(preheat.isValidOptionCode(1L, "OTHER"));
+    assertFalse(preheat.isValidOptionCode(2L, "CODE"));
+  }
+
+  @Test
+  void shouldReturnFalseForOptionSetThatWasNeverResolved() {
+    assertFalse(preheat.isOptionSetResolved(1L));
+  }
+
+  @Test
+  void shouldTrackResolvedOptionSetsIndependentlyOfCodeValidity() {
+    preheat.addResolvedOptionSet(1L);
+
+    assertTrue(preheat.isOptionSetResolved(1L));
+    assertFalse(preheat.isOptionSetResolved(2L));
+    // resolving an option set says nothing about which of its codes are valid
+    assertFalse(preheat.isValidOptionCode(1L, "CODE"));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/OptionValueSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/OptionValueSupplierTest.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.preheat.supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.tracker.TrackerIdSchemeParam;
+import org.hisp.dhis.tracker.imports.domain.Attribute;
+import org.hisp.dhis.tracker.imports.domain.DataValue;
+import org.hisp.dhis.tracker.imports.domain.Enrollment;
+import org.hisp.dhis.tracker.imports.domain.Event;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class OptionValueSupplierTest {
+
+  private JdbcTemplate jdbcTemplate;
+
+  private OptionValueSupplier supplier;
+
+  private OptionSet optionSet;
+
+  private DataElement dataElement;
+
+  private TrackedEntityAttribute trackedEntityAttribute;
+
+  @BeforeEach
+  void setUp() {
+    jdbcTemplate = mock(JdbcTemplate.class);
+    supplier = new OptionValueSupplier(jdbcTemplate);
+
+    optionSet = new OptionSet();
+    optionSet.setId(1L);
+
+    dataElement = new DataElement();
+    dataElement.setUid("dataElement");
+    dataElement.setValueType(ValueType.TEXT);
+    dataElement.setOptionSet(optionSet);
+
+    trackedEntityAttribute = new TrackedEntityAttribute();
+    trackedEntityAttribute.setUid("attribute");
+    trackedEntityAttribute.setValueType(ValueType.MULTI_TEXT);
+    trackedEntityAttribute.setOptionSet(optionSet);
+  }
+
+  @Test
+  void shouldCollectCandidateFromEventDataValue() {
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(dataElement);
+
+    DataValue dataValue =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("dataElement"))
+            .value("A00")
+            .build();
+    Event event = Event.builder().event(UID.generate()).dataValues(Set.of(dataValue)).build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    Set<Pair<Long, String>> candidates = supplier.collectCandidates(trackerObjects, preheat);
+
+    assertEquals(Set.of(Pair.of(1L, "A00")), candidates);
+  }
+
+  @Test
+  void shouldSplitMultiTextValuesFromTrackedEntityAndEnrollmentAttributes() {
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(TrackerIdSchemeParam.UID, trackedEntityAttribute);
+
+    Attribute attribute =
+        Attribute.builder()
+            .attribute(MetadataIdentifier.ofUid("attribute"))
+            .value("A00,B99")
+            .build();
+    TrackedEntity trackedEntity =
+        TrackedEntity.builder()
+            .trackedEntity(UID.generate())
+            .attributes(List.of(attribute))
+            .build();
+    Enrollment enrollment =
+        Enrollment.builder().enrollment(UID.generate()).attributes(List.of(attribute)).build();
+    TrackerObjects trackerObjects =
+        TrackerObjects.builder()
+            .trackedEntities(List.of(trackedEntity))
+            .enrollments(List.of(enrollment))
+            .build();
+
+    Set<Pair<Long, String>> candidates = supplier.collectCandidates(trackerObjects, preheat);
+
+    assertEquals(Set.of(Pair.of(1L, "A00"), Pair.of(1L, "B99")), candidates);
+  }
+
+  @Test
+  void shouldSkipValuesWithoutAnOptionSet() {
+    DataElement plainDataElement = new DataElement();
+    plainDataElement.setUid("plain");
+    plainDataElement.setValueType(ValueType.TEXT);
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(plainDataElement);
+
+    DataValue dataValue =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("plain"))
+            .value("anything")
+            .build();
+    Event event = Event.builder().event(UID.generate()).dataValues(Set.of(dataValue)).build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    Set<Pair<Long, String>> candidates = supplier.collectCandidates(trackerObjects, preheat);
+
+    assertEquals(Set.of(), candidates);
+  }
+
+  @Test
+  void shouldSkipValuesWhoseDataElementIsNotPreheated() {
+    TrackerPreheat preheat = new TrackerPreheat();
+
+    DataValue dataValue =
+        DataValue.builder().dataElement(MetadataIdentifier.ofUid("unknown")).value("A00").build();
+    Event event = Event.builder().event(UID.generate()).dataValues(Set.of(dataValue)).build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    Set<Pair<Long, String>> candidates = supplier.collectCandidates(trackerObjects, preheat);
+
+    assertEquals(Set.of(), candidates);
+  }
+
+  @Test
+  void shouldNotQueryTheDatabaseWhenNoValueReferencesAnOptionSet() {
+    DataElement plainDataElement = new DataElement();
+    plainDataElement.setUid("plain");
+    plainDataElement.setValueType(ValueType.TEXT);
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(plainDataElement);
+
+    DataValue dataValue =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("plain"))
+            .value("anything")
+            .build();
+    Event event = Event.builder().event(UID.generate()).dataValues(Set.of(dataValue)).build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    supplier.preheatAdd(trackerObjects, preheat);
+
+    verifyNoInteractions(jdbcTemplate);
+  }
+
+  @Test
+  void shouldMarkOptionSetAsResolvedEvenWhenNoCodeTurnsOutToBeValid() {
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(dataElement);
+
+    DataValue dataValue =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("dataElement"))
+            .value("A00")
+            .build();
+    Event event = Event.builder().event(UID.generate()).dataValues(Set.of(dataValue)).build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    supplier.collectCandidates(trackerObjects, preheat);
+
+    assertTrue(preheat.isOptionSetResolved(1L));
+    // no code was confirmed against the database, the option set is still "resolved"
+    assertFalse(preheat.isValidOptionCode(1L, "A00"));
+  }
+
+  @Test
+  void shouldNotMarkAnOptionSetAsResolvedWhenNoValueReferencesOne() {
+    DataElement plainDataElement = new DataElement();
+    plainDataElement.setUid("plain");
+    plainDataElement.setValueType(ValueType.TEXT);
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(plainDataElement);
+
+    DataValue dataValue =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("plain"))
+            .value("anything")
+            .build();
+    Event event = Event.builder().event(UID.generate()).dataValues(Set.of(dataValue)).build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    supplier.collectCandidates(trackerObjects, preheat);
+
+    assertFalse(preheat.isOptionSetResolved(1L));
+  }
+
+  @Test
+  void shouldNotValidateAFabricatedCrossOptionSetPairEvenWhenBothHalvesExistSeparately()
+      throws SQLException {
+    OptionSet optionSetA = new OptionSet();
+    optionSetA.setId(1L);
+    OptionSet optionSetB = new OptionSet();
+    optionSetB.setId(2L);
+    OptionSet optionSetC = new OptionSet();
+    optionSetC.setId(3L);
+
+    DataElement dataElementA = new DataElement();
+    dataElementA.setUid("dataElementA");
+    dataElementA.setValueType(ValueType.TEXT);
+    dataElementA.setOptionSet(optionSetA);
+
+    DataElement dataElementB = new DataElement();
+    dataElementB.setUid("dataElementB");
+    dataElementB.setValueType(ValueType.TEXT);
+    dataElementB.setOptionSet(optionSetB);
+
+    DataElement dataElementC = new DataElement();
+    dataElementC.setUid("dataElementC");
+    dataElementC.setValueType(ValueType.TEXT);
+    dataElementC.setOptionSet(optionSetC);
+
+    TrackerPreheat preheat = new TrackerPreheat();
+    preheat.put(dataElementA);
+    preheat.put(dataElementB);
+    preheat.put(dataElementC);
+
+    // The payload asks about (1,"A00") and (2,"B00") - neither actually exists - and (3,"C00"),
+    // which does.
+    DataValue dataValueA =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("dataElementA"))
+            .value("A00")
+            .build();
+    DataValue dataValueB =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("dataElementB"))
+            .value("B00")
+            .build();
+    DataValue dataValueC =
+        DataValue.builder()
+            .dataElement(MetadataIdentifier.ofUid("dataElementC"))
+            .value("C00")
+            .build();
+    Event event =
+        Event.builder()
+            .event(UID.generate())
+            .dataValues(Set.of(dataValueA, dataValueB, dataValueC))
+            .build();
+    TrackerObjects trackerObjects = TrackerObjects.builder().events(List.of(event)).build();
+
+    // The database actually contains (1,"B00"), (2,"A00") and (3,"C00"): every optionSetId and
+    // every code the query's two IN-lists ask for is present in some row, but the fabricated
+    // pairs (1,"A00") and (2,"B00") never co-occur on the same row.
+    mockQueryResult(Pair.of(1L, "B00"), Pair.of(2L, "A00"), Pair.of(3L, "C00"));
+
+    supplier.preheatAdd(trackerObjects, preheat);
+
+    assertFalse(
+        preheat.isValidOptionCode(1L, "A00"),
+        "fabricated cross-option-set pair must not be validated");
+    assertFalse(
+        preheat.isValidOptionCode(2L, "B00"),
+        "fabricated cross-option-set pair must not be validated");
+    assertTrue(preheat.isValidOptionCode(3L, "C00"), "a genuine pair must still be validated");
+  }
+
+  @SafeVarargs
+  @SuppressWarnings("unchecked")
+  private void mockQueryResult(Pair<Long, String>... rows) throws SQLException {
+    Connection connection = mock(Connection.class);
+    PreparedStatement ps = mock(PreparedStatement.class);
+    ResultSet rs = mock(ResultSet.class);
+    when(connection.prepareStatement(anyString())).thenReturn(ps);
+    when(connection.createArrayOf(anyString(), any())).thenReturn(mock(Array.class));
+    when(ps.executeQuery()).thenReturn(rs);
+
+    int[] index = {0};
+    when(rs.next()).thenAnswer(invocation -> index[0]++ < rows.length);
+    when(rs.getLong("optionsetid")).thenAnswer(invocation -> rows[index[0] - 1].getLeft());
+    when(rs.getString("code")).thenAnswer(invocation -> rows[index[0] - 1].getRight());
+
+    when(jdbcTemplate.execute(any(ConnectionCallback.class)))
+        .thenAnswer(
+            invocation ->
+                invocation.<ConnectionCallback<?>>getArgument(0).doInConnection(connection));
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/AttributeValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -51,6 +51,7 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.encryption.EncryptionStatus;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntity;
@@ -260,6 +261,62 @@ class AttributeValidatorTest {
                 .trackedEntity(enrollment.getTrackedEntity())
                 .attributes(List.of(attribute, attribute1))
                 .build()));
+
+    validator.validate(reporter, bundle, enrollment);
+
+    assertNoErrors(reporter);
+  }
+
+  @Test
+  void shouldFailValidationWhenAttributeValueIsNotValidOptionCode() {
+    OptionSet optionSet = new OptionSet();
+    optionSet.setId(1L);
+    trackedEntityAttribute.setOptionSet(optionSet);
+
+    Attribute attribute =
+        Attribute.builder()
+            .attribute(MetadataIdentifier.ofUid(TRACKED_ATTRIBUTE))
+            .value("wrongCode")
+            .build();
+
+    when(program.getProgramAttributes())
+        .thenReturn(
+            List.of(
+                new ProgramTrackedEntityAttribute(program, trackedEntityAttribute, false, false)));
+    when(enrollment.getAttributes()).thenReturn(Collections.singletonList(attribute));
+    when(trackedEntity.getTrackedEntityAttributeValues()).thenReturn(Set.of());
+    when(enrollment.getTrackedEntity()).thenReturn(UID.generate());
+    when(preheat.getTrackedEntity(enrollment.getTrackedEntity())).thenReturn(trackedEntity);
+    when(preheat.isValidOptionCode(1L, "wrongCode")).thenReturn(false);
+    bundle.setStrategy(enrollment, TrackerImportStrategy.CREATE);
+
+    validator.validate(reporter, bundle, enrollment);
+
+    assertHasError(reporter, enrollment, ValidationCode.E1125);
+  }
+
+  @Test
+  void shouldPassValidationWhenAttributeValueIsValidOptionCode() {
+    OptionSet optionSet = new OptionSet();
+    optionSet.setId(1L);
+    trackedEntityAttribute.setOptionSet(optionSet);
+
+    Attribute attribute =
+        Attribute.builder()
+            .attribute(MetadataIdentifier.ofUid(TRACKED_ATTRIBUTE))
+            .value("CODE")
+            .build();
+
+    when(program.getProgramAttributes())
+        .thenReturn(
+            List.of(
+                new ProgramTrackedEntityAttribute(program, trackedEntityAttribute, false, false)));
+    when(enrollment.getAttributes()).thenReturn(Collections.singletonList(attribute));
+    when(trackedEntity.getTrackedEntityAttributeValues()).thenReturn(Set.of());
+    when(enrollment.getTrackedEntity()).thenReturn(UID.generate());
+    when(preheat.getTrackedEntity(enrollment.getTrackedEntity())).thenReturn(trackedEntity);
+    when(preheat.isValidOptionCode(1L, "CODE")).thenReturn(true);
+    bundle.setStrategy(enrollment, TrackerImportStrategy.CREATE);
 
     validator.validate(reporter, bundle, enrollment);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,6 @@ import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidatio
 import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidations.assertNoErrors;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -45,7 +44,6 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.fileresource.FileResource;
-import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.ProgramStage;
@@ -855,16 +853,13 @@ class DataValuesValidatorTest {
     DataValue nullDataValue = dataValue(null);
 
     OptionSet optionSet = new OptionSet();
-    Option option = new Option();
-    option.setCode("CODE");
-    Option option1 = new Option();
-    option1.setCode("CODE1");
-    optionSet.setOptions(List.of(option, option1));
+    optionSet.setId(1L);
 
     DataElement dataElement = dataElement();
     dataElement.setOptionSet(optionSet);
     when(preheat.getDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID)))
         .thenReturn(dataElement);
+    when(preheat.isValidOptionCode(1L, "CODE")).thenReturn(true);
 
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
@@ -889,16 +884,13 @@ class DataValuesValidatorTest {
     validDataValue.setDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID));
 
     OptionSet optionSet = new OptionSet();
-    Option option = new Option();
-    option.setCode("CODE");
-    Option option1 = new Option();
-    option1.setCode("CODE1");
-    optionSet.setOptions(List.of(option, option1));
+    optionSet.setId(1L);
 
     DataElement dataElement = dataElement();
     dataElement.setOptionSet(optionSet);
     when(preheat.getDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID)))
         .thenReturn(dataElement);
+    when(preheat.isValidOptionCode(1L, "value")).thenReturn(false);
 
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
@@ -923,16 +915,14 @@ class DataValuesValidatorTest {
     DataValue nullDataValue = dataValue(null);
 
     OptionSet optionSet = new OptionSet();
-    Option option = new Option();
-    option.setCode("CODE");
-    Option option1 = new Option();
-    option1.setCode("CODE1");
-    optionSet.setOptions(List.of(option, option1));
+    optionSet.setId(1L);
 
     DataElement dataElement = dataElement(ValueType.MULTI_TEXT);
     dataElement.setOptionSet(optionSet);
     when(preheat.getDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID)))
         .thenReturn(dataElement);
+    when(preheat.isValidOptionCode(1L, "CODE")).thenReturn(true);
+    when(preheat.isValidOptionCode(1L, "CODE1")).thenReturn(true);
 
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
@@ -957,16 +947,14 @@ class DataValuesValidatorTest {
     validDataValue.setDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID));
 
     OptionSet optionSet = new OptionSet();
-    Option option = new Option();
-    option.setCode("CODE");
-    Option option1 = new Option();
-    option1.setCode("CODE1");
-    optionSet.setOptions(List.of(option, option1));
+    optionSet.setId(1L);
 
     DataElement dataElement = dataElement(ValueType.MULTI_TEXT);
     dataElement.setOptionSet(optionSet);
     when(preheat.getDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID)))
         .thenReturn(dataElement);
+    when(preheat.isValidOptionCode(1L, "CODE1")).thenReturn(true);
+    when(preheat.isValidOptionCode(1L, "CODE2")).thenReturn(false);
 
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/AttributeValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,6 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.encryption.EncryptionStatus;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.fileresource.FileResource;
-import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
@@ -96,7 +95,7 @@ class AttributeValidatorTest {
   private TrackerIdSchemeParams idSchemes;
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     bundle = TrackerBundle.builder().preheat(preheat).build();
     idSchemes = TrackerIdSchemeParams.builder().build();
     when(preheat.getIdSchemes()).thenReturn(idSchemes);
@@ -418,6 +417,7 @@ class AttributeValidatorTest {
         .thenReturn(trackedEntityAttribute);
     when(preheat.getTrackedEntityType((MetadataIdentifier) any()))
         .thenReturn(new TrackedEntityType());
+    when(preheat.isValidOptionCode(1L, "wrongCode")).thenReturn(false);
 
     TrackedEntity trackedEntity =
         TrackedEntity.builder()
@@ -444,6 +444,7 @@ class AttributeValidatorTest {
         .thenReturn(trackedEntityAttribute);
     when(preheat.getTrackedEntityType((MetadataIdentifier) any()))
         .thenReturn(new TrackedEntityType());
+    when(preheat.isValidOptionCode(1L, "CODE")).thenReturn(true);
 
     TrackedEntity trackedEntity =
         TrackedEntity.builder()
@@ -470,6 +471,8 @@ class AttributeValidatorTest {
         .thenReturn(trackedEntityAttribute);
     when(preheat.getTrackedEntityType((MetadataIdentifier) any()))
         .thenReturn(new TrackedEntityType());
+    when(preheat.isValidOptionCode(2L, "CODE1")).thenReturn(true);
+    when(preheat.isValidOptionCode(2L, "CODE4")).thenReturn(false);
 
     TrackedEntity trackedEntity =
         TrackedEntity.builder()
@@ -496,6 +499,8 @@ class AttributeValidatorTest {
         .thenReturn(trackedEntityAttribute);
     when(preheat.getTrackedEntityType((MetadataIdentifier) any()))
         .thenReturn(new TrackedEntityType());
+    when(preheat.isValidOptionCode(2L, "CODE1")).thenReturn(true);
+    when(preheat.isValidOptionCode(2L, "CODE2")).thenReturn(true);
 
     TrackedEntity trackedEntity =
         TrackedEntity.builder()
@@ -650,13 +655,7 @@ class AttributeValidatorTest {
     trackedEntityAttribute.setValueType(ValueType.TEXT);
 
     OptionSet optionSet = new OptionSet();
-    Option option = new Option();
-    option.setCode("CODE");
-
-    Option option1 = new Option();
-    option1.setCode("CODE1");
-
-    optionSet.setOptions(Arrays.asList(option, option1));
+    optionSet.setId(1L);
 
     trackedEntityAttribute.setOptionSet(optionSet);
     return trackedEntityAttribute;
@@ -668,16 +667,7 @@ class AttributeValidatorTest {
     trackedEntityAttribute.setValueType(ValueType.MULTI_TEXT);
 
     OptionSet optionSet = new OptionSet();
-    Option option1 = new Option();
-    option1.setCode("CODE1");
-
-    Option option2 = new Option();
-    option2.setCode("CODE2");
-
-    Option option3 = new Option();
-    option3.setCode("CODE3");
-
-    optionSet.setOptions(Arrays.asList(option1, option2, option3));
+    optionSet.setId(2L);
 
     trackedEntityAttribute.setOptionSet(optionSet);
     return trackedEntityAttribute;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -304,6 +304,8 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     assertHasOnlyWarnings(importReport, E1308);
     if (!hasValidValue) {
       assertHasOnlyErrors(importReport, E1125);
+    } else {
+      assertNoErrors(importReport);
     }
   }
 


### PR DESCRIPTION
## Summary
- Ports master's optionset preheat N+1 fix (#24850) to 2.42: preheat only the `(option set, code)` pairs actually referenced by an import payload instead of fully materializing every touched `OptionSet.options` collection.
- 2.42 predates master's tracker/single-event domain split, so the cherry-picked code referencing `TrackerEvent` was adjusted to use 2.42's `Event` domain class instead. No other behavioral changes.

## Test plan
- [x] `dhis-service-tracker` compiles and test-compiles clean
- [x] `OptionValueSupplierTest` 8/8
- [x] `TrackerPreheatTest` 25/25
- [x] `AttributeValidatorTest` (enrollment) 43/43
- [x] `AttributeValidatorTest` (trackedentity) 16/16
- [x] `DataValuesValidatorTest` 46/46
- [x] `ProgramRuleAssignActionTest` (Postgres integration test) 13/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)