### PR TITLE
fix: avoid OptionSet.getOptions() N+1 in analytics metadata resolution [DHIS2-21975]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/MetadataDimensionsHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/MetadataDimensionsHandler.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.MetadataItem;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.option.Option;
+import org.hisp.dhis.option.OptionService;
 import org.hisp.dhis.period.PeriodType;
 
 /**
@@ -66,6 +67,12 @@ import org.hisp.dhis.period.PeriodType;
  * the risk of bugs.
  */
 public class MetadataDimensionsHandler {
+  private final OptionService optionService;
+
+  MetadataDimensionsHandler(OptionService optionService) {
+    this.optionService = optionService;
+  }
+
   /**
    * Handles all required logic/rules in order to return a map of metadata item identifiers.
    *
@@ -147,7 +154,11 @@ public class MetadataDimensionsHandler {
    */
   private void putQueryItemsIntoMap(
       Map<String, List<String>> dimensionItems, List<QueryItem> items, Grid grid) {
-    Map<String, List<Option>> optionsPresentInGrid = getItemOptions(grid, items);
+    Map<String, List<Option>> optionsPresentInGrid =
+        getItemOptions(
+            grid,
+            items,
+            optionSet -> optionService.findOptionsByNamePattern(optionSet.getUid(), null, null));
 
     for (QueryItem item : items) {
       String itemUid = getItemUid(item);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/MetadataItemsHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/MetadataItemsHandler.java
@@ -64,6 +64,7 @@ import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.legend.Legend;
 import org.hisp.dhis.option.Option;
+import org.hisp.dhis.option.OptionService;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodDimension;
@@ -83,6 +84,12 @@ import org.hisp.dhis.program.ProgramStage;
  * the risk of bugs.
  */
 public class MetadataItemsHandler {
+  private final OptionService optionService;
+
+  public MetadataItemsHandler(OptionService optionService) {
+    this.optionService = optionService;
+  }
+
   /**
    * Handles all required logic/rules in order to return a map of metadata item identifiers and its
    * respective {@link MetadataItem}.
@@ -103,7 +110,11 @@ public class MetadataItemsHandler {
         delegator.getItemsOptions().stream()
             .filter(o -> isInOriginalRequest(o.getUid(), commonRequestParams))
             .collect(toSet());
-    Map<String, List<Option>> optionsPresentInGrid = getItemOptions(grid, items);
+    Map<String, List<Option>> optionsPresentInGrid =
+        getItemOptions(
+            grid,
+            items,
+            optionSet -> optionService.findOptionsByNamePattern(optionSet.getUid(), null, null));
     Set<Option> optionItems = getOptionItems(grid, itemOptions, items, optionsPresentInGrid);
     List<DimensionalObject> allDimensionalObjects = delegator.getAllDimensionalObjects();
     List<DimensionItemKeywords.Keyword> periodKeywords = delegator.getPeriodKeywords();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/MetadataParamsHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/MetadataParamsHandler.java
@@ -65,6 +65,7 @@ import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.MetadataItem;
 import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.option.OptionService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
@@ -82,6 +83,12 @@ import org.springframework.stereotype.Component;
 public class MetadataParamsHandler {
   private static final String DOT = ".";
   private static final String ORG_UNIT_DIM = "ou";
+
+  private final OptionService optionService;
+
+  public MetadataParamsHandler(OptionService optionService) {
+    this.optionService = optionService;
+  }
 
   /**
    * Appends the metadata to the given {@link Grid} based on the given arguments.
@@ -103,7 +110,8 @@ public class MetadataParamsHandler {
       List<AnalyticsMetaDataKey> userOrgUnitMetaDataKeys =
           getUserOrgUnitsMetadataKeys(commonParsed);
       Map<String, Object> items =
-          new HashMap<>(new MetadataItemsHandler().handle(grid, commonParsed, commonRequest));
+          new HashMap<>(
+              new MetadataItemsHandler(optionService).handle(grid, commonParsed, commonRequest));
 
       commonParsed
           .getAllDimensionIdentifiers()
@@ -116,7 +124,8 @@ public class MetadataParamsHandler {
       metadataInfo.put(ITEMS.getKey(), items);
 
       metadataInfo.put(
-          DIMENSIONS.getKey(), new MetadataDimensionsHandler().handle(grid, commonParsed));
+          DIMENSIONS.getKey(),
+          new MetadataDimensionsHandler(optionService).handle(grid, commonParsed));
 
       // Org. Units.
       boolean hierarchyMeta = commonRequest.isHierarchyMeta();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/QueryItemHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/QueryItemHelper.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -174,18 +175,23 @@ public class QueryItemHelper {
    *
    * @param grid the {@link Grid}.
    * @param queryItems the list of {@link QueryItem}.
+   * @param optionsResolver resolves the {@link Option}s belonging to an {@link OptionSet}. Callers
+   *     backed by a real persistence context should supply a resolver that fetches the options
+   *     directly (e.g. via a service call), rather than {@link OptionSet#getOptions()}, since that
+   *     lazy collection can degrade into one query per option under a cold second-level cache.
    * @return a map of list of options.
    */
-  public static Map<String, List<Option>> getItemOptions(Grid grid, List<QueryItem> queryItems) {
+  public static Map<String, List<Option>> getItemOptions(
+      Grid grid, List<QueryItem> queryItems, Function<OptionSet, List<Option>> optionsResolver) {
     Map<String, List<Option>> options = new HashMap<>();
 
     for (int i = 0; i < grid.getHeaders().size(); ++i) {
       GridHeader gridHeader = grid.getHeaders().get(i);
 
       if (gridHeader.hasOptionSet() && isNotEmpty(grid.getRows())) {
-        options.put(gridHeader.getName(), getItemOptionsThatMatchesRows(grid, i));
+        options.put(gridHeader.getName(), getItemOptionsThatMatchesRows(grid, i, optionsResolver));
       } else if (gridHeader.hasOptionSet() && isEmpty(grid.getRows())) {
-        options.put(gridHeader.getName(), getItemOptionsForEmptyRows(queryItems));
+        options.put(gridHeader.getName(), getItemOptionsForEmptyRows(queryItems, optionsResolver));
       }
     }
 
@@ -255,18 +261,14 @@ public class QueryItemHelper {
    * @param queryItems the {@link EventQueryParams}.
    * @return the options for empty rows.
    */
-  private static List<Option> getItemOptionsForEmptyRows(List<QueryItem> queryItems) {
+  private static List<Option> getItemOptionsForEmptyRows(
+      List<QueryItem> queryItems, Function<OptionSet, List<Option>> optionsResolver) {
     List<Option> options = new ArrayList<>();
 
     if (isNotEmpty(queryItems)) {
-      List<QueryItem> items = queryItems;
-
-      for (QueryItem item : items) {
-        boolean hasOptions =
-            item.getOptionSet() != null && isNotEmpty(item.getOptionSet().getOptions());
-
-        if (hasOptions && isNotEmpty(item.getFilters())) {
-          options.addAll(getItemOptionsForFilter(item));
+      for (QueryItem item : queryItems) {
+        if (item.getOptionSet() != null && isNotEmpty(item.getFilters())) {
+          options.addAll(getItemOptionsForFilter(item, optionsResolver));
         }
       }
     }
@@ -281,9 +283,12 @@ public class QueryItemHelper {
    *
    * @param grid the {@link Grid}.
    * @param columnIndex the column index.
+   * @param optionsResolver resolves the {@link Option}s belonging to an {@link OptionSet} without
+   *     going through {@link OptionSet#getOptions()}.
    * @return a list of matching options.
    */
-  private static List<Option> getItemOptionsThatMatchesRows(Grid grid, int columnIndex) {
+  private static List<Option> getItemOptionsThatMatchesRows(
+      Grid grid, int columnIndex, Function<OptionSet, List<Option>> optionsResolver) {
     if (grid == null || grid.getHeaders() == null || columnIndex < 0) {
       return Collections.emptyList();
     }
@@ -292,15 +297,11 @@ public class QueryItemHelper {
     }
 
     GridHeader gridHeader = grid.getHeaders().get(columnIndex);
-    if (gridHeader == null
-        || gridHeader.getOptionSetObject() == null
-        || gridHeader.getOptionSetObject().getOptions() == null) {
+    if (gridHeader == null || gridHeader.getOptionSetObject() == null) {
       return Collections.emptyList();
     }
 
-    List<Option> allOptions = gridHeader.getOptionSetObject().getOptions();
-    // Check if there are no options to filter or no rows to check against
-    if (allOptions.isEmpty() || grid.getRows() == null || grid.getRows().isEmpty()) {
+    if (grid.getRows() == null || grid.getRows().isEmpty()) {
       return Collections.emptyList();
     }
 
@@ -315,8 +316,13 @@ public class QueryItemHelper {
             .collect(Collectors.toSet());
 
     // If there are no distinct, non-null values in the rows for this column, no option can possibly
-    // match.
+    // match, so there is no need to resolve any options at all.
     if (distinctRowCellValues.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<Option> allOptions = optionsResolver.apply(gridHeader.getOptionSetObject());
+    if (allOptions == null || allOptions.isEmpty()) {
       return Collections.emptyList();
     }
 
@@ -400,10 +406,16 @@ public class QueryItemHelper {
    * @param item the {@link QueryItem}.
    * @return a list of options found in the filter.
    */
-  private static List<Option> getItemOptionsForFilter(QueryItem item) {
+  private static List<Option> getItemOptionsForFilter(
+      QueryItem item, Function<OptionSet, List<Option>> optionsResolver) {
     List<Option> options = new ArrayList<>();
+    List<Option> resolvedOptions = optionsResolver.apply(item.getOptionSet());
 
-    for (Option option : item.getOptionSet().getOptions()) {
+    if (resolvedOptions == null) {
+      return options;
+    }
+
+    for (Option option : resolvedOptions) {
       for (QueryFilter filter : item.getFilters()) {
         List<String> filterSplit =
             Arrays.stream(trimToEmpty(filter.getFilter()).split(";")).collect(toList());

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tracker/MetadataItemsHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tracker/MetadataItemsHandler.java
@@ -91,6 +91,8 @@ import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.option.Option;
+import org.hisp.dhis.option.OptionService;
+import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodDimension;
 import org.hisp.dhis.period.PeriodType;
@@ -111,6 +113,8 @@ public class MetadataItemsHandler {
   private final OrganisationUnitResolver organisationUnitResolver;
 
   private final I18nManager i18nManager;
+
+  private final OptionService optionService;
 
   /**
    * Adds meta-data values to the given grid based on the given data query parameters.
@@ -187,7 +191,8 @@ public class MetadataItemsHandler {
    */
   private Set<Option> collectOptionItems(Grid grid, EventQueryParams params) {
     Set<Option> optionItems = new LinkedHashSet<>();
-    Map<String, List<Option>> optionsPresentInGrid = getItemOptions(grid, params.getItems());
+    Map<String, List<Option>> optionsPresentInGrid =
+        getItemOptions(grid, params.getItems(), this::resolveOptions);
 
     if (isNotEmpty(grid.getRows())) {
       optionItems.addAll(
@@ -208,10 +213,23 @@ public class MetadataItemsHandler {
    */
   private Map<String, List<String>> buildDimensionItems(Grid grid, EventQueryParams params) {
     if (params.isComingFromQuery()) {
-      Map<String, List<Option>> optionsPresentInGrid = getItemOptions(grid, params.getItems());
+      Map<String, List<Option>> optionsPresentInGrid =
+          getItemOptions(grid, params.getItems(), this::resolveOptions);
       return getDimensionItems(params, Optional.of(optionsPresentInGrid));
     }
     return getDimensionItems(params, empty());
+  }
+
+  /**
+   * Resolves the {@link Option}s belonging to the given {@link OptionSet} directly, instead of
+   * through {@link OptionSet#getOptions()} - that lazy collection can fall back to one query per
+   * option under a cold second-level cache.
+   *
+   * @param optionSet the {@link OptionSet}.
+   * @return the list of {@link Option}.
+   */
+  private List<Option> resolveOptions(OptionSet optionSet) {
+    return optionService.findOptionsByNamePattern(optionSet.getUid(), null, null);
   }
 
   /**
@@ -337,7 +355,7 @@ public class MetadataItemsHandler {
                     includeDetails ? option.getUid() : null,
                     option.getCode())));
 
-    new org.hisp.dhis.analytics.common.processing.MetadataItemsHandler()
+    new org.hisp.dhis.analytics.common.processing.MetadataItemsHandler(optionService)
         .addOptionsSetIntoMap(metadataItemMap, itemOptions);
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/GridAdaptorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/GridAdaptorTest.java
@@ -72,6 +72,7 @@ import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.option.OptionService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.test.TestBase;
@@ -96,6 +97,8 @@ class GridAdaptorTest extends TestBase {
 
   @Mock private I18n i18n;
 
+  @Mock private OptionService optionService;
+
   private GridAdaptor gridAdaptor;
 
   private HeaderParamsHandler headerParamsHandler;
@@ -107,7 +110,7 @@ class GridAdaptorTest extends TestBase {
   @BeforeEach
   void setUp() {
     headerParamsHandler = new HeaderParamsHandler();
-    metadataDetailsHandler = new MetadataParamsHandler();
+    metadataDetailsHandler = new MetadataParamsHandler(optionService);
     schemeIdResponseMapper = new SchemeIdResponseMapper(i18nManager);
     gridAdaptor =
         new GridAdaptor(headerParamsHandler, metadataDetailsHandler, schemeIdResponseMapper);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/processing/MetadataParamsHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/processing/MetadataParamsHandlerTest.java
@@ -51,6 +51,7 @@ import org.hisp.dhis.common.MetadataItem;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.option.OptionService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.system.grid.ListGrid;
@@ -59,16 +60,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class MetadataParamsHandlerTest {
 
+  @Mock private OptionService optionService;
+
   private MetadataParamsHandler metadataParamsHandler;
 
   @BeforeEach
   void setUp() {
-    metadataParamsHandler = new MetadataParamsHandler();
+    metadataParamsHandler = new MetadataParamsHandler(optionService);
   }
 
   @Nested

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryItemHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryItemHelperTest.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.analytics.data;
 
 import static org.hisp.dhis.common.QueryOperator.IN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
@@ -40,6 +41,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.QueryItemHelper;
 import org.hisp.dhis.common.CodeGenerator;
@@ -262,7 +264,8 @@ class QueryItemHelperTest extends TestBase {
     EventQueryParams params = new EventQueryParams.Builder().addItem(queryItem).build();
     params.getItems().add(queryItem);
 
-    Map<String, List<Option>> options = QueryItemHelper.getItemOptions(grid, params.getItems());
+    Map<String, List<Option>> options =
+        QueryItemHelper.getItemOptions(grid, params.getItems(), OptionSet::getOptions);
 
     assertTrue(options.values().stream().flatMap(Collection::stream).toList().contains(option));
   }
@@ -279,9 +282,41 @@ class QueryItemHelperTest extends TestBase {
     EventQueryParams params = new EventQueryParams.Builder().addItem(queryItem).build();
     params.getItems().add(queryItem);
 
-    Map<String, List<Option>> options = QueryItemHelper.getItemOptions(grid, params.getItems());
+    Map<String, List<Option>> options =
+        QueryItemHelper.getItemOptions(grid, params.getItems(), OptionSet::getOptions);
 
     assertTrue(options.values().stream().flatMap(Collection::stream).toList().contains(option));
+  }
+
+  @Test
+  void testGetItemOptionsThatMatchesRowsUsesInjectedOptionsResolverNotOptionSetDirectly() {
+    // An option living directly on the OptionSet's own (e.g. lazily-loaded) collection.
+    Option optionOnOptionSet = new Option("Opt-A", "Code-A");
+    OptionSet optionSet = createOptionSet('A', optionOnOptionSet);
+
+    // A distinct Option instance, with the same code, that only the resolver knows about -
+    // standing in for a batched/direct DB fetch that bypasses OptionSet.getOptions().
+    Option optionFromResolver = new Option("Opt-A-Resolved", "Code-A");
+    AtomicBoolean resolverInvoked = new AtomicBoolean(false);
+
+    Grid grid = stubGridWithRowsAndOptionSet(optionSet);
+    QueryItem queryItem = new QueryItem(null, null, null, null, optionSet);
+    EventQueryParams params = new EventQueryParams.Builder().addItem(queryItem).build();
+    params.getItems().add(queryItem);
+
+    Map<String, List<Option>> options =
+        QueryItemHelper.getItemOptions(
+            grid,
+            params.getItems(),
+            os -> {
+              resolverInvoked.set(true);
+              return List.of(optionFromResolver);
+            });
+
+    assertTrue(resolverInvoked.get(), "the injected options resolver should have been invoked");
+    List<Option> matchedOptions = options.values().stream().flatMap(Collection::stream).toList();
+    assertTrue(matchedOptions.contains(optionFromResolver));
+    assertFalse(matchedOptions.contains(optionOnOptionSet));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentQueryServiceTest.java
@@ -65,7 +65,7 @@ class EnrollmentQueryServiceTest {
             null,
             securityManager(params),
             eventQueryValidator(),
-            new MetadataItemsHandler(null, null, null, null),
+            new MetadataItemsHandler(null, null, null, null, null),
             new SchemeIdHandler(null),
             sqlBuilder());
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateOuMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/trackedentity/TrackedEntityAggregateOuMetadataTest.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreator;
 import org.hisp.dhis.analytics.trackedentity.query.context.sql.SqlQueryCreatorService;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.MetadataItem;
+import org.hisp.dhis.option.OptionService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.ProgramService;
@@ -110,6 +111,7 @@ class TrackedEntityAggregateOuMetadataTest {
   private final UserService userService = mock(UserService.class);
   private final OrganisationUnitService organisationUnitService =
       mock(OrganisationUnitService.class);
+  private final OptionService optionService = mock(OptionService.class);
 
   private final TrackedEntityAggregateService service =
       new TrackedEntityAggregateService(
@@ -117,7 +119,7 @@ class TrackedEntityAggregateOuMetadataTest {
           sqlQueryCreatorService,
           executionPlanStore,
           securityManager,
-          new MetadataParamsHandler(),
+          new MetadataParamsHandler(optionService),
           userService,
           organisationUnitService);
 


### PR DESCRIPTION
## Summary

- Fixes [DHIS2-21975](https://dhis2.atlassian.net/browse/DHIS2-21975): `/analytics/events/query` (and equivalent enrollment/tracked-entity aggregate endpoints) build response metadata via `QueryItemHelper.getItemOptions`, which calls `OptionSet.getOptions()` directly for every option-set-backed column.
- `OptionSet.options` is an L2-cached Hibernate `<bag>`, but the collection cache region only stores member IDs — reassembling entities under a cold entity-level cache falls back to one `SELECT ... WHERE optionvalueid = ?` per option. Production profiling on a request with ~12 option-set-backed dimensions showed 6,713 individual selects, 1.38s of a 2s transaction (~69%).
- This is the same class of defect already fixed for the tracker import preheat path (#24850), but an independent call site in analytics metadata building, unaffected by that fix.
- Fix: thread an injectable `Function<OptionSet, List<Option>>` resolver through `QueryItemHelper.getItemOptions` and its two private helpers, wired at the three real callers (`analytics.tracker.MetadataItemsHandler`, `analytics.common.processing.MetadataItemsHandler`, `analytics.common.processing.MetadataDimensionsHandler`, via `MetadataParamsHandler`) to `OptionService.findOptionsByNamePattern(uid, null, null)` — an existing HQL join query that fetches the option set in one direct query, bypassing the broken collection-cache path entirely. No change to existing option-matching semantics.
- Follow-up ticket to file separately (not in this PR): `AbstractJdbcEventAnalyticsManager.addGridDoubleTypeValue` and `SchemeIdResponseMapper.getOptionCodePropertyMap` have the identical defect but weren't hit by the profiled request.

## Test plan

- [x] New unit test in `QueryItemHelperTest` proving the injected resolver (not `OptionSet.getOptions()`) is what's consulted — written before the implementation, watched it fail for the right reason first.
- [x] All directly and indirectly affected tests green locally (127 tests): `QueryItemHelperTest`, `analytics.tracker.MetadataItemsHandlerTest`, `analytics.common.processing.MetadataItemsHandlerTest`/`MetadataParamsHandlerTest`, `GridAdaptorTest`, `TrackedEntityAggregateOuMetadataTest`, `EnrollmentQueryServiceTest`, `DimensionalObjectProviderTest`, `EnrollmentAggregateServiceTest`, `EventAggregateServiceTableLayoutTest`, `EventQueryServiceTest`, `TrackedEntityAggregateServiceTest`.
- [x] Spotless clean.
- [ ] Awaiting CI, in particular the analytics test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DHIS2-21975]: https://dhis2.atlassian.net/browse/DHIS2-21975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ