### PR TITLE
feat: configurable refresh token TTL and rotation for DCR clients (2.42)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -742,6 +742,14 @@ public enum ConfigurationKey {
   OAUTH2_JWT_KEYSTORE_GENERATE_IF_MISSING(
       "oauth2.server.jwt.keystore.generate-if-missing", "true", false),
 
+  /**
+   * Refresh token time-to-live in seconds for clients registered through OIDC Dynamic Client
+   * Registration (e.g. Android devices). Refresh tokens are rotated on every use, so this is a
+   * sliding window: each refresh issues a new refresh token valid for this duration. (default: 30
+   * days)
+   */
+  OAUTH2_SERVER_DCR_REFRESH_TOKEN_TTL("oauth2.server.dcr.refresh-token-ttl", "2592000", false),
+
   /** Ehcache monitoring. (default: off) */
   MONITORING_EHCACHE_ENABLED("monitoring.ehcache.enabled", Constants.OFF, false),
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
@@ -31,6 +31,8 @@ package org.hisp.dhis.webapi.controller.security;
 
 import static org.hisp.dhis.security.oauth2.dcr.OAuth2DcrService.createIaToken;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,12 +49,15 @@ import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -72,9 +77,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.jackson2.SecurityJackson2Modules;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.JwsHeader;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -83,11 +90,15 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.jackson2.OAuth2AuthorizationServerJackson2Module;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 /**
@@ -161,6 +172,169 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
             .getResponse()
             .getContentAsString();
     assertNotNull(usersResp);
+  }
+
+  @Test
+  @DisplayName("Test DCR-registered client refresh token settings")
+  void testDcrRegisteredClientRefreshTokenSettings() throws Exception {
+    // Given an initial access token (iat)
+    String initialAccessToken = createClientAndIat();
+
+    // Given a key pair to be used for the client's private_key_jwt authentication
+    KeyPair keyPair = createKeys();
+
+    // When registering a client
+    String clientId = doClientRegistrationRequest(initialAccessToken, keyPair);
+    RegisteredClient client = oAuth2ClientService.findByClientId(clientId);
+    assertNotNull(client);
+
+    // Then the refresh token TTL is the oauth2.server.dcr.refresh-token-ttl default (30 days),
+    // not the SAS framework default of 60 minutes
+    TokenSettings tokenSettings = client.getTokenSettings();
+    assertEquals(Duration.ofDays(30), tokenSettings.getRefreshTokenTimeToLive());
+
+    // Then refresh tokens are rotated on every use (OAuth 2.1 requirement for public clients),
+    // making the TTL a sliding window instead of a hard wall after the initial login
+    assertFalse(tokenSettings.isReuseRefreshTokens());
+
+    // Then the id-token signature algorithm set by the SAS delegate converter is preserved
+    assertEquals(SignatureAlgorithm.RS256, tokenSettings.getIdTokenSignatureAlgorithm());
+  }
+
+  @Test
+  @DisplayName("Test refresh token rotation and sliding window expiry")
+  void testRefreshTokenRotationAndSlidingWindow() throws Exception {
+    // Given a DCR-registered client with the refresh_token grant
+    KeyPair keyPair = createKeys();
+    String clientId = registerRefreshCapableClient(keyPair);
+    RegisteredClient client = oAuth2ClientService.findByClientId(clientId);
+
+    // Given a persisted authorization holding a valid refresh token, as after a completed
+    // authorization_code flow
+    String initialRefreshToken = "rotation-initial-refresh-token";
+    saveAuthorizationWithRefreshToken(
+        client,
+        "authzRot001",
+        initialRefreshToken,
+        Instant.now(),
+        Instant.now().plus(Duration.ofDays(30)));
+
+    // When refreshing with the valid refresh token, then new tokens are issued
+    String response =
+        callRefreshTokenEndpoint(keyPair, clientId, initialRefreshToken)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.access_token").exists())
+            .andExpect(jsonPath("$.refresh_token").exists())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    // Then the refresh token is rotated: the response contains a NEW refresh token
+    String rotatedRefreshToken =
+        ((JsonObject) JsonValue.of(response)).getString("refresh_token").string();
+    assertNotEquals(initialRefreshToken, rotatedRefreshToken);
+
+    // Then the rotated refresh token has a fresh 30 day expiry (sliding window), enforced from
+    // the persisted refresh_token_expires_at
+    OAuth2Authorization refreshed =
+        dhis2OAuth2AuthorizationService.findByToken(
+            rotatedRefreshToken, OAuth2TokenType.REFRESH_TOKEN);
+    assertNotNull(refreshed);
+    Instant rotatedExpiresAt = refreshed.getRefreshToken().getToken().getExpiresAt();
+    assertNotNull(rotatedExpiresAt);
+    assertTrue(
+        rotatedExpiresAt.isAfter(Instant.now().plus(Duration.ofDays(29)))
+            && rotatedExpiresAt.isBefore(Instant.now().plus(Duration.ofDays(31))),
+        "rotated refresh token must expire ~30 days from now, was: " + rotatedExpiresAt);
+
+    // Then replaying the superseded refresh token is rejected (rotation invalidates it)
+    callRefreshTokenEndpoint(keyPair, clientId, initialRefreshToken)
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("invalid_grant"));
+  }
+
+  @Test
+  @DisplayName("Test expired refresh token is rejected")
+  void testExpiredRefreshTokenRejected() throws Exception {
+    // Given a DCR-registered client with the refresh_token grant
+    KeyPair keyPair = createKeys();
+    String clientId = registerRefreshCapableClient(keyPair);
+    RegisteredClient client = oAuth2ClientService.findByClientId(clientId);
+
+    // Given a persisted authorization whose refresh token expired one hour ago. Expiry is
+    // enforced against the persisted refresh_token_expires_at, so backdating it simulates the
+    // passage of time without mocking any clock.
+    String expiredRefreshToken = "backdated-expired-refresh-token";
+    saveAuthorizationWithRefreshToken(
+        client,
+        "authzExp001",
+        expiredRefreshToken,
+        Instant.now().minus(Duration.ofDays(31)),
+        Instant.now().minus(Duration.ofHours(1)));
+
+    // When refreshing with the expired token, then the grant is rejected
+    callRefreshTokenEndpoint(keyPair, clientId, expiredRefreshToken)
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("invalid_grant"));
+  }
+
+  /** Registers a client with the authorization_code and refresh_token grants via DCR. */
+  private String registerRefreshCapableClient(KeyPair keyPair) throws Exception {
+    String initialAccessToken = createClientAndIat();
+    MockHttpServletRequestBuilder registration =
+        getGetClientRegPost(
+            initialAccessToken, keyPair, "[\"authorization_code\", \"refresh_token\"]");
+    String response =
+        mvc.perform(registration)
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return ((JsonObject) JsonValue.of(response)).getString("client_id").string();
+  }
+
+  /**
+   * Persists an {@link OAuth2Authorization} holding a refresh token with the given lifetime, as it
+   * would exist after a completed authorization_code flow.
+   */
+  private void saveAuthorizationWithRefreshToken(
+      RegisteredClient client,
+      String uid,
+      String refreshTokenValue,
+      Instant issuedAt,
+      Instant expiresAt) {
+    // MockMvc requests clear the thread's security context; the authorization store needs a
+    // current user for auditing
+    injectAdminIntoSecurityContext();
+    OAuth2RefreshToken refreshToken =
+        new OAuth2RefreshToken(refreshTokenValue, issuedAt, expiresAt);
+    UsernamePasswordAuthenticationToken principal =
+        UsernamePasswordAuthenticationToken.authenticated("admin", null, List.of());
+    OAuth2Authorization authorization =
+        OAuth2Authorization.withRegisteredClient(client)
+            // the service persists a non-UUID id verbatim as the 11-char uid column value;
+            // UUID-shaped ids would be remapped to a generated uid instead
+            .id(uid)
+            .principalName("admin")
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .authorizedScopes(Set.of("username"))
+            .attribute(Principal.class.getName(), principal)
+            .refreshToken(refreshToken)
+            .build();
+    dhis2OAuth2AuthorizationService.save(authorization);
+  }
+
+  private ResultActions callRefreshTokenEndpoint(
+      KeyPair keyPair, String clientId, String refreshToken) throws Exception {
+    return mvc.perform(
+        post("/oauth2/token")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .param("client_id", clientId)
+            .param(
+                "client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+            .param("grant_type", "refresh_token")
+            .param("refresh_token", refreshToken)
+            .param("client_assertion", createClientAssertion(keyPair, clientId)));
   }
 
   @Test
@@ -262,6 +436,11 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
    * @return
    */
   private static MockHttpServletRequestBuilder getGetClientRegPost(String iat, KeyPair keyPair) {
+    return getGetClientRegPost(iat, keyPair, "[\"client_credentials\"]");
+  }
+
+  private static MockHttpServletRequestBuilder getGetClientRegPost(
+      String iat, KeyPair keyPair, String grantTypesJson) {
     return post("/connect/register")
         .header(HttpHeaders.AUTHORIZATION, "Bearer " + iat)
         .contentType(MediaType.APPLICATION_JSON)
@@ -271,7 +450,7 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
                  {
                    "client_name": "Test DHIS2 Android Client",
                    "redirect_uris": ["https://dhis2.org"],
-                   "grant_types": ["client_credentials"],
+                   "grant_types": %s,
                    "response_types": ["code"],
                    "token_endpoint_auth_method": "private_key_jwt",
                    "token_endpoint_auth_signing_alg": "RS256",
@@ -280,6 +459,7 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
                    "jwks": %s
                  }
                 """,
+                grantTypesJson,
                 keyPair
                     .jwkSet())); // Inline JWKS , note jwks_uri is also set but should be ignored,
     // validation will fail if not set, only jwks is used
@@ -307,7 +487,7 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
     return iaToken.iatJwt();
   }
 
-  private String callTokenEndpoint(KeyPair keyPair, String clientId) throws Exception {
+  private String createClientAssertion(KeyPair keyPair, String clientId) {
     // This is the server base URL with trailing slash!!!
     String serverBaseUrlWithTrailingSlash = authorizationServerSettings.getIssuer();
 
@@ -326,10 +506,13 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
             .expiresAt(Instant.now().plus(1, ChronoUnit.HOURS))
             .build();
 
-    String clientAssertion =
-        clientJwtEncoder
-            .encode(JwtEncoderParameters.from(assertionHeader, assertionClaims))
-            .getTokenValue();
+    return clientJwtEncoder
+        .encode(JwtEncoderParameters.from(assertionHeader, assertionClaims))
+        .getTokenValue();
+  }
+
+  private String callTokenEndpoint(KeyPair keyPair, String clientId) throws Exception {
+    String clientAssertion = createClientAssertion(keyPair, clientId);
 
     return mvc.perform(
             post("/oauth2/token")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthorizationServerConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthorizationServerConfig.java
@@ -44,6 +44,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -156,7 +157,10 @@ public class AuthorizationServerConfig {
   @Bean
   @Order(1)
   public SecurityFilterChain authorizationServerSecurityFilterChain(
-      HttpSecurity http, CustomClaimValidator<Jwt> customClaimValidator) throws Exception {
+      HttpSecurity http,
+      CustomClaimValidator<Jwt> customClaimValidator,
+      DhisConfigurationProvider dhisConfig)
+      throws Exception {
     OAuth2AuthorizationServerConfigurer authorizationServerConfigurer =
         OAuth2AuthorizationServerConfigurer.authorizationServer();
 
@@ -172,7 +176,8 @@ public class AuthorizationServerConfig {
                     .oidc(
                         oidc ->
                             oidc.clientRegistrationEndpoint(
-                                cr -> cr.authenticationProviders(customizeDcrProviders()))))
+                                cr ->
+                                    cr.authenticationProviders(customizeDcrProviders(dhisConfig)))))
         .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
         .exceptionHandling(
             exceptions ->
@@ -219,10 +224,15 @@ public class AuthorizationServerConfig {
    * Customizes the Dynamic Client Registration (DCR) authentication providers to use our custom
    * client converters.
    *
+   * @param dhisConfig the system configuration, used for the DCR refresh token time-to-live
    * @return a consumer that customizes the DCR authentication providers.
    */
-  private Consumer<List<AuthenticationProvider>> customizeDcrProviders() {
-    RegisteredClientConverter regConverter = new RegisteredClientConverter();
+  private Consumer<List<AuthenticationProvider>> customizeDcrProviders(
+      DhisConfigurationProvider dhisConfig) {
+    Duration refreshTokenTtl =
+        Duration.ofSeconds(
+            dhisConfig.getIntProperty(ConfigurationKey.OAUTH2_SERVER_DCR_REFRESH_TOKEN_TTL));
+    RegisteredClientConverter regConverter = new RegisteredClientConverter(refreshTokenTtl);
     ClientRegistrationConverter readConverter = new ClientRegistrationConverter();
     return providers ->
         providers.forEach(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/InlineJwksClientMetadataConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/InlineJwksClientMetadataConfig.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.webapi.security.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.jwk.JWKSet;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +42,7 @@ import org.springframework.security.oauth2.server.authorization.oidc.OidcClientR
 import org.springframework.security.oauth2.server.authorization.oidc.converter.OidcClientRegistrationRegisteredClientConverter;
 import org.springframework.security.oauth2.server.authorization.oidc.converter.RegisteredClientOidcClientRegistrationConverter;
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
 
 /**
  * Support for inline JWKS in OIDC Dynamic Client Registration (DCR).
@@ -63,6 +65,12 @@ final class InlineJwksClientMetadataConfig {
 
     private final OidcClientRegistrationRegisteredClientConverter delegate =
         new OidcClientRegistrationRegisteredClientConverter();
+
+    private final Duration refreshTokenTtl;
+
+    public RegisteredClientConverter(Duration refreshTokenTtl) {
+      this.refreshTokenTtl = refreshTokenTtl;
+    }
 
     @Override
     public RegisteredClient convert(OidcClientRegistration reg) {
@@ -98,7 +106,22 @@ final class InlineJwksClientMetadataConfig {
         throw new IllegalArgumentException("'jwks' must be provided in registration");
       }
 
-      return RegisteredClient.from(rc).clientSettings(cs.build()).build();
+      // The SAS delegate leaves token settings at framework defaults: refresh token TTL 60
+      // minutes with reuseRefreshTokens(true), i.e. no rotation and no expiry extension on
+      // refresh, which forces re-authentication one hour after the initial login. DCR-registered
+      // clients are long-lived native apps (Android devices), so use the configured TTL
+      // (oauth2.server.dcr.refresh-token-ttl) and rotate the refresh token on every use, as
+      // required for public clients by OAuth 2.1. Rotation makes the TTL a sliding window.
+      TokenSettings tokenSettings =
+          TokenSettings.withSettings(rc.getTokenSettings().getSettings())
+              .refreshTokenTimeToLive(refreshTokenTtl)
+              .reuseRefreshTokens(false)
+              .build();
+
+      return RegisteredClient.from(rc)
+          .clientSettings(cs.build())
+          .tokenSettings(tokenSettings)
+          .build();
     }
   }
 


### PR DESCRIPTION
Backport of #24754 (merged to master 2026-08-17).

## Change

- New dhis.conf key `oauth2.server.dcr.refresh-token-ttl` (seconds, default `2592000` = 30 days) applied to DCR-registered clients in `RegisteredClientConverter`.
- Refresh token rotation enabled for DCR clients (`reuseRefreshTokens=false`), making the TTL a sliding window; without it the refresh token hard-expires 60 minutes after login regardless of activity.
- Other delegate-set token settings (id-token signature algorithm, access token TTL/format) preserved.

## Backport notes

- Same resolution as the 2.43 backport; additionally kept the 2.42 `/dhis-web-login/` login entry point and the 2.42 test class name `DcrWithJwksTest`.
- Dropped the master-only DCR scope-defaults block and its `testDcrRegisteredClientDefaultScopesExcludeEmail` test (both belong to #24478, tracked for a separate parity backport).
- No Flyway migrations.

## Tests

`testDcrRegisteredClientRefreshTokenSettings`, `testRefreshTokenRotationAndSlidingWindow`, `testExpiredRefreshTokenRejected` included; verified via CI on this PR.

AI Assisted