### PR TITLE
fix: Gist API - lower input as wellf or ieq [DHIS2-21972]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -873,11 +873,13 @@ final class GistBuilder {
       }
     }
     String param = ":f_" + index;
+    if (operator.isCaseInsensitive()) param = "lower(" + param + ")";
+    if (operator.isMultiValue()) param = "(" + param + ")";
     Map<String, String> variables =
         Map.ofEntries(
             entry("left", replace(template, Map.of("property", field))),
             entry("op", operator.getSql()),
-            entry("right", operator.isMultiValue() ? "(" + param + ")" : param));
+            entry("right", param));
     return operator.isUnary()
         ? replace("${left} ${op}", variables)
         : replace("${left} ${op} ${right}", variables);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
@@ -458,7 +458,7 @@ class GistFilterControllerTest extends AbstractGistControllerTest {
         orgUnitId, "Peter", "Paul", "Paula", "Ringo", "John", "George", "paul");
     assertEquals(
         List.of("Paul", "paul"),
-        GET("/dataSets/gist?fields=name&filter=name:ieq:paul&headless=true&order=name")
+        GET("/dataSets/gist?fields=name&filter=name:ieq:PAUL&headless=true&order=name")
             .content()
             .stringValues());
   }


### PR DESCRIPTION
### Summary
For `IEQ` operator in Gist API only the column matched was transformed with `lower(...)` but not the user input it is compared to making it not a true case-insensitive comparison.

While the issue was noticed with the metadata API that was using Gist bridge this is purely a gist query building issue and fixes both Gist API and Gist bridge.

### Automatic Testing
There was a test but it did use user input that was already all lower case hiding the issue. It got adjusted to use upper case input.

### Manual Testing
On SL demo DB http://localhost:8080/api/dataElements?fields=id,name&filter=name:ieq:cho and http://localhost:8080/api/dataElements?fields=id,name&filter=name:eq:CHO should yield the same match. This is also true for any other case spelling of the search term `cho`. 