### PR TITLE
fix: Gist API - lower input as wellf or ieq [DHIS2-21972] (2.42)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -901,7 +901,10 @@ final class GistBuilder {
     str.append(String.format(fieldTemplate, field));
     str.append(" ").append(createOperatorLeftSideHQL(operator));
     if (!operator.isUnary()) {
-      str.append(" :f_").append(index).append(createOperatorRightSideHQL(operator));
+      if (operator.isCaseInsensitive()) str.append("lower(");
+      str.append(" :f_").append(index);
+      if (operator.isCaseInsensitive()) str.append(")");
+      str.append(createOperatorRightSideHQL(operator));
     }
     return str.toString();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -901,7 +901,7 @@ final class GistBuilder {
     str.append(String.format(fieldTemplate, field));
     str.append(" ").append(createOperatorLeftSideHQL(operator));
     if (!operator.isUnary()) {
-      if (operator.isCaseInsensitive()) str.append("lower(");
+      if (operator.isCaseInsensitive()) str.append(" lower(");
       str.append(" :f_").append(index);
       if (operator.isCaseInsensitive()) str.append(")");
       str.append(createOperatorRightSideHQL(operator));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
@@ -458,7 +458,7 @@ class GistFilterControllerTest extends AbstractGistControllerTest {
         orgUnitId, "Peter", "Paul", "Paula", "Ringo", "John", "George", "paul");
     assertEquals(
         List.of("Paul", "paul"),
-        GET("/dataSets/gist?fields=name&filter=name:ieq:paul&headless=true&order=name")
+        GET("/dataSets/gist?fields=name&filter=name:ieq:PAUL&headless=true&order=name")
             .content()
             .stringValues());
   }


### PR DESCRIPTION
redone changes from #24879 manually as the query building did not yet use a variables map in 42