### PR TITLE
fix: custom data entry form crash on BOOLEAN field with bracketed stored value

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataentryform/DefaultDataEntryFormService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataentryform/DefaultDataEntryFormService.java
@@ -254,7 +254,7 @@ public class DefaultDataEntryFormService implements DataEntryFormService {
                 : "";
 
         if (ValueType.BOOLEAN == valueType) {
-          inputHtml = inputHtml.replaceAll(inputHtml, TAG_CLOSE);
+          inputHtml = TAG_CLOSE;
 
           appendCode += "<label>";
           appendCode +=

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataentryform/DataEntryFormServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataentryform/DataEntryFormServiceTest.java
@@ -159,7 +159,8 @@ class DataEntryFormServiceTest extends PostgresIntegrationTestBase {
 
   @Test
   void testPrepareDataEntryFormForEntryWithBooleanFieldAndBracketedStoredValue() {
-    DataElement booleanDataElement = createDataElement('Z', ValueType.BOOLEAN, AggregationType.NONE);
+    DataElement booleanDataElement =
+        createDataElement('Z', ValueType.BOOLEAN, AggregationType.NONE);
     dataElementService.addDataElement(booleanDataElement);
 
     DataSet dataSet = createDataSet('Z', periodType);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataentryform/DataEntryFormServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataentryform/DataEntryFormServiceTest.java
@@ -29,12 +29,17 @@
  */
 package org.hisp.dhis.dataentryform;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
@@ -61,6 +66,8 @@ class DataEntryFormServiceTest extends PostgresIntegrationTestBase {
   @Autowired private DataEntryFormService dataEntryFormService;
 
   @Autowired private DataElementService dataElementService;
+
+  @Autowired private CategoryService categoryService;
 
   private PeriodType periodType;
 
@@ -148,5 +155,29 @@ class DataEntryFormServiceTest extends PostgresIntegrationTestBase {
         "<table><tr><td><input id=\"1434-11-val\" style=\"width:4em;text-align:center\" title=\"\" value=\"\" /></td></tr></table>";
     String actual = dataEntryFormService.prepareDataEntryFormForSave(html);
     assertEquals(expected, actual);
+  }
+
+  @Test
+  void testPrepareDataEntryFormForEntryWithBooleanFieldAndBracketedStoredValue() {
+    DataElement booleanDataElement = createDataElement('Z', ValueType.BOOLEAN, AggregationType.NONE);
+    dataElementService.addDataElement(booleanDataElement);
+
+    DataSet dataSet = createDataSet('Z', periodType);
+    dataSet.addDataSetElement(booleanDataElement);
+
+    CategoryOptionCombo defaultOptionCombo = categoryService.getDefaultCategoryOptionCombo();
+    String inputFieldId = booleanDataElement.getUid() + "-" + defaultOptionCombo.getUid();
+
+    String html =
+        "<table><tr><td><input id=\""
+            + inputFieldId
+            + "-val\" name=\"entryfield\" title=\"Multi-grade teaching\" "
+            + "value=\"[ Multi-grade teaching ]\" /></td></tr></table>";
+    DataEntryForm dataEntryForm = createDataEntryForm('Z', html);
+    dataEntryFormService.addDataEntryForm(dataEntryForm);
+    dataSet.setDataEntryForm(dataEntryForm);
+    dataSetService.addDataSet(dataSet);
+
+    assertDoesNotThrow(() -> dataEntryFormService.prepareDataEntryFormForEntry(dataSet));
   }
 }


### PR DESCRIPTION
## Summary

- `DefaultDataEntryFormService.prepareDataEntryFormForEntry()` used the raw, unescaped `<input>` tag HTML as a **regex pattern** (`inputHtml.replaceAll(inputHtml, TAG_CLOSE)`) just to collapse it down to `"/>"` before splicing in the BOOLEAN yes/no radio markup.
- Any regex metacharacter in that tag's stored `title=`/`value=` attributes (most commonly an unescaped `[`) can throw `PatternSyntaxException`, crashing the whole custom-form render request — or silently produce the wrong result even when it doesn't throw.
- Live-validated against a real custom data entry form: a `BOOLEAN` data element whose stored template still had `value="[ ... Multi-grade ... ]"` baked in (likely from previously-rendered form output being saved back as the template) reproduced the exact crash — the hyphen in "Multi-grade" forms an invalid descending character-class range (`i-g`), which is exactly `PatternSyntaxException: Illegal character range`.
- Fix: replace the regex call with a plain assignment expressing the actual intent — reduce `inputHtml` to just `"/>"`, independent of whatever text happens to be in the tag's attributes.

## Test plan

- [x] Added `DataEntryFormServiceTest#testPrepareDataEntryFormForEntryWithBooleanFieldAndBracketedStoredValue`, which builds a custom form template matching the real-world shape (BOOLEAN data element, bracketed hyphenated `value=`/`title=`) and reproduces the exact `PatternSyntaxException` before the fix.
- [x] Verified RED: test failed with the byte-identical crash/stack trace as the field report, at the same line, before the fix.
- [x] Verified GREEN: full `DataEntryFormServiceTest` (7 tests) passes after the fix.
- [x] No other value-type branches touched; change is scoped to the single BOOLEAN-only line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)