### PR TITLE
feat: adopt PKCE-by-default and formalize OAuth2/DCR scopes (2.42)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2Constants.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2Constants.java
@@ -29,6 +29,9 @@
  */
 package org.hisp.dhis.security.oauth2;
 
+import java.util.List;
+import java.util.Set;
+
 /**
  * Shared constants for the DHIS2 OAuth2 authorization server integration.
  *
@@ -45,6 +48,56 @@ public final class OAuth2Constants {
    * value.
    */
   public static final String SYSTEM_REGISTRAR_CLIENTID = "system-dcr-registrar-client";
+
+  /** OpenID Connect scope. */
+  public static final String SCOPE_OPENID = "openid";
+
+  /** OIDC profile scope. */
+  public static final String SCOPE_PROFILE = "profile";
+
+  /** DHIS2-specific scope that maps the token to a DHIS2 username claim. */
+  public static final String SCOPE_USERNAME = "username";
+
+  /** OIDC email scope. */
+  public static final String SCOPE_EMAIL = "email";
+
+  /**
+   * Reserved scope that authorizes minting new clients through the DCR endpoint {@code
+   * /connect/register}. Only the system DCR registrar's Initial Access Tokens may carry it.
+   */
+  public static final String SCOPE_CLIENT_CREATE = "client.create";
+
+  /** Prefix shared by all reserved client-management scopes. */
+  public static final String RESERVED_SCOPE_PREFIX = "client.";
+
+  /** Scopes admin/metadata/DCR-assigned clients may carry. */
+  public static final Set<String> ALLOWED_CLIENT_SCOPES =
+      Set.of(SCOPE_OPENID, SCOPE_PROFILE, SCOPE_USERNAME, SCOPE_EMAIL);
+
+  /** Reserved for the system DCR registrar / IAT path only. */
+  public static final Set<String> RESERVED_SCOPES = Set.of(SCOPE_CLIENT_CREATE);
+
+  /**
+   * Server-side default scopes assigned to DCR-registered clients when the registration omits
+   * scopes. Spring Authorization Server 7 forbids client-supplied {@code scope} on DCR requests, so
+   * these are the only scopes a DCR client gets. Matches the Android reference client's authorize
+   * scopes; deliberately excludes {@code email} (PR-H decision D3).
+   */
+  public static final List<String> DCR_DEFAULT_SCOPES =
+      List.of(SCOPE_OPENID, SCOPE_PROFILE, SCOPE_USERNAME);
+
+  /**
+   * Returns true when the scope is reserved for server-managed clients: an exact member of {@link
+   * #RESERVED_SCOPES} or any scope under the {@code client.} prefix.
+   */
+  public static boolean isReservedScope(String scope) {
+    return RESERVED_SCOPES.contains(scope) || scope.startsWith(RESERVED_SCOPE_PREFIX);
+  }
+
+  /** Returns true when the scope may be assigned to admin/metadata/DCR-created clients. */
+  public static boolean isAllowedClientScope(String scope) {
+    return ALLOWED_CLIENT_SCOPES.contains(scope);
+  }
 
   /**
    * Max length of the persisted {@code oauth2_client.name} column; kept in sync with the HBM

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
@@ -51,7 +51,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.NonTransactional;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -83,7 +82,6 @@ import org.springframework.util.StringUtils;
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@Slf4j
 @Service
 public class Dhis2OAuth2ClientServiceImpl
     implements Dhis2OAuth2ClientService, RegisteredClientRepository {
@@ -515,9 +513,8 @@ public class Dhis2OAuth2ClientServiceImpl
    * <p>{@code clientSettings} must parse with the same Jackson configuration {@link #toObject}
    * uses, and must carry both {@code settings.client.require-proof-key} and {@code
    * settings.client.require-authorization-consent} as booleans — Spring AS unboxes these on every
-   * authorize call, so a partial map would NPE at runtime. An explicit {@code
-   * require-proof-key:false} remains a supported (temporary) opt-out for legacy integrations, but
-   * is logged so the downgrade is auditable.
+   * authorize call, so a partial map would NPE at runtime. {@code
+   * settings.client.require-proof-key} must be {@code true}; disabling PKCE is rejected.
    */
   private void validateSettings(Dhis2OAuth2Client entity, Consumer<ErrorReport> errors) {
     String clientSettings = entity.getClientSettings();
@@ -530,11 +527,11 @@ public class Dhis2OAuth2ClientServiceImpl
         checkRequiredBooleanSetting(
             settings, ConfigurationSettingNames.Client.REQUIRE_AUTHORIZATION_CONSENT, errors);
         if (Boolean.FALSE.equals(proofKey)) {
-          log.warn(
-              "OAuth2 client '{}' explicitly opts out of PKCE (require-proof-key=false). This is a"
-                  + " temporary escape hatch for legacy integrations; new authorization-code"
-                  + " clients should use S256 PKCE.",
-              entity.getClientId());
+          errors.accept(
+              new ErrorReport(
+                  Dhis2OAuth2Client.class,
+                  ErrorCode.E4000,
+                  "PKCE cannot be disabled: settings.client.require-proof-key must be true."));
         }
       }
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
@@ -29,8 +29,11 @@
  */
 package org.hisp.dhis.security.oauth2.client;
 
+import static org.hisp.dhis.security.oauth2.OAuth2Constants.ALLOWED_CLIENT_SCOPES;
 import static org.hisp.dhis.security.oauth2.OAuth2Constants.CLIENT_NAME_MAX_LENGTH;
 import static org.hisp.dhis.security.oauth2.OAuth2Constants.SYSTEM_REGISTRAR_CLIENTID;
+import static org.hisp.dhis.security.oauth2.OAuth2Constants.isAllowedClientScope;
+import static org.hisp.dhis.security.oauth2.OAuth2Constants.isReservedScope;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -48,6 +51,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.NonTransactional;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -66,6 +70,7 @@ import org.springframework.security.oauth2.server.authorization.client.Registere
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.jackson2.OAuth2AuthorizationServerJackson2Module;
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.settings.ConfigurationSettingNames;
 import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,6 +83,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
+@Slf4j
 @Service
 public class Dhis2OAuth2ClientServiceImpl
     implements Dhis2OAuth2ClientService, RegisteredClientRepository {
@@ -350,7 +356,9 @@ public class Dhis2OAuth2ClientServiceImpl
   public void validateCreate(Dhis2OAuth2Client entity, Consumer<ErrorReport> errors) {
     checkClientIdNotReserved(entity.getClientId(), "create a client with", errors);
     validateGrantTypes(entity, errors);
+    validateScopes(entity, errors);
     validateRedirectUris(entity, errors);
+    validateSettings(entity, errors);
   }
 
   @Override
@@ -360,7 +368,9 @@ public class Dhis2OAuth2ClientServiceImpl
       checkClientIdNotReserved(newEntity.getClientId(), "rename a client to", errors);
     }
     validateGrantTypes(newEntity, errors);
+    validateScopes(newEntity, errors);
     validateRedirectUris(newEntity, errors);
+    validateSettings(newEntity, errors);
   }
 
   @Override
@@ -370,11 +380,15 @@ public class Dhis2OAuth2ClientServiceImpl
     if (entity.getRawName() == null || entity.getRawName().isEmpty()) {
       entity.setName(truncateName(entity.getClientId()));
     }
-    if (entity.getClientSettings() == null) {
-      ClientSettings defaults = ClientSettings.builder().requireAuthorizationConsent(true).build();
+    // PKCE-by-default (PR-H): new admin/metadata-created clients require S256 PKCE on the
+    // authorization-code flow. Both flags are set explicitly and deliberately instead of
+    // relying on the ClientSettings builder defaults, so the policy is visible and stable.
+    if (entity.getClientSettings() == null || entity.getClientSettings().isBlank()) {
+      ClientSettings defaults =
+          ClientSettings.builder().requireAuthorizationConsent(true).requireProofKey(true).build();
       entity.setClientSettings(writeMap(defaults.getSettings()));
     }
-    if (entity.getTokenSettings() == null) {
+    if (entity.getTokenSettings() == null || entity.getTokenSettings().isBlank()) {
       entity.setTokenSettings(writeMap(TokenSettings.builder().build().getSettings()));
     }
   }
@@ -450,10 +464,129 @@ public class Dhis2OAuth2ClientServiceImpl
   }
 
   /**
-   * Redirect URI allow-list: http and https are always accepted; any other URI must match verbatim
-   * an entry in the {@code deviceEnrollmentRedirectAllowlist} system setting. Default-to-deny
-   * closes the stored-XSS / token-exfiltration surface that Spring Authorization Server leaves open
-   * when it emits the {@code Location} header without scheme filtering.
+   * Enforce the admin scope policy: reserved scopes ({@code client.create} and anything under the
+   * {@code client.} prefix) can never be assigned through admin paths — a client carrying them
+   * could mint new clients via {@code /connect/register}. All other scopes must be members of
+   * {@link org.hisp.dhis.security.oauth2.OAuth2Constants#ALLOWED_CLIENT_SCOPES}. The DCR system
+   * registrar is exempt so a full metadata round-trip can re-import it (same exception as {@link
+   * #validateGrantTypes}).
+   */
+  private void validateScopes(Dhis2OAuth2Client entity, Consumer<ErrorReport> errors) {
+    if (SYSTEM_REGISTRAR_CLIENTID.equals(entity.getClientId())) {
+      return;
+    }
+    String raw = entity.getScopes();
+    if (raw == null || raw.isBlank()) {
+      return;
+    }
+    for (String scope : raw.split(",")) {
+      String trimmed = scope.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      if (isReservedScope(trimmed)) {
+        errors.accept(
+            new ErrorReport(
+                Dhis2OAuth2Client.class,
+                ErrorCode.E4000,
+                "Scope '"
+                    + trimmed
+                    + "' is reserved for the system DCR registrar and cannot be assigned to"
+                    + " clients."));
+      } else if (!isAllowedClientScope(trimmed)) {
+        errors.accept(
+            new ErrorReport(
+                Dhis2OAuth2Client.class,
+                ErrorCode.E4000,
+                "Invalid scope: '"
+                    + trimmed
+                    + "'. Allowed scopes are: "
+                    + String.join(", ", ALLOWED_CLIENT_SCOPES.stream().sorted().toList())
+                    + "."));
+      }
+    }
+  }
+
+  /**
+   * Validate admin-supplied {@code clientSettings} / {@code tokenSettings} JSON at write time, so a
+   * row that would later fail (or surprise) {@link #toObject} is rejected up front instead of
+   * breaking the authorization server at runtime.
+   *
+   * <p>{@code clientSettings} must parse with the same Jackson configuration {@link #toObject}
+   * uses, and must carry both {@code settings.client.require-proof-key} and {@code
+   * settings.client.require-authorization-consent} as booleans — Spring AS unboxes these on every
+   * authorize call, so a partial map would NPE at runtime. An explicit {@code
+   * require-proof-key:false} remains a supported (temporary) opt-out for legacy integrations, but
+   * is logged so the downgrade is auditable.
+   */
+  private void validateSettings(Dhis2OAuth2Client entity, Consumer<ErrorReport> errors) {
+    String clientSettings = entity.getClientSettings();
+    if (clientSettings != null && !clientSettings.isBlank()) {
+      Map<String, Object> settings = tryParseSettings("clientSettings", clientSettings, errors);
+      if (settings != null) {
+        Boolean proofKey =
+            checkRequiredBooleanSetting(
+                settings, ConfigurationSettingNames.Client.REQUIRE_PROOF_KEY, errors);
+        checkRequiredBooleanSetting(
+            settings, ConfigurationSettingNames.Client.REQUIRE_AUTHORIZATION_CONSENT, errors);
+        if (Boolean.FALSE.equals(proofKey)) {
+          log.warn(
+              "OAuth2 client '{}' explicitly opts out of PKCE (require-proof-key=false). This is a"
+                  + " temporary escape hatch for legacy integrations; new authorization-code"
+                  + " clients should use S256 PKCE.",
+              entity.getClientId());
+        }
+      }
+    }
+    String tokenSettings = entity.getTokenSettings();
+    if (tokenSettings != null && !tokenSettings.isBlank()) {
+      tryParseSettings("tokenSettings", tokenSettings, errors);
+    }
+  }
+
+  /**
+   * Parse a settings JSON string with the same mapper {@link #toObject} uses at read time; reports
+   * an {@link ErrorCode#E4000} and returns {@code null} when unreadable.
+   */
+  @CheckForNull
+  private Map<String, Object> tryParseSettings(
+      String field, String json, Consumer<ErrorReport> errors) {
+    try {
+      return this.objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+    } catch (Exception ex) {
+      errors.accept(
+          new ErrorReport(
+              Dhis2OAuth2Client.class,
+              ErrorCode.E4000,
+              "Invalid " + field + " JSON: " + ex.getMessage()));
+      return null;
+    }
+  }
+
+  /**
+   * Require the given settings key to be present and boolean; reports an error and returns {@code
+   * null} otherwise.
+   */
+  @CheckForNull
+  private static Boolean checkRequiredBooleanSetting(
+      Map<String, Object> settings, String key, Consumer<ErrorReport> errors) {
+    if (settings.get(key) instanceof Boolean value) {
+      return value;
+    }
+    errors.accept(
+        new ErrorReport(
+            Dhis2OAuth2Client.class,
+            ErrorCode.E4000,
+            "Invalid clientSettings: setting '" + key + "' must be present and a boolean."));
+    return null;
+  }
+
+  /**
+   * Redirect URI allow-list: http and https are always accepted; any other URI (e.g. a custom
+   * scheme like {@code dhis2oauth://oauth}) must match verbatim an entry in the {@code
+   * deviceEnrollmentRedirectAllowlist} system setting. Default-to-deny closes the stored-XSS and
+   * token-exfiltration surface that Spring Authorization Server leaves open when it emits the
+   * {@code Location} header without scheme filtering.
    */
   private void validateRedirectUris(Dhis2OAuth2Client entity, Consumer<ErrorReport> errors) {
     if (entity.getRedirectUris() == null) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
@@ -514,9 +514,9 @@ public class Dhis2OAuth2ClientServiceImpl
    * uses, and must carry both {@code settings.client.require-proof-key} and {@code
    * settings.client.require-authorization-consent} as booleans — Spring AS unboxes these on every
    * authorize call, so a partial map would NPE at runtime. {@code
-   * settings.client.require-proof-key} must be {@code true} for {@code authorization_code}
-   * clients; disabling PKCE is rejected. {@code client_credentials} clients (the DCR system
-   * registrar) are not subject to this check.
+   * settings.client.require-proof-key} must be {@code true} for {@code authorization_code} clients;
+   * disabling PKCE is rejected. {@code client_credentials} clients (the DCR system registrar) are
+   * not subject to this check.
    */
   private void validateSettings(Dhis2OAuth2Client entity, Consumer<ErrorReport> errors) {
     String clientSettings = entity.getClientSettings();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
@@ -514,7 +514,9 @@ public class Dhis2OAuth2ClientServiceImpl
    * uses, and must carry both {@code settings.client.require-proof-key} and {@code
    * settings.client.require-authorization-consent} as booleans — Spring AS unboxes these on every
    * authorize call, so a partial map would NPE at runtime. {@code
-   * settings.client.require-proof-key} must be {@code true}; disabling PKCE is rejected.
+   * settings.client.require-proof-key} must be {@code true} for {@code authorization_code}
+   * clients; disabling PKCE is rejected. {@code client_credentials} clients (the DCR system
+   * registrar) are not subject to this check.
    */
   private void validateSettings(Dhis2OAuth2Client entity, Consumer<ErrorReport> errors) {
     String clientSettings = entity.getClientSettings();
@@ -526,7 +528,12 @@ public class Dhis2OAuth2ClientServiceImpl
                 settings, ConfigurationSettingNames.Client.REQUIRE_PROOF_KEY, errors);
         checkRequiredBooleanSetting(
             settings, ConfigurationSettingNames.Client.REQUIRE_AUTHORIZATION_CONSENT, errors);
-        if (Boolean.FALSE.equals(proofKey)) {
+        // PKCE applies to the authorization_code grant only. The DCR system registrar is
+        // client_credentials and is created with the SAS builder default (false on SAS 1.x);
+        // a full metadata export/import must be able to re-import it.
+        if (Boolean.FALSE.equals(proofKey)
+            && getAuthorizationGrantTypesSet(entity)
+                .contains(AuthorizationGrantType.AUTHORIZATION_CODE)) {
           errors.accept(
               new ErrorReport(
                   Dhis2OAuth2Client.class,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/dcr/OAuth2DcrService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/dcr/OAuth2DcrService.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.security.oauth2.dcr;
 
+import static org.hisp.dhis.security.oauth2.OAuth2Constants.SCOPE_CLIENT_CREATE;
 import static org.hisp.dhis.security.oauth2.OAuth2Constants.SYSTEM_REGISTRAR_CLIENTID;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -133,7 +134,7 @@ public class OAuth2DcrService {
                           .filter(trimmed -> !trimmed.isEmpty())
                           .forEach(l::add))
               .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
-              .scope("client.create")
+              .scope(SCOPE_CLIENT_CREATE)
               .build();
       oAuth2ClientService.save(registeredClient, new SystemUser());
     } else {
@@ -190,7 +191,7 @@ public class OAuth2DcrService {
             .expiresAt(ttlInSeconds)
             .subject(username)
             .id(UUID.randomUUID().toString()) // (jti) Unique token ID
-            .claim("scope", "client.create")
+            .claim("scope", SCOPE_CLIENT_CREATE)
             .claim("redirect_url", redirectUri)
             .build();
 
@@ -206,7 +207,7 @@ public class OAuth2DcrService {
             jwtEncodedToken,
             now,
             ttlInSeconds,
-            Set.of("client.create"));
+            Set.of(SCOPE_CLIENT_CREATE));
 
     // Persist the authorization so that it can be used for authentication/authorization
     OAuth2Authorization authorization =

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/BaseE2ETest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/BaseE2ETest.java
@@ -248,7 +248,7 @@ public class BaseE2ETest {
     }
   }
 
-  public String callTokenEndpoint(String code) {
+  public String callTokenEndpoint(String code, String codeVerifier) {
     RestTemplate restTemplate = getRestTemplateNoRedirects();
     String apiUrl = serverHostUrl + "/oauth2/token";
     HttpHeaders headers = new HttpHeaders();
@@ -260,6 +260,9 @@ public class BaseE2ETest {
     formData.add("client_secret", "secret");
     formData.add("grant_type", "authorization_code");
     formData.add("redirect_uri", "http://localhost:9090/oauth2/code/dhis2-client");
+    if (codeVerifier != null) {
+      formData.add("code_verifier", codeVerifier);
+    }
 
     HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(formData, headers);
     ResponseEntity<String> response =

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/oauth2/OAuth2Test.java
@@ -40,8 +40,13 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.text.ParseException;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -73,11 +78,32 @@ class OAuth2Test extends BaseE2ETest {
 
   private static final String REDIRECT_URI = "http://localhost:9090/oauth2/code/dhis2-client";
 
-  private static final String AUTHORIZE_PARAMS =
-      "/oauth2/authorize?response_type=code&client_id=dhis2-client"
-          + "&redirect_uri="
-          + REDIRECT_URI
-          + "&scope=openid%20email";
+  private static final String CODE_VERIFIER;
+  private static final String CODE_CHALLENGE;
+  private static final String AUTHORIZE_PARAMS;
+
+  static {
+    byte[] verifierBytes = new byte[32];
+    new SecureRandom().nextBytes(verifierBytes);
+    CODE_VERIFIER = Base64.getUrlEncoder().withoutPadding().encodeToString(verifierBytes);
+
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] challengeBytes = digest.digest(CODE_VERIFIER.getBytes(StandardCharsets.US_ASCII));
+      CODE_CHALLENGE = Base64.getUrlEncoder().withoutPadding().encodeToString(challengeBytes);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+
+    AUTHORIZE_PARAMS =
+        "/oauth2/authorize?response_type=code&client_id=dhis2-client"
+            + "&redirect_uri="
+            + REDIRECT_URI
+            + "&scope=openid%20email"
+            + "&code_challenge="
+            + CODE_CHALLENGE
+            + "&code_challenge_method=S256";
+  }
 
   private WebDriver driver;
 
@@ -123,7 +149,7 @@ class OAuth2Test extends BaseE2ETest {
             "authorizationGrantTypes", "refresh_token,authorization_code",
             "redirectUris", REDIRECT_URI,
             "postLogoutRedirectUris", "http://127.0.0.1:8080/",
-            "scopes", "email_verified,openid,profile,email");
+            "scopes", "openid,profile,email");
 
     // Create client
     ResponseEntity<String> response = postAsAdmin(serverApiUrl + "/oAuth2Clients", clientMap);
@@ -388,7 +414,7 @@ class OAuth2Test extends BaseE2ETest {
   }
 
   public String getAccessToken(String code) throws JsonProcessingException {
-    String body = callTokenEndpoint(code);
+    String body = callTokenEndpoint(code, CODE_VERIFIER);
     assertNotNull(body, "Token endpoint returned null body");
     log.info("[getAccessToken] token endpoint response body: {}", body);
     JsonNode jsonNode = objectMapper.readTree(body);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceIntegrationTest.java
@@ -30,13 +30,17 @@
 package org.hisp.dhis.security.oauth2.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -266,6 +270,73 @@ public class Dhis2OAuth2ClientServiceIntegrationTest extends PostgresIntegration
     ClientSettings clientSettings = foundClient.getClientSettings();
 
     assertTrue(clientSettings.isRequireAuthorizationConsent());
+  }
+
+  @Test
+  void testApplyCreateDefaultsRequiresProofKeyAndConsent() {
+    // Given: an entity without clientSettings/tokenSettings (see testEntityToDomainConversion
+    // for the entity-construction pattern).
+    Dhis2OAuth2Client entity = new Dhis2OAuth2Client();
+    entity.setUid(CodeGenerator.generateUid());
+    entity.setName("Defaults Client");
+    entity.setClientId("defaults-client-" + UUID.randomUUID());
+    entity.setClientSecret("defaults-secret");
+    entity.setClientAuthenticationMethods(
+        ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue());
+    entity.setAuthorizationGrantTypes(AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
+    entity.setRedirectUris("https://defaults.example.com/callback");
+    entity.setScopes("openid");
+
+    // When: applyCreateDefaults fills in clientSettings since none was supplied.
+    clientRepository.applyCreateDefaults(entity);
+
+    // Then: PR-H removed the temporary requireProofKey(false) bridge -- both PKCE and consent
+    // must default to true.
+    ClientSettings clientSettings = clientRepository.toObject(entity).getClientSettings();
+    assertTrue(clientSettings.isRequireProofKey());
+    assertTrue(clientSettings.isRequireAuthorizationConsent());
+  }
+
+  @Test
+  void testValidateCreateRejectsReservedScope() {
+    Dhis2OAuth2Client entity = new Dhis2OAuth2Client();
+    entity.setUid(CodeGenerator.generateUid());
+    entity.setName("Reserved Scope Client");
+    entity.setClientId("reserved-scope-client-" + UUID.randomUUID());
+    entity.setClientSecret("secret");
+    entity.setClientAuthenticationMethods(
+        ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue());
+    entity.setAuthorizationGrantTypes(AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
+    entity.setRedirectUris("https://reserved.example.com/callback");
+    entity.setScopes("client.create");
+
+    List<ErrorReport> errors = new ArrayList<>();
+    clientRepository.validateCreate(entity, errors::add);
+
+    assertFalse(errors.isEmpty());
+    assertTrue(
+        errors.stream().anyMatch(e -> e.getMessage().contains("reserved")),
+        "Expected a reserved-scope error, got: " + errors);
+  }
+
+  @Test
+  void testValidateCreateRejectsMalformedClientSettings() {
+    Dhis2OAuth2Client entity = new Dhis2OAuth2Client();
+    entity.setUid(CodeGenerator.generateUid());
+    entity.setName("Malformed Settings Client");
+    entity.setClientId("malformed-settings-client-" + UUID.randomUUID());
+    entity.setClientSecret("secret");
+    entity.setClientAuthenticationMethods(
+        ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue());
+    entity.setAuthorizationGrantTypes(AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
+    entity.setRedirectUris("https://malformed.example.com/callback");
+    entity.setScopes("openid");
+    entity.setClientSettings("{not json");
+
+    List<ErrorReport> errors = new ArrayList<>();
+    clientRepository.validateCreate(entity, errors::add);
+
+    assertFalse(errors.isEmpty());
   }
 
   /** Creates a test client with basic attributes for testing. */

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
@@ -158,8 +158,16 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
     assertNull(client.getClientSecret());
     // DCR-registered clients are first-party (Android) and must not require consent
     assertEquals(false, clientSettings.isRequireAuthorizationConsent());
+    // DCR auth-code clients require S256 PKCE by default (PR-H)
+    assertTrue(clientSettings.isRequireProofKey());
+    // Default scopes assigned by the server when registration omits scopes: openid, profile,
+    // username (email is intentionally excluded, see OAuth2Constants.DCR_DEFAULT_SCOPES)
+    assertEquals(Set.of("openid", "profile", "username"), client.getScopes());
 
     // When calling token endpoint with private_key_jwt authentication
+    // Uses grant_type=client_credentials with scope "openid profile username" as a secondary
+    // fixture; PKCE does not apply to the client_credentials grant. The auth-code + PKCE path
+    // is covered by OAuth2PkceEnforcementTest.
     String tokenResponse = callTokenEndpoint(keyPair, clientId);
     String accessToken = JsonValue.of(tokenResponse).asObject().getString("access_token").string();
     assertNotNull(accessToken);
@@ -172,6 +180,29 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
             .getResponse()
             .getContentAsString();
     assertNotNull(usersResp);
+  }
+
+  @Test
+  @DisplayName("Test DCR-registered client default scopes exclude email")
+  void testDcrRegisteredClientDefaultScopesExcludeEmail() throws Exception {
+    // Given an initial access token (iat)
+    String initialAccessToken = createClientAndIat();
+
+    // Given a key pair to be used for the client's private_key_jwt authentication
+    KeyPair keyPair = createKeys();
+
+    // When registering a client without specifying scopes
+    String clientId = doClientRegistrationRequest(initialAccessToken, keyPair);
+    RegisteredClient client = oAuth2ClientService.findByClientId(clientId);
+    assertNotNull(client);
+
+    // Then the server-assigned default scopes are exactly openid, profile, username
+    assertTrue(client.getScopes().contains("openid"));
+    assertTrue(client.getScopes().contains("profile"));
+    assertTrue(client.getScopes().contains("username"));
+    assertFalse(
+        client.getScopes().contains("email"),
+        "DCR default scopes must not include email (PR-H, OAuth2Constants.DCR_DEFAULT_SCOPES)");
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/FederatedOidcTokenControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/FederatedOidcTokenControllerTest.java
@@ -38,6 +38,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -63,6 +65,7 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
 import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -125,7 +128,9 @@ class FederatedOidcTokenControllerTest extends ControllerWithJwtTokenAuthTestBas
     OAuth2AuthenticationToken oidcAuthentication =
         new OAuth2AuthenticationToken(oidcPrincipal, oidcPrincipal.getAuthorities(), "google");
 
-    // And: a confidential authorization_code client (the native app's server-side equivalent).
+    // And: a confidential authorization_code client. SAS 7's ClientSettings builder default is
+    // requireProofKey(true), so this client now REQUIRES S256 PKCE on the authorization_code
+    // grant (no explicit clientSettings() override).
     String clientId = "federated-test-client";
     String clientSecret = "federated-secret";
     String redirectUri = "https://app.example.org/callback";
@@ -143,6 +148,10 @@ class FederatedOidcTokenControllerTest extends ControllerWithJwtTokenAuthTestBas
             .build();
     oAuth2ClientService.save(client);
 
+    // And: the S256 PKCE pair the client would have generated for /oauth2/authorize.
+    String codeVerifier = generateCodeVerifier();
+    String codeChallenge = generateCodeChallenge(codeVerifier);
+
     // And: the authorization the /oauth2/authorize step would have stored after the OIDC login.
     String issuer = authorizationServerSettings.getIssuer();
     String codeValue = "fed-code-value";
@@ -155,6 +164,12 @@ class FederatedOidcTokenControllerTest extends ControllerWithJwtTokenAuthTestBas
             .redirectUri(redirectUri)
             .scopes(Set.of("openid", "profile", "username", "email"))
             .state("state-0001")
+            .additionalParameters(
+                Map.of(
+                    PkceParameterNames.CODE_CHALLENGE,
+                    codeChallenge,
+                    PkceParameterNames.CODE_CHALLENGE_METHOD,
+                    "S256"))
             .build();
     OAuth2Authorization authorization =
         OAuth2Authorization.withRegisteredClient(client)
@@ -179,7 +194,8 @@ class FederatedOidcTokenControllerTest extends ControllerWithJwtTokenAuthTestBas
                     .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                     .param("grant_type", "authorization_code")
                     .param("code", codeValue)
-                    .param("redirect_uri", redirectUri))
+                    .param("redirect_uri", redirectUri)
+                    .param(PkceParameterNames.CODE_VERIFIER, codeVerifier))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.access_token").exists())
             .andReturn()
@@ -206,5 +222,17 @@ class FederatedOidcTokenControllerTest extends ControllerWithJwtTokenAuthTestBas
     mvc.perform(get("/api/me").header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.username").value(user.getUsername()));
+  }
+
+  /** Fixed S256 PKCE code_verifier: 43 chars from the RFC 7636 unreserved set (deterministic). */
+  private static String generateCodeVerifier() {
+    return "0123456789abcdefghijklmnopqrstuvwxyzABCDEF-";
+  }
+
+  /** Derives the S256 code_challenge: Base64URL-no-padding of SHA-256(verifier ASCII bytes). */
+  private static String generateCodeChallenge(String codeVerifier) throws NoSuchAlgorithmException {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    byte[] hash = digest.digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2ClientControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2ClientControllerTest.java
@@ -31,6 +31,8 @@ package org.hisp.dhis.webapi.controller.security;
 
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -42,6 +44,7 @@ import org.hisp.dhis.security.oauth2.client.Dhis2OAuth2ClientService;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -444,6 +447,139 @@ class OAuth2ClientControllerTest extends H2ControllerIntegrationTestBase {
     JsonObject client = GET("/oAuth2Clients/{id}", uid).content(HttpStatus.OK);
     assertEquals("client-no-name", client.getString("name").string());
     assertEquals("client-no-name", client.getString("clientId").string());
+  }
+
+  @Test
+  void testRejectsReservedScopeOnCreate() {
+    // Reserved client.* scopes (e.g. client.create) authorize DCR self-registration via
+    // /connect/register and must never be assignable through the admin CRUD path.
+    assertStatus(
+        HttpStatus.CONFLICT,
+        POST(
+            "/oAuth2Clients",
+            "{"
+                + "'clientId':'client-reserved-scope',"
+                + "'clientSecret':'secret',"
+                + "'clientAuthenticationMethods':'client_secret_basic',"
+                + "'authorizationGrantTypes':'authorization_code',"
+                + "'redirectUris':'https://example.com/callback',"
+                + "'scopes':'client.create'"
+                + "}"));
+  }
+
+  @Test
+  void testRejectsUnknownScopeOnCreate() {
+    assertStatus(
+        HttpStatus.CONFLICT,
+        POST(
+            "/oAuth2Clients",
+            "{"
+                + "'clientId':'client-unknown-scope',"
+                + "'clientSecret':'secret',"
+                + "'clientAuthenticationMethods':'client_secret_basic',"
+                + "'authorizationGrantTypes':'authorization_code',"
+                + "'redirectUris':'https://example.com/callback',"
+                + "'scopes':'openid,evil'"
+                + "}"));
+  }
+
+  @Test
+  void testAcceptsAllowedScopes() {
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/oAuth2Clients",
+            "{"
+                + "'clientId':'client-allowed-scopes',"
+                + "'clientSecret':'secret',"
+                + "'clientAuthenticationMethods':'client_secret_basic',"
+                + "'authorizationGrantTypes':'authorization_code',"
+                + "'redirectUris':'https://example.com/callback',"
+                + "'scopes':'openid,profile,username'"
+                + "}"));
+  }
+
+  @Test
+  void testRejectsMalformedClientSettingsJson() {
+    assertStatus(
+        HttpStatus.CONFLICT,
+        POST(
+            "/oAuth2Clients",
+            "{"
+                + "'clientId':'client-bad-settings-json',"
+                + "'clientSecret':'secret',"
+                + "'clientAuthenticationMethods':'client_secret_basic',"
+                + "'authorizationGrantTypes':'authorization_code',"
+                + "'redirectUris':'https://example.com/callback',"
+                + "'scopes':'openid',"
+                + "'clientSettings':'{not json'"
+                + "}"));
+  }
+
+  @Test
+  void testRejectsClientSettingsMissingRequiredKeys() {
+    // Parses fine (carries the @class wrapper the service's security-configured ObjectMapper
+    // requires for Spring Security's polymorphic Collections$UnmodifiableMap deserialization)
+    // but omits both required boolean keys (require-proof-key, require-authorization-consent).
+    String body =
+        """
+        {
+          "clientId":"client-settings-missing-keys",
+          "clientSecret":"secret",
+          "clientAuthenticationMethods":"client_secret_basic",
+          "authorizationGrantTypes":"authorization_code",
+          "redirectUris":"https://example.com/callback",
+          "scopes":"openid",
+          "clientSettings":"{\\"@class\\":\\"java.util.Collections$UnmodifiableMap\\",\\"settings.client.foo\\":true}"
+        }
+        """;
+    assertStatus(HttpStatus.CONFLICT, POST("/oAuth2Clients", body));
+  }
+
+  @Test
+  void testCreateWithoutSettingsDefaultsToPkceAndConsent() {
+    // F3: creating a client without clientSettings must default to requiring S256 PKCE and
+    // consent (PR-H) — the temporary requireProofKey(false) bridge is gone.
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/oAuth2Clients",
+            "{"
+                + "'clientId':'client-default-settings',"
+                + "'clientSecret':'secret',"
+                + "'clientAuthenticationMethods':'client_secret_basic',"
+                + "'authorizationGrantTypes':'authorization_code',"
+                + "'redirectUris':'https://example.com/callback',"
+                + "'scopes':'openid'"
+                + "}"));
+
+    RegisteredClient registeredClient = clientService.findByClientId("client-default-settings");
+    assertNotNull(registeredClient);
+    assertTrue(registeredClient.getClientSettings().isRequireProofKey());
+    assertTrue(registeredClient.getClientSettings().isRequireAuthorizationConsent());
+  }
+
+  @Test
+  void testExplicitProofKeyOptOutStillAccepted() {
+    // require-proof-key:false remains a supported, logged opt-out for legacy integrations.
+    String body =
+        """
+        {
+          "clientId":"client-proof-key-optout",
+          "clientSecret":"secret",
+          "clientAuthenticationMethods":"client_secret_basic",
+          "authorizationGrantTypes":"authorization_code",
+          "redirectUris":"https://example.com/callback",
+          "scopes":"openid",
+          "clientSettings":"{\\"@class\\":\\"java.util.Collections$UnmodifiableMap\\",\\"settings.client.require-proof-key\\":false,\\"settings.client.require-authorization-consent\\":true}"
+        }
+        """;
+    assertStatus(HttpStatus.CREATED, POST("/oAuth2Clients", body));
+
+    RegisteredClient registeredClient = clientService.findByClientId("client-proof-key-optout");
+    assertNotNull(registeredClient);
+    assertFalse(registeredClient.getClientSettings().isRequireProofKey());
+    assertTrue(registeredClient.getClientSettings().isRequireAuthorizationConsent());
   }
 
   private String createClient(String clientId, String name) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2ClientControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2ClientControllerTest.java
@@ -31,7 +31,6 @@ package org.hisp.dhis.webapi.controller.security;
 
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -560,8 +559,7 @@ class OAuth2ClientControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
-  void testExplicitProofKeyOptOutStillAccepted() {
-    // require-proof-key:false remains a supported, logged opt-out for legacy integrations.
+  void testExplicitProofKeyOptOutRejected() {
     String body =
         """
         {
@@ -574,12 +572,7 @@ class OAuth2ClientControllerTest extends H2ControllerIntegrationTestBase {
           "clientSettings":"{\\"@class\\":\\"java.util.Collections$UnmodifiableMap\\",\\"settings.client.require-proof-key\\":false,\\"settings.client.require-authorization-consent\\":true}"
         }
         """;
-    assertStatus(HttpStatus.CREATED, POST("/oAuth2Clients", body));
-
-    RegisteredClient registeredClient = clientService.findByClientId("client-proof-key-optout");
-    assertNotNull(registeredClient);
-    assertFalse(registeredClient.getClientSettings().isRequireProofKey());
-    assertTrue(registeredClient.getClientSettings().isRequireAuthorizationConsent());
+    assertStatus(HttpStatus.CONFLICT, POST("/oAuth2Clients", body));
   }
 
   private String createClient(String clientId, String name) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2PkceEnforcementTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2PkceEnforcementTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.security;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Set;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.security.oauth2.authorization.Dhis2OAuth2AuthorizationService;
+import org.hisp.dhis.security.oauth2.client.Dhis2OAuth2ClientService;
+import org.hisp.dhis.test.webapi.ControllerWithJwtTokenAuthTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationCode;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Locks in the PKCE-by-default guarantee at {@code /oauth2/token}: since Spring Authorization
+ * Server 7's {@code ClientSettings.builder()} itself now defaults {@code requireProofKey(true)}
+ * (the DHIS2-side {@code requireProofKey(false)} bridge in {@code Dhis2OAuth2ClientServiceImpl} is
+ * gone), any {@link RegisteredClient} built without an explicit {@code clientSettings(...)}
+ * override REQUIRES S256 PKCE on the authorization_code grant.
+ *
+ * <p>Findings from decompiling {@code spring-security-oauth2-authorization-server-7.0.6.jar} and
+ * {@code spring-security-oauth2-core-7.0.6.jar} (neither module has an attached sources jar in this
+ * local repository; verified with {@code javap -p -c -s} against {@code CodeVerifierAuthenticator},
+ * {@code ClientSecretAuthenticationProvider}, {@code PublicClientAuthenticationProvider} and {@code
+ * ClientSettings}):
+ *
+ * <ul>
+ *   <li>{@code ClientSettings.builder()} itself calls {@code requireProofKey(true)} (and {@code
+ *       requireAuthorizationConsent(false)}) before returning, and {@code
+ *       RegisteredClient.Builder.build()} substitutes {@code ClientSettings.builder().build()}
+ *       whenever {@code clientSettings(...)} was never called. So simply omitting the {@code
+ *       clientSettings(...)} call - as this test does - is enough to require PKCE; no explicit
+ *       {@code requireProofKey(true)} needs to be set.
+ *   <li>{@code CodeVerifierAuthenticator.authenticate(...)} reads {@code code_challenge} from the
+ *       <em>stored</em> {@link OAuth2AuthorizationRequest}'s additional parameters (looked up via
+ *       {@code authorizationService.findByToken(code, "code")}) and {@code code_verifier} from the
+ *       incoming token request. If {@code code_challenge} is blank AND the client's {@code
+ *       requireProofKey} is {@code true}, it throws {@code invalid_grant} UNCONDITIONALLY - even if
+ *       no {@code code_verifier} was sent either. In other words: SAS 7 enforces {@code
+ *       requireProofKey} at the {@code /oauth2/token} authorization_code exchange itself (not only
+ *       by refusing to hand out a code at {@code /oauth2/authorize}), so a code stored without a
+ *       challenge for a PKCE-required client can never be redeemed.
+ *   <li>When {@code code_challenge} is present, {@code codeVerifierValid(...)} recomputes {@code
+ *       Base64Url-no-padding(SHA-256(code_verifier))} for method {@code S256} and compares it
+ *       against the stored challenge; a missing or mismatching {@code code_verifier} throws {@code
+ *       invalid_grant} the same way. Non-{@code S256} methods always fail (no {@code plain}
+ *       support).
+ *   <li>{@code ClientSecretAuthenticationProvider} (confidential clients, e.g. {@code
+ *       client_secret_basic} - what this test uses) calls {@code
+ *       codeVerifierAuthenticator.authenticateIfAvailable(...)}, while {@code
+ *       PublicClientAuthenticationProvider} (public, secret-less clients) calls {@code
+ *       authenticateRequired(...)}. Both wrappers delegate to the same private {@code
+ *       authenticate(...)} method, which throws internally whenever {@code requireProofKey} is
+ *       {@code true} and the challenge/verifier pair does not check out - so a confidential client
+ *       with {@code requireProofKey(true)} is enforced just as strictly as a public one. The {@code
+ *       Required}/{@code IfAvailable} distinction only matters for the silent-skip case (blank
+ *       challenge AND {@code requireProofKey=false}), which none of these tests exercise.
+ * </ul>
+ *
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@ActiveProfiles("oauth2-authorization-server-test")
+class OAuth2PkceEnforcementTest extends ControllerWithJwtTokenAuthTestBase {
+
+  @Autowired private Dhis2OAuth2ClientService oAuth2ClientService;
+  @Autowired private Dhis2OAuth2AuthorizationService authorizationService;
+  @Autowired private AuthorizationServerSettings authorizationServerSettings;
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  @Test
+  @DisplayName(
+      "PKCE-required client: token exchange without a code_verifier fails with invalid_grant")
+  void tokenExchangeWithoutVerifierFailsForPkceRequiredClient() throws Exception {
+    // Given: a client with requireProofKey=true and a stored authorization whose
+    // authorization request carries a code_challenge.
+    String codeVerifier = generateCodeVerifier();
+    String codeChallenge = generateCodeChallenge(codeVerifier);
+    Fixture fixture = registerClientAndAuthorization(codeChallenge);
+
+    // When: the client exchanges the code without sending a code_verifier at all.
+    // Then: CodeVerifierAuthenticator.codeVerifierValid(...) sees a blank verifier and fails.
+    mvc.perform(tokenRequest(fixture, null))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("invalid_grant"));
+  }
+
+  @Test
+  @DisplayName(
+      "PKCE-required client: token exchange with a wrong code_verifier fails with invalid_grant")
+  void tokenExchangeWithWrongVerifierFails() throws Exception {
+    // Given: same PKCE-required client/authorization setup as above.
+    String codeVerifier = generateCodeVerifier();
+    String codeChallenge = generateCodeChallenge(codeVerifier);
+    Fixture fixture = registerClientAndAuthorization(codeChallenge);
+
+    // When: the client sends a code_verifier that does not hash to the stored code_challenge.
+    // Then: the SHA-256(verifier) vs. code_challenge comparison fails.
+    mvc.perform(tokenRequest(fixture, "wrong-" + codeVerifier))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("invalid_grant"));
+  }
+
+  @Test
+  @DisplayName(
+      "PKCE-required client: token exchange for a code stored without a code_challenge fails"
+          + " with invalid_grant, even without a code_verifier")
+  void authorizationWithoutChallengeFailsForPkceRequiredClient() throws Exception {
+    // Given: the stored authorization request carries NO code_challenge/code_challenge_method at
+    // all (as if /oauth2/authorize had been reached by a legacy caller that never sent one).
+    Fixture fixture = registerClientAndAuthorization(null);
+
+    // When: the client exchanges the code without a code_verifier.
+    // Then: CodeVerifierAuthenticator rejects it - a blank code_challenge with
+    // requireProofKey=true throws invalid_grant unconditionally; SAS enforces requireProofKey
+    // at /oauth2/token itself for the authorization_code grant, not only by withholding the
+    // code at /oauth2/authorize.
+    mvc.perform(tokenRequest(fixture, null))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("invalid_grant"));
+  }
+
+  /** Fixture data for a single token-exchange attempt. */
+  private record Fixture(String clientId, String clientSecret, String redirectUri, String code) {}
+
+  /**
+   * Registers a confidential authorization_code client with {@code requireProofKey(true)} set
+   * explicitly (the SAS 1.x builder default is {@code false}), and stores an authorization for it
+   * carrying an authorization code and the given {@code codeChallenge} (or no challenge at all when
+   * {@code codeChallenge} is {@code null}).
+   */
+  private Fixture registerClientAndAuthorization(String codeChallenge) {
+    String suffix = CodeGenerator.generateUid();
+    String clientId = "pkce-test-client-" + suffix;
+    String clientSecret = "pkce-test-secret";
+    String redirectUri = "https://app.example.org/callback";
+    RegisteredClient client =
+        RegisteredClient.withId(CodeGenerator.generateUid())
+            .clientId(clientId)
+            .clientSecret(passwordEncoder.encode(clientSecret))
+            .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri(redirectUri)
+            .scope("openid")
+            // SAS 1.x's ClientSettings.builder() default is requireProofKey(false) (unlike
+            // SAS 7), so PKCE is required explicitly here. DHIS2's admin/DCR create paths set
+            // this flag for new clients; this fixture persists directly via the repository.
+            .clientSettings(ClientSettings.builder().requireProofKey(true).build())
+            .build();
+    oAuth2ClientService.save(client);
+
+    Instant now = Instant.now();
+    String codeValue = "pkce-code-" + suffix;
+    OAuth2AuthorizationCode authorizationCode =
+        new OAuth2AuthorizationCode(codeValue, now, now.plus(5, ChronoUnit.MINUTES));
+
+    OAuth2AuthorizationRequest.Builder authorizationRequestBuilder =
+        OAuth2AuthorizationRequest.authorizationCode()
+            .authorizationUri(authorizationServerSettings.getIssuer() + "oauth2/authorize")
+            .clientId(clientId)
+            .redirectUri(redirectUri)
+            .scopes(Set.of("openid"))
+            .state("state-" + suffix);
+    if (codeChallenge != null) {
+      authorizationRequestBuilder.additionalParameters(
+          Map.of(
+              PkceParameterNames.CODE_CHALLENGE,
+              codeChallenge,
+              PkceParameterNames.CODE_CHALLENGE_METHOD,
+              "S256"));
+    }
+    OAuth2AuthorizationRequest authorizationRequest = authorizationRequestBuilder.build();
+
+    OAuth2Authorization authorization =
+        OAuth2Authorization.withRegisteredClient(client)
+            .id(CodeGenerator.generateUid())
+            .principalName("pkce-test-user")
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .authorizedScopes(Set.of("openid"))
+            .token(authorizationCode)
+            .attribute(OAuth2AuthorizationRequest.class.getName(), authorizationRequest)
+            .build();
+    authorizationService.save(authorization);
+
+    return new Fixture(clientId, clientSecret, redirectUri, codeValue);
+  }
+
+  /**
+   * Builds the {@code /oauth2/token} POST for the given fixture. {@code codeVerifier} is omitted
+   * from the request entirely when {@code null} (as opposed to sent empty).
+   */
+  private MockHttpServletRequestBuilder tokenRequest(Fixture fixture, String codeVerifier) {
+    String basicAuth =
+        Base64.getEncoder()
+            .encodeToString(
+                (fixture.clientId() + ":" + fixture.clientSecret())
+                    .getBytes(StandardCharsets.UTF_8));
+    MockHttpServletRequestBuilder request =
+        post("/oauth2/token")
+            .header(HttpHeaders.AUTHORIZATION, "Basic " + basicAuth)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .param("grant_type", "authorization_code")
+            .param("code", fixture.code())
+            .param("redirect_uri", fixture.redirectUri());
+    if (codeVerifier != null) {
+      request.param(PkceParameterNames.CODE_VERIFIER, codeVerifier);
+    }
+    return request;
+  }
+
+  /** Fixed S256 PKCE code_verifier: 43 chars from the RFC 7636 unreserved set (deterministic). */
+  private static String generateCodeVerifier() {
+    return "0123456789abcdefghijklmnopqrstuvwxyzABCDEF-";
+  }
+
+  /** Derives the S256 code_challenge: Base64URL-no-padding of SHA-256(verifier ASCII bytes). */
+  private static String generateCodeChallenge(String codeVerifier) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+      return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 must be available on any supported JVM", e);
+    }
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/InlineJwksClientMetadataConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/InlineJwksClientMetadataConfig.java
@@ -35,6 +35,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.security.oauth2.OAuth2Constants;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
@@ -81,8 +82,11 @@ final class InlineJwksClientMetadataConfig {
       // Override the SAS default of requireAuthorizationConsent(true) — DCR-registered clients
       // are first-party (e.g. Android app) authenticating with their own DHIS2 server,
       // so no end-user consent prompt is needed.
+      // requireProofKey(true) is SAS 7's builder default but is set explicitly: DCR-registered
+      // authorization-code clients (Android devices) must use S256 PKCE (PR-H).
       ClientSettings.Builder cs = ClientSettings.withSettings(rc.getClientSettings().getSettings());
       cs.requireAuthorizationConsent(false);
+      cs.requireProofKey(true);
       Map<String, Object> claims = reg.getClaims();
 
       // Accept optional "token_endpoint_auth_signing_alg": "RS256"
@@ -118,10 +122,19 @@ final class InlineJwksClientMetadataConfig {
               .reuseRefreshTokens(false)
               .build();
 
-      return RegisteredClient.from(rc)
-          .clientSettings(cs.build())
-          .tokenSettings(tokenSettings)
-          .build();
+      // Client-supplied scopes on DCR requests are overridden with the server-side first-party
+      // defaults (openid, profile, username — see OAuth2Constants.DCR_DEFAULT_SCOPES) so
+      // authorize and token requests have usable scopes. Defense-in-depth: any scopes that
+      // arrive on the registration are filtered against the allowed-client-scope set.
+      RegisteredClient.Builder builder =
+          RegisteredClient.from(rc).clientSettings(cs.build()).tokenSettings(tokenSettings);
+      if (rc.getScopes() == null || rc.getScopes().isEmpty()) {
+        OAuth2Constants.DCR_DEFAULT_SCOPES.forEach(builder::scope);
+      } else {
+        builder.scopes(
+            scopes -> scopes.removeIf(scope -> !OAuth2Constants.isAllowedClientScope(scope)));
+      }
+      return builder.build();
     }
   }
 


### PR DESCRIPTION
## Change

- New admin/metadata clients without explicit `clientSettings` default to **S256 PKCE required + consent required**. Existing DB rows keep their stored settings.
- DCR-registered clients require PKCE on the auth-code flow (consent stays off); server assigns default scopes `openid profile username` (no `email`) and filters client-supplied scopes against the allowed set.
- Reserved scopes (`client.create` / `client.*`) rejected on admin/metadata paths (E4000); allowed client scopes are `openid profile username email`.
- `clientSettings`/`tokenSettings` validated at write time; explicit `require-proof-key:false` remains a validated, WARN-logged opt-out.
- e2e auth-code flow uses S256 challenge + verifier.

## Backport notes (Spring 6 / SAS 1.x branch)

- **Dropped** the `DhisAuthorizationCodeTokenResponseClient` hardening + its test: that part is the Spring-7 RestClient rewrite and does not apply here.
- SAS 1.x does not reject `scope` on `/connect/register` like SAS 7 does; parity is at the result level, the converter overrides/filters whatever arrives.

## Release note

New OAuth2 `authorization_code` clients require S256 PKCE from this version. 

AI Assisted