### PR TITLE
fix: force-initialize collections dropped by replicateUser's uninitialized-proxy merge skip

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -643,6 +643,34 @@ class UserControllerTest extends DhisControllerConvenienceTest {
                 "/users/" + peter.getUid() + "/replica",
                 "{'username':'peter2','password':'Saf€sEcre1'}")
             .content());
+  }
+
+  @Test
+  @DisplayName("Replica should retain the source user's organisation units")
+  void testReplicateUserCopiesOrganisationUnits() {
+    OrganisationUnit orgUnit = createOrganisationUnit('R');
+    organisationUnitService.addOrganisationUnit(orgUnit);
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/" + peter.getUid(),
+            "[{'op':'add','path':'/organisationUnits','value':[{'id':'%s'}]}]"
+                .formatted(orgUnit.getUid())));
+
+    assertWebMessage(
+        "Created",
+        201,
+        "OK",
+        "User replica created",
+        POST(
+                "/users/" + peter.getUid() + "/replica",
+                "{'username':'peterreplica','password':'Saf€sEcre1'}")
+            .content());
+
+    User replica = userService.getUserByUsername("peterreplica");
+    assertEquals(1, replica.getOrganisationUnits().size());
+    assertTrue(replica.getOrganisationUnits().contains(orgUnit));
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
 import static org.hisp.dhis.external.conf.ConfigurationKey.LINKED_ACCOUNTS_ENABLED;
 import static org.hisp.dhis.web.HttpStatus.Series.SUCCESSFUL;
 import static org.hisp.dhis.web.WebClient.Accept;
@@ -671,6 +672,79 @@ class UserControllerTest extends DhisControllerConvenienceTest {
     User replica = userService.getUserByUsername("peterreplica");
     assertEquals(1, replica.getOrganisationUnits().size());
     assertTrue(replica.getOrganisationUnits().contains(orgUnit));
+  }
+
+  @Test
+  @DisplayName("Replica should retain the source user's user roles")
+  void testReplicateUserCopiesUserRoles() {
+    UserRole extraRole = createUserRole("ROLE_REPLICATE_TARGET", "F_USER_ADD");
+    userService.addUserRole(extraRole);
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/" + peter.getUid(),
+            "[{'op':'add','path':'/userRoles','value':[{'id':'%s'}]}]"
+                .formatted(extraRole.getUid())));
+
+    assertWebMessage(
+        "Created",
+        201,
+        "OK",
+        "User replica created",
+        POST(
+                "/users/" + peter.getUid() + "/replica",
+                "{'username':'peterreplica2','password':'Saf€sEcre1'}")
+            .content());
+
+    User replica = userService.getUserByUsername("peterreplica2");
+    Set<String> replicaRoleUids =
+        replica.getUserRoles().stream().map(BaseIdentifiableObject::getUid).collect(toSet());
+    assertTrue(
+        replicaRoleUids.contains(extraRole.getUid()),
+        "Replica should have inherited the role added to the source user");
+  }
+
+  @Test
+  @DisplayName("Replica should retain the source user's dimension constraints")
+  void testReplicateUserCopiesDimensionConstraints() {
+    CategoryOption categoryOption = createCategoryOption('D');
+    categoryService.addCategoryOption(categoryOption);
+    Category category = createCategory('D', categoryOption);
+    categoryService.addCategory(category);
+
+    CategoryOptionGroupSet categoryOptionGroupSet = new CategoryOptionGroupSet();
+    categoryOptionGroupSet.setAutoFields();
+    categoryOptionGroupSet.setDataDimensionType(DataDimensionType.DISAGGREGATION);
+    categoryOptionGroupSet.setName("cogsD");
+    categoryOptionGroupSet.setShortName("cogsD");
+    manager.save(categoryOptionGroupSet);
+
+    // Assigned via a real PATCH request (not a direct service call) so the source user is
+    // reloaded fresh, rather than reusing this test method's own Hibernate session/persistence
+    // context - a direct service call here would mask the very bug this test exists to catch.
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/" + peter.getUid(),
+            """
+            [{'op':'add','path':'/catDimensionConstraints','value':[{'id':'%s'}]},
+             {'op':'add','path':'/cogsDimensionConstraints','value':[{'id':'%s'}]}]"""
+                .formatted(category.getUid(), categoryOptionGroupSet.getUid())));
+
+    assertWebMessage(
+        "Created",
+        201,
+        "OK",
+        "User replica created",
+        POST(
+                "/users/" + peter.getUid() + "/replica",
+                "{'username':'peterreplica3','password':'Saf€sEcre1'}")
+            .content());
+
+    User replica = userService.getUserByUsername("peterreplica3");
+    assertEquals(Set.of(category), replica.getCatDimensionConstraints());
+    assertEquals(Set.of(categoryOptionGroupSet), replica.getCogsDimensionConstraints());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -58,6 +58,7 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Hibernate;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DhisApiVersion;
@@ -447,6 +448,13 @@ public class UserController extends AbstractCrudController<User> {
     if (existingUser == null) {
       return conflict("User not found: " + uid);
     }
+
+    // MetadataMergeService.merge() silently skips any collection that is still an
+    // uninitialized Hibernate proxy at merge time (to avoid triggering large lazy loads
+    // elsewhere), so force-initialize the org-unit collections here or they get dropped.
+    Hibernate.initialize(existingUser.getOrganisationUnits());
+    Hibernate.initialize(existingUser.getDataViewOrganisationUnits());
+    Hibernate.initialize(existingUser.getTeiSearchOrganisationUnits());
 
     User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
     validateCreateUser(existingUser, currentUser);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -451,10 +451,16 @@ public class UserController extends AbstractCrudController<User> {
 
     // MetadataMergeService.merge() silently skips any collection that is still an
     // uninitialized Hibernate proxy at merge time (to avoid triggering large lazy loads
-    // elsewhere), so force-initialize the org-unit collections here or they get dropped.
+    // elsewhere), so force-initialize every collection it needs to copy here, or they get
+    // dropped from the replica with no error. "groups" is not in this list because it is
+    // re-established explicitly via userGroupService.addUserToGroups() below, independent of
+    // whatever merge() does with it.
     Hibernate.initialize(existingUser.getOrganisationUnits());
     Hibernate.initialize(existingUser.getDataViewOrganisationUnits());
     Hibernate.initialize(existingUser.getTeiSearchOrganisationUnits());
+    Hibernate.initialize(existingUser.getUserRoles());
+    Hibernate.initialize(existingUser.getCogsDimensionConstraints());
+    Hibernate.initialize(existingUser.getCatDimensionConstraints());
 
     User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
     validateCreateUser(existingUser, currentUser);


### PR DESCRIPTION
## Summary

`UserController.replicateUser()` clones a user via `metadataMergeService.merge()`. That merge
path (`DefaultMetadataMergeService.merge()`) silently skips any collection property that is
still an uninitialized Hibernate proxy at merge time:

```java
if (sourceObject == null || !Hibernate.isInitialized(sourceObject)) {
  continue;
}
```

`existingUser` is loaded via a plain get-by-uid with no eager fetch, so any of its lazy
collections can still be uninitialized proxies when the merge runs — and they get silently
dropped from the replica, with no error of any kind.

This was found live on a production 2.41 instance: a user with 1 `usermembership` row was
replicated, and the replica ended up with 0 rows in `usermembership` — confirmed directly via
SQL, not just API/UI symptoms. The same defect reproduces deterministically in an H2 controller
test against plain, unmodified `2.41` (no local branch changes involved) — it isn't dependent on
any caching config, timing, or environment; the source collection is simply not initialized
by the time `merge()` runs.

**Update:** the same defect also affects `userRoles`, `cogsDimensionConstraints`, and
`catDimensionConstraints` — none of them have any explicit re-copy step (unlike `groups`, which
is safe because it's re-established separately via `userGroupService.addUserToGroups()` after
the merge, regardless of what the merge itself did). `userRoles` is the most severe of these:
a replicated user could silently end up with zero authorities.

Master already avoids this entire class of bug via a later JDBC-based rewrite of
`replicateUser` (PR #23154, "fix: Replicate users with JDBC") — its own PR description
independently confirms this exact root cause: *"That merge path conditionally copies
collections based on Hibernate initialization state, however when the source user is detached
with lazy collections uninitialized, memberships and dimension constraints are silently
skipped during the clone."* Backporting that full rewrite is a much larger effort (14 files,
~870 lines), so this PR instead applies the minimal, targeted fix: force-initialize the
affected collections right after loading `existingUser`, so the merge can no longer skip them
regardless of session/cache timing.

## Fix

Six `Hibernate.initialize(...)` calls in `UserController.replicateUser()`, right after
`userService.getUser(uid)`:
- `organisationUnits`, `dataViewOrganisationUnits`, `teiSearchOrganisationUnits`
- `userRoles`, `cogsDimensionConstraints`, `catDimensionConstraints`

Each only loads that one user's own membership rows for that collection — it does not cascade
into related entities' own lazy associations (e.g. initializing `organisationUnits` does not
walk the org unit hierarchy tree), so there's no risk of a large/expensive load regardless of
how big those referenced collections are elsewhere.

`groups` is deliberately not in this list — it's already safe via the explicit
`addUserToGroups()` call.

## Test plan

- [x] `UserControllerTest#testReplicateUserCopiesOrganisationUnits` — assigns an org unit to a
      user, replicates via the real `/replica` HTTP endpoint, asserts the replica retains it.
      Verified red before the fix, green after.
- [x] `UserControllerTest#testReplicateUserCopiesUserRoles` — same pattern for a user role.
      Verified red before the fix, green after.
- [x] `UserControllerTest#testReplicateUserCopiesDimensionConstraints` — same pattern for
      `catDimensionConstraints`/`cogsDimensionConstraints`. Verified red before the fix, green
      after.
- [x] Note: earlier drafts of the userRoles and dimension-constraints tests passed even
      *without* the fix, because the test code touched the source user's collection directly
      (via a service call) in the same Hibernate session the replication request later reused,
      accidentally pre-initializing it. Rewrote both to go through real PATCH HTTP requests
      instead, which produced honest failures. This also explains why the underlying bug
      reproduces inconsistently across environments/manual testing — it depends on whatever
      else touched that collection earlier in the same session, not on caching config or timing.
- [x] Full `UserControllerTest` suite (54 tests) passes, no regressions.
- [x] Confirmed the org-unit fix's red→green behavior against a clean worktree of plain
      `origin/2.41` (no other local changes) to rule out any dependency on branch-specific
      caching changes.
