### PR TITLE
feat: data integrity check for users with no organisation unit

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -91,6 +91,7 @@ checks:
   - users/users_with_invalid_usernames.yaml
   - users/users_with_all_authority.yaml
   - users/users_with_app_hub_authority.yaml
+  - users/users_with_no_organisation_units.yaml
   - file_resources/file_resources_no_icon.yaml
   - tracked_entity_attributes/tracked_entity_attributes_invalid_trigram_search_configuration.yaml
   - tracked_entity_attributes/tracked_entity_attributes_trigram_index_out_of_sync.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_with_no_organisation_units.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_with_no_organisation_units.yaml
@@ -1,0 +1,59 @@
+# Copyright (c) 2004-2026, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: users_with_no_organisation_units
+description: Users who have no data capture organisation unit assigned.
+section: Users
+section_order: 8
+summary_sql: >-
+  SELECT COUNT(*) as value,
+    100.0 * COUNT(*) / NULLIF((SELECT COUNT(*) FROM userinfo), 0) as percent
+    FROM userinfo
+    WHERE userinfoid NOT IN (SELECT DISTINCT userinfoid FROM usermembership);
+details_sql: >
+  SELECT uid,
+  username as name,
+  'disabled:' || disabled as comment
+  from userinfo
+  WHERE userinfoid NOT IN (SELECT DISTINCT userinfoid FROM usermembership);
+details_id_type: users
+severity: WARNING
+introduction: >
+  Users are ordinarily expected to have at least one data capture organisation unit assigned.
+  A user with none may be invisible to org-unit-scoped user searches (for example the
+  "assign user" pickers in the Tracker Capture and Event Capture apps, or any request using the
+  userOrgUnits/orgUnitBoundary query parameters), even to a user with the ALL authority, since
+  those searches match on a common organisation unit connection between the viewer and the
+  target user. This can happen, for example, when a user is created via the user replication
+  ("clone user") endpoint if the source user's organisation units were not correctly carried
+  over.
+recommendation: >
+  Using the list of users provided by the details query, assign at least one data capture
+  organisation unit to each affected user, or confirm the missing assignment is intentional
+  (for example a service account that is not expected to capture data). Affected users can be
+  updated directly by UID (e.g. via the API) even though they may not appear in org-unit-scoped
+  user list searches.

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -93,7 +93,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(96, checks.size());
+    assertEquals(97, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -2123,6 +2123,7 @@ data_integrity.user_roles_no_authorities.name=User roles without assigned author
 data_integrity.user_roles_with_no_users.name=User roles without assigned users
 data_integrity.file_resources_no_icon.name=File resources of type ICON that have no entry in the icon table
 data_integrity.users_with_all_authority.name=Users which have the ALL authority assigned
+data_integrity.users_with_no_organisation_units.name=Users who have no data capture organisation unit assigned.
 data_integrity.category_options_default_incorrect_sharing.name=The default category option should be publicly shared with all users
 data_integrity.tracked_entity_attributes_invalid_trigram_search_configuration.name=Tracked entity attributes having a suboptimal search configuration that potentially results in slower search performance when searching tracked entities using those attributes
 data_integrity.tracked_entity_attributes_trigram_index_out_of_sync.name=Partial trigram indexes on trackedentityattributevalue table must be in sync with the tracked entity attribute metadata configuration

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersWithNoOrganisationUnitsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersWithNoOrganisationUnitsControllerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import static org.hisp.dhis.http.HttpAssertions.assertStatus;
+
+import org.hisp.dhis.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integrity check to identify users who have no data capture organisation unit assigned. {@see
+ * dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_with_no_organisation_units.yaml}
+ */
+class DataIntegrityUsersWithNoOrganisationUnitsControllerTest
+    extends AbstractDataIntegrityIntegrationTest {
+
+  private static final String CHECK_NAME = "users_with_no_organisation_units";
+
+  private static final String DETAILS_ID_TYPE = "users";
+
+  @Test
+  void testCanIdentifyUsersWithNoOrganisationUnits() {
+    String orgunitAUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnits",
+                "{ 'name': 'Fish District', 'shortName': 'Fish District', 'openingDate' : '2022-01-01'}"));
+
+    // Ensure the baseline test user isn't itself flagged, regardless of the default test setup.
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/" + getCurrentUser().getUid(),
+            "[{'op':'add','path':'/organisationUnits','value':[{'id':'" + orgunitAUid + "'}]}]"));
+
+    String userRoleUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST("/userRoles", "{ 'name': 'Some role', 'authorities': ['F_DATAVALUE_ADD'] }"));
+
+    // A user with an org unit assigned - should not be flagged.
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/users",
+            "{ 'username': 'hasorgunit', 'password': 'District123+', 'firstName': 'Has', 'surname': 'Orgunit', 'organisationUnits' : [{'id' : '"
+                + orgunitAUid
+                + "'}], 'userRoles' : [{'id' : '"
+                + userRoleUid
+                + "'}]}"));
+
+    // A user with no org unit assigned - should be flagged.
+    String flaggedUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/users",
+                "{ 'username': 'noorgunit', 'password': 'District123+', 'firstName': 'No', 'surname': 'Orgunit', 'userRoles' : [{'id' : '"
+                    + userRoleUid
+                    + "'}]}"));
+
+    // 3 total users (baseline admin, hasorgunit, noorgunit); 1 flagged => 33%
+    assertHasDataIntegrityIssues(
+        DETAILS_ID_TYPE, CHECK_NAME, 33, flaggedUid, "noorgunit", "disabled:false", true);
+  }
+}


### PR DESCRIPTION
## Summary

Users can end up with zero rows in `usermembership` (data capture organisation units) - one
known path is the `replicateUser` bug fixed separately in #24878, but there may be other paths
producing the same state. This has a real, non-obvious consequence beyond "no capture org unit
for data entry": `HibernateUserStore.getUserQuery()`'s org-unit `LEFT JOIN` effectively behaves
as an `INNER JOIN` when `userOrgUnits=true`/`orgUnitBoundary=...` is set (filtering on the
joined-side column in the `WHERE` clause), silently excluding such users from **every**
org-unit-scoped user search - including the assign-user pickers in Tracker Capture and Event
Capture - for any viewer, including superusers with the `ALL` authority.

Confirmed live on a production instance: several real users with zero `usermembership` rows,
invisible via the assign-user search despite the searching admin having `ALL` authority.

## What this adds

`users_with_no_organisation_units` - a `WARNING`-severity data integrity check listing users
with no data capture organisation unit assigned, by UID.

**Remediation note (in the check's `recommendation` text):** affected users can be fixed via a
direct `PATCH /api/users/{uid}` even though they won't show up in the normal org-unit-scoped
search UI - confirmed that `GET`/`PATCH` by UID never goes through `getUserQuery()`'s join logic,
so it works independent of the visibility bug described above.

## Test plan

- [x] `DataIntegrityUsersWithNoOrganisationUnitsControllerTest` - creates one user with an org
      unit (not flagged) and one without (flagged), asserts the check's summary/details output.
- [x] `DataIntegrityYamlReaderTest` - count bumped to 97, i18n key added
      character-for-character matching the YAML description, acronym checked for collisions
      against all ~97 registered checks.
- [x] Both tests pass locally.