### PR TITLE
feat: add per-table-type analytics update timestamps [DHIS2-21992]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -40,6 +40,7 @@ import java.util.function.BinaryOperator;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.analytics.AnalyticsCacheTtlMode;
 import org.hisp.dhis.analytics.AnalyticsFinancialYearStartKey;
+import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.analytics.AnalyticsWeeklyStartKey;
 import org.hisp.dhis.common.DigitGroupSeparator;
 import org.hisp.dhis.common.DisplayProperty;
@@ -379,6 +380,102 @@ public non-sealed interface SystemSettings extends Settings {
 
   default Date getLastSuccessfulLatestAnalyticsPartitionUpdate() {
     return asDate("keyLastSuccessfulLatestAnalyticsPartitionUpdate", new Date(0L));
+  }
+
+  /**
+   * Per-{@link AnalyticsTableType} counterpart of {@link
+   * #getLastSuccessfulAnalyticsTablesUpdate()}. Only registered for the table types that support a
+   * latest partition (see {@link AnalyticsTableType#isLatestPartition()}) since those are the only
+   * ones a latest-partition update ever needs to read a per-type clock for.
+   */
+  static String keyLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType type) {
+    return "keyLastSuccessfulAnalyticsTablesUpdate." + type.name();
+  }
+
+  /**
+   * Per-{@link AnalyticsTableType} counterpart of {@link
+   * #getLastSuccessfulLatestAnalyticsPartitionUpdate()}.
+   */
+  static String keyLastSuccessfulLatestAnalyticsPartitionUpdate(AnalyticsTableType type) {
+    return "keyLastSuccessfulLatestAnalyticsPartitionUpdate." + type.name();
+  }
+
+  default Date getLastSuccessfulAnalyticsTablesUpdateDataValue() {
+    return asDate(
+        keyLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType.DATA_VALUE), new Date(0L));
+  }
+
+  default Date getLastSuccessfulAnalyticsTablesUpdateCompleteness() {
+    return asDate(
+        keyLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType.COMPLETENESS), new Date(0L));
+  }
+
+  default Date getLastSuccessfulAnalyticsTablesUpdateEvent() {
+    return asDate(keyLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType.EVENT), new Date(0L));
+  }
+
+  default Date getLastSuccessfulAnalyticsTablesUpdateTrackedEntityInstanceEvents() {
+    return asDate(
+        keyLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType.TRACKED_ENTITY_INSTANCE_EVENTS),
+        new Date(0L));
+  }
+
+  default Date getLastSuccessfulLatestAnalyticsPartitionUpdateDataValue() {
+    return asDate(
+        keyLastSuccessfulLatestAnalyticsPartitionUpdate(AnalyticsTableType.DATA_VALUE),
+        new Date(0L));
+  }
+
+  default Date getLastSuccessfulLatestAnalyticsPartitionUpdateCompleteness() {
+    return asDate(
+        keyLastSuccessfulLatestAnalyticsPartitionUpdate(AnalyticsTableType.COMPLETENESS),
+        new Date(0L));
+  }
+
+  default Date getLastSuccessfulLatestAnalyticsPartitionUpdateEvent() {
+    return asDate(
+        keyLastSuccessfulLatestAnalyticsPartitionUpdate(AnalyticsTableType.EVENT), new Date(0L));
+  }
+
+  default Date getLastSuccessfulLatestAnalyticsPartitionUpdateTrackedEntityInstanceEvents() {
+    return asDate(
+        keyLastSuccessfulLatestAnalyticsPartitionUpdate(
+            AnalyticsTableType.TRACKED_ENTITY_INSTANCE_EVENTS),
+        new Date(0L));
+  }
+
+  /**
+   * Typed, per-type read access to {@link #getLastSuccessfulAnalyticsTablesUpdateDataValue()} and
+   * its siblings, dispatching on {@code type}. Not itself a registered setting (it takes an
+   * argument, so it is invisible to the reflective default-value/key discovery that {@link
+   * #keysWithDefaults()} relies on) &mdash; it only reads the already-registered per-type getters
+   * above. A type with no registered per-type key (i.e. {@link
+   * AnalyticsTableType#isLatestPartition()} is {@code false}) defaults to the epoch, same as an
+   * unset registered key would.
+   */
+  default Date getLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType type) {
+    return switch (type) {
+      case DATA_VALUE -> getLastSuccessfulAnalyticsTablesUpdateDataValue();
+      case COMPLETENESS -> getLastSuccessfulAnalyticsTablesUpdateCompleteness();
+      case EVENT -> getLastSuccessfulAnalyticsTablesUpdateEvent();
+      case TRACKED_ENTITY_INSTANCE_EVENTS ->
+          getLastSuccessfulAnalyticsTablesUpdateTrackedEntityInstanceEvents();
+      default -> new Date(0L);
+    };
+  }
+
+  /**
+   * Per-type counterpart of {@link #getLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType)}.
+   */
+  default Date getLastSuccessfulLatestAnalyticsPartitionUpdate(AnalyticsTableType type) {
+    return switch (type) {
+      case DATA_VALUE -> getLastSuccessfulLatestAnalyticsPartitionUpdateDataValue();
+      case COMPLETENESS -> getLastSuccessfulLatestAnalyticsPartitionUpdateCompleteness();
+      case EVENT -> getLastSuccessfulLatestAnalyticsPartitionUpdateEvent();
+      case TRACKED_ENTITY_INSTANCE_EVENTS ->
+          getLastSuccessfulLatestAnalyticsPartitionUpdateTrackedEntityInstanceEvents();
+      default -> new Date(0L);
+    };
   }
 
   default Date getLastSuccessfulResourceTablesUpdate() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -387,9 +387,14 @@ public non-sealed interface SystemSettings extends Settings {
    * #getLastSuccessfulAnalyticsTablesUpdate()}. Only registered for the table types that support a
    * latest partition (see {@link AnalyticsTableType#isLatestPartition()}) since those are the only
    * ones a latest-partition update ever needs to read a per-type clock for.
+   *
+   * <p>No separator character between the base key and the type suffix (deliberately not a "."): a
+   * flat settings key containing a literal "." is misread as a nested path by {@code
+   * JsonObject.get(path)}-style dot-path accessors, which would silently report an existing flat
+   * key as missing.
    */
   static String keyLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType type) {
-    return "keyLastSuccessfulAnalyticsTablesUpdate." + type.name();
+    return "keyLastSuccessfulAnalyticsTablesUpdate" + perTypeKeySuffix(type);
   }
 
   /**
@@ -397,7 +402,18 @@ public non-sealed interface SystemSettings extends Settings {
    * #getLastSuccessfulLatestAnalyticsPartitionUpdate()}.
    */
   static String keyLastSuccessfulLatestAnalyticsPartitionUpdate(AnalyticsTableType type) {
-    return "keyLastSuccessfulLatestAnalyticsPartitionUpdate." + type.name();
+    return "keyLastSuccessfulLatestAnalyticsPartitionUpdate" + perTypeKeySuffix(type);
+  }
+
+  /** Matches the corresponding per-type getter method name suffix below, e.g. {@code DataValue}. */
+  private static String perTypeKeySuffix(AnalyticsTableType type) {
+    return switch (type) {
+      case DATA_VALUE -> "DataValue";
+      case COMPLETENESS -> "Completeness";
+      case EVENT -> "Event";
+      case TRACKED_ENTITY_INSTANCE_EVENTS -> "TrackedEntityInstanceEvents";
+      default -> type.name();
+    };
   }
 
   default Date getLastSuccessfulAnalyticsTablesUpdateDataValue() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -461,37 +461,28 @@ public non-sealed interface SystemSettings extends Settings {
   }
 
   /**
-   * Typed, per-type read access to {@link #getLastSuccessfulAnalyticsTablesUpdateDataValue()} and
-   * its siblings, dispatching on {@code type}. Not itself a registered setting (it takes an
-   * argument, so it is invisible to the reflective default-value/key discovery that {@link
-   * #keysWithDefaults()} relies on) &mdash; it only reads the already-registered per-type getters
-   * above. A type with no registered per-type key (i.e. {@link
-   * AnalyticsTableType#isLatestPartition()} is {@code false}) defaults to the epoch, same as an
-   * unset registered key would.
+   * Typed, per-type read access to the same key {@link
+   * #getLastSuccessfulAnalyticsTablesUpdateDataValue()} and its siblings read, computed directly
+   * via {@link #keyLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType)} rather than dispatching
+   * to those getters. Not itself a registered setting (it takes an argument, so it is invisible to
+   * the reflective default-value/key discovery that {@link #keysWithDefaults()} relies on) &mdash;
+   * that registration still comes from the no-arg per-type getters above, which remain unchanged. A
+   * type with no registered per-type key (i.e. {@link AnalyticsTableType#isLatestPartition()} is
+   * {@code false}) defaults to the epoch, same as an unset registered key would.
    */
   default Date getLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType type) {
-    return switch (type) {
-      case DATA_VALUE -> getLastSuccessfulAnalyticsTablesUpdateDataValue();
-      case COMPLETENESS -> getLastSuccessfulAnalyticsTablesUpdateCompleteness();
-      case EVENT -> getLastSuccessfulAnalyticsTablesUpdateEvent();
-      case TRACKED_ENTITY_INSTANCE_EVENTS ->
-          getLastSuccessfulAnalyticsTablesUpdateTrackedEntityInstanceEvents();
-      default -> new Date(0L);
-    };
+    return type.isLatestPartition()
+        ? asDate(keyLastSuccessfulAnalyticsTablesUpdate(type), new Date(0L))
+        : new Date(0L);
   }
 
   /**
    * Per-type counterpart of {@link #getLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType)}.
    */
   default Date getLastSuccessfulLatestAnalyticsPartitionUpdate(AnalyticsTableType type) {
-    return switch (type) {
-      case DATA_VALUE -> getLastSuccessfulLatestAnalyticsPartitionUpdateDataValue();
-      case COMPLETENESS -> getLastSuccessfulLatestAnalyticsPartitionUpdateCompleteness();
-      case EVENT -> getLastSuccessfulLatestAnalyticsPartitionUpdateEvent();
-      case TRACKED_ENTITY_INSTANCE_EVENTS ->
-          getLastSuccessfulLatestAnalyticsPartitionUpdateTrackedEntityInstanceEvents();
-      default -> new Date(0L);
-    };
+    return type.isLatestPartition()
+        ? asDate(keyLastSuccessfulLatestAnalyticsPartitionUpdate(type), new Date(0L))
+        : new Date(0L);
   }
 
   default Date getLastSuccessfulResourceTablesUpdate() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/system/SystemInfo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/system/SystemInfo.java
@@ -31,11 +31,13 @@ package org.hisp.dhis.system;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.system.capability.SystemCapability;
 import org.hisp.dhis.system.database.DatabaseInfo;
 
@@ -71,6 +73,11 @@ public final class SystemInfo {
   @JsonProperty private final Date lastAnalyticsTablePartitionSuccess;
   @JsonProperty private final String intervalSinceLastAnalyticsTablePartitionSuccess;
   @JsonProperty private final String lastAnalyticsTablePartitionRuntime;
+  @JsonProperty private final Map<AnalyticsTableType, Date> lastAnalyticsTableSuccessByType;
+
+  @JsonProperty
+  private final Map<AnalyticsTableType, Date> lastAnalyticsTablePartitionSuccessByType;
+
   @JsonProperty private final DatabaseInfo databaseInfo;
   @JsonProperty private final SystemCapability capability;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
@@ -37,8 +37,8 @@ import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_STAGE;
 import static org.hisp.dhis.util.DateUtils.toLongDate;
 
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -126,7 +126,7 @@ public class DefaultAnalyticsTableGenerator implements AnalyticsTableGenerator {
       }
     }
 
-    Set<AnalyticsTableType> processedTypes = new LinkedHashSet<>();
+    Set<AnalyticsTableType> processedTypes = EnumSet.noneOf(AnalyticsTableType.class);
 
     for (AnalyticsTableService service : analyticsTableServices) {
       AnalyticsTableType tableType = service.getAnalyticsTableType();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
@@ -38,9 +38,11 @@ import static org.hisp.dhis.util.DateUtils.toLongDate;
 
 import java.util.Date;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -124,15 +126,18 @@ public class DefaultAnalyticsTableGenerator implements AnalyticsTableGenerator {
       }
     }
 
+    Set<AnalyticsTableType> processedTypes = new LinkedHashSet<>();
+
     for (AnalyticsTableService service : analyticsTableServices) {
       AnalyticsTableType tableType = service.getAnalyticsTableType();
       if (!skipTypes.contains(tableType)) {
         service.create(params, progress);
+        processedTypes.add(tableType);
       }
     }
 
     progress.startingStage("Updating system settings");
-    progress.runStage(() -> updateLastSuccessfulSystemSettings(params, clock));
+    progress.runStage(() -> updateLastSuccessfulSystemSettings(params, clock, processedTypes));
 
     progress.startingStage("Invalidate analytics caches", SKIP_STAGE);
     progress.runStage(analyticsCache::invalidateAll);
@@ -146,15 +151,42 @@ public class DefaultAnalyticsTableGenerator implements AnalyticsTableGenerator {
    *
    * @param params the {@link AnalyticsTableUpdateParams}.
    * @param clock the {@link Clock}.
+   * @param processedTypes the {@link AnalyticsTableType} values actually processed in this run,
+   *     i.e. not in {@link AnalyticsTableUpdateParams#getSkipTableTypes()}.
    */
-  private void updateLastSuccessfulSystemSettings(AnalyticsTableUpdateParams params, Clock clock) {
+  private void updateLastSuccessfulSystemSettings(
+      AnalyticsTableUpdateParams params, Clock clock, Set<AnalyticsTableType> processedTypes) {
     if (params.isLatestUpdate()) {
       settingsService.put("keyLastSuccessfulLatestAnalyticsPartitionUpdate", params.getStartTime());
       settingsService.put("keyLastSuccessfulLatestAnalyticsPartitionRuntime", clock.time());
+      updatePerTypeSuccessfulSystemSettings(
+          SystemSettings::keyLastSuccessfulLatestAnalyticsPartitionUpdate,
+          params.getStartTime(),
+          processedTypes);
     } else {
       settingsService.put("keyLastSuccessfulAnalyticsTablesUpdate", params.getStartTime());
       settingsService.put("keyLastSuccessfulAnalyticsTablesRuntime", clock.time());
+      updatePerTypeSuccessfulSystemSettings(
+          SystemSettings::keyLastSuccessfulAnalyticsTablesUpdate,
+          params.getStartTime(),
+          processedTypes);
     }
+  }
+
+  /**
+   * Stamps the per-{@link AnalyticsTableType} counterpart of the shared "last successful update"
+   * clock, for every processed type that has one registered (see {@link
+   * AnalyticsTableType#isLatestPartition()}). A type without a registered key is skipped rather
+   * than attempted, since {@link SystemSettingsService#put} silently drops writes for keys not in
+   * {@link SystemSettings#keysWithDefaults()}.
+   */
+  private void updatePerTypeSuccessfulSystemSettings(
+      Function<AnalyticsTableType, String> keyFunction,
+      Date startTime,
+      Set<AnalyticsTableType> processedTypes) {
+    processedTypes.stream()
+        .filter(AnalyticsTableType::isLatestPartition)
+        .forEach(type -> settingsService.put(keyFunction.apply(type), startTime));
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGeneratorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGeneratorTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.table;
+
+import static org.hisp.dhis.analytics.AnalyticsTableType.DATA_VALUE;
+import static org.hisp.dhis.analytics.AnalyticsTableType.ENROLLMENT;
+import static org.hisp.dhis.analytics.AnalyticsTableType.EVENT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.hisp.dhis.analytics.AnalyticsTableService;
+import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
+import org.hisp.dhis.analytics.cache.AnalyticsCache;
+import org.hisp.dhis.analytics.cache.OutliersCache;
+import org.hisp.dhis.analytics.table.setting.AnalyticsTableSettings;
+import org.hisp.dhis.resourcetable.ResourceTableService;
+import org.hisp.dhis.scheduling.JobProgress;
+import org.hisp.dhis.setting.SystemSettings;
+import org.hisp.dhis.setting.SystemSettingsService;
+import org.hisp.dhis.tablereplication.TableReplicationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests {@link DefaultAnalyticsTableGenerator}, in particular the per-{@link
+ * org.hisp.dhis.analytics.AnalyticsTableType} update-timestamp settings added for DHIS2-21992
+ * (Phase 1: write path only).
+ *
+ * @author Jason P. Pickering <jason@dhis2.org>
+ */
+@ExtendWith(MockitoExtension.class)
+class DefaultAnalyticsTableGeneratorTest {
+
+  @Mock private AnalyticsTableService dataValueTableService;
+  @Mock private AnalyticsTableService eventTableService;
+  @Mock private ResourceTableService resourceTableService;
+  @Mock private TableReplicationService tableReplicationService;
+  @Mock private SystemSettingsService settingsService;
+  @Mock private AnalyticsTableSettings analyticsTableSettings;
+  @Mock private AnalyticsCache analyticsCache;
+  @Mock private OutliersCache outliersCache;
+
+  private DefaultAnalyticsTableGenerator generator;
+
+  private void setUp() {
+    when(dataValueTableService.getAnalyticsTableType()).thenReturn(DATA_VALUE);
+    when(eventTableService.getAnalyticsTableType()).thenReturn(EVENT);
+    when(settingsService.getCurrentSettings()).thenReturn(SystemSettings.of(Map.of()));
+    generator =
+        new DefaultAnalyticsTableGenerator(
+            List.of(dataValueTableService, eventTableService),
+            resourceTableService,
+            tableReplicationService,
+            settingsService,
+            analyticsTableSettings,
+            analyticsCache,
+            outliersCache);
+  }
+
+  @Test
+  void skippedTypeGetsNoPerTypeLatestPartitionKey_processedTypeDoes() {
+    setUp();
+    Date startTime = new Date();
+    AnalyticsTableUpdateParams params =
+        AnalyticsTableUpdateParams.newBuilder()
+            .skipResourceTables(true)
+            .skipTableTypes(Set.of(EVENT))
+            .startTime(startTime)
+            .build()
+            .withLatestPartition();
+
+    generator.generateAnalyticsTables(params, JobProgress.noop());
+
+    verify(eventTableService, never()).create(any(), any());
+    verify(dataValueTableService).create(any(), any());
+
+    verify(settingsService, never())
+        .put(eq(SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(EVENT)), any());
+    verify(settingsService)
+        .put(
+            eq(SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(DATA_VALUE)),
+            eq(startTime));
+  }
+
+  @Test
+  void skippedTypeGetsNoPerTypeFullUpdateKey_processedTypeDoes() {
+    setUp();
+    Date startTime = new Date();
+    AnalyticsTableUpdateParams params =
+        AnalyticsTableUpdateParams.newBuilder()
+            .skipResourceTables(true)
+            .skipTableTypes(Set.of(EVENT))
+            .startTime(startTime)
+            .build();
+
+    generator.generateAnalyticsTables(params, JobProgress.noop());
+
+    verify(settingsService, never())
+        .put(eq(SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(EVENT)), any());
+    verify(settingsService)
+        .put(eq(SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(DATA_VALUE)), eq(startTime));
+  }
+
+  @Test
+  void typeWithoutLatestPartitionSupportGetsNoPerTypeKeyEvenWhenProcessed() {
+    when(dataValueTableService.getAnalyticsTableType()).thenReturn(ENROLLMENT);
+    when(settingsService.getCurrentSettings()).thenReturn(SystemSettings.of(Map.of()));
+    generator =
+        new DefaultAnalyticsTableGenerator(
+            List.of(dataValueTableService),
+            resourceTableService,
+            tableReplicationService,
+            settingsService,
+            analyticsTableSettings,
+            analyticsCache,
+            outliersCache);
+    AnalyticsTableUpdateParams params =
+        AnalyticsTableUpdateParams.newBuilder().skipResourceTables(true).build();
+
+    generator.generateAnalyticsTables(params, JobProgress.noop());
+
+    verify(dataValueTableService).create(any(), any());
+    // ENROLLMENT has no registered per-type key (AnalyticsTableType.isLatestPartition() == false)
+    // - writing it would be silently dropped by SystemSettingsService.put(), so it must not be
+    // attempted at all.
+    verify(settingsService, never())
+        .put(eq("keyLastSuccessfulAnalyticsTablesUpdate.ENROLLMENT"), any());
+  }
+
+  @Test
+  void legacyLatestPartitionKeysStillWrittenUnconditionally_regressionGuard() {
+    setUp();
+    Date startTime = new Date();
+    AnalyticsTableUpdateParams params =
+        AnalyticsTableUpdateParams.newBuilder()
+            .skipResourceTables(true)
+            .skipTableTypes(Set.of(EVENT, DATA_VALUE))
+            .startTime(startTime)
+            .build()
+            .withLatestPartition();
+
+    generator.generateAnalyticsTables(params, JobProgress.noop());
+
+    verify(settingsService)
+        .put(eq("keyLastSuccessfulLatestAnalyticsPartitionUpdate"), eq(startTime));
+    verify(settingsService).put(eq("keyLastSuccessfulLatestAnalyticsPartitionRuntime"), any());
+  }
+
+  @Test
+  void legacyFullUpdateKeysStillWrittenUnconditionally_regressionGuard() {
+    setUp();
+    Date startTime = new Date();
+    AnalyticsTableUpdateParams params =
+        AnalyticsTableUpdateParams.newBuilder()
+            .skipResourceTables(true)
+            .skipTableTypes(Set.of(EVENT, DATA_VALUE))
+            .startTime(startTime)
+            .build();
+
+    generator.generateAnalyticsTables(params, JobProgress.noop());
+
+    verify(settingsService).put(eq("keyLastSuccessfulAnalyticsTablesUpdate"), eq(startTime));
+    verify(settingsService).put(eq("keyLastSuccessfulAnalyticsTablesRuntime"), any());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGeneratorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGeneratorTest.java
@@ -113,9 +113,7 @@ class DefaultAnalyticsTableGeneratorTest {
     verify(settingsService, never())
         .put(eq(SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(EVENT)), any());
     verify(settingsService)
-        .put(
-            eq(SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(DATA_VALUE)),
-            eq(startTime));
+        .put(SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(DATA_VALUE), startTime);
   }
 
   @Test
@@ -134,7 +132,7 @@ class DefaultAnalyticsTableGeneratorTest {
     verify(settingsService, never())
         .put(eq(SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(EVENT)), any());
     verify(settingsService)
-        .put(eq(SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(DATA_VALUE)), eq(startTime));
+        .put(SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(DATA_VALUE), startTime);
   }
 
   @Test
@@ -177,8 +175,7 @@ class DefaultAnalyticsTableGeneratorTest {
 
     generator.generateAnalyticsTables(params, JobProgress.noop());
 
-    verify(settingsService)
-        .put(eq("keyLastSuccessfulLatestAnalyticsPartitionUpdate"), eq(startTime));
+    verify(settingsService).put("keyLastSuccessfulLatestAnalyticsPartitionUpdate", startTime);
     verify(settingsService).put(eq("keyLastSuccessfulLatestAnalyticsPartitionRuntime"), any());
   }
 
@@ -195,7 +192,7 @@ class DefaultAnalyticsTableGeneratorTest {
 
     generator.generateAnalyticsTables(params, JobProgress.noop());
 
-    verify(settingsService).put(eq("keyLastSuccessfulAnalyticsTablesUpdate"), eq(startTime));
+    verify(settingsService).put("keyLastSuccessfulAnalyticsTablesUpdate", startTime);
     verify(settingsService).put(eq("keyLastSuccessfulAnalyticsTablesRuntime"), any());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGeneratorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGeneratorTest.java
@@ -160,7 +160,7 @@ class DefaultAnalyticsTableGeneratorTest {
     // - writing it would be silently dropped by SystemSettingsService.put(), so it must not be
     // attempted at all.
     verify(settingsService, never())
-        .put(eq("keyLastSuccessfulAnalyticsTablesUpdate.ENROLLMENT"), any());
+        .put(eq("keyLastSuccessfulAnalyticsTablesUpdateEnrollment"), any());
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/DefaultSystemService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/DefaultSystemService.java
@@ -34,16 +34,14 @@ import static org.hisp.dhis.util.DateUtils.getPrettyInterval;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.LinkedHashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
@@ -181,9 +179,13 @@ public class DefaultSystemService implements SystemService, InitializingBean {
    */
   static Map<AnalyticsTableType, Date> getLastSuccessfulUpdateByType(
       Function<AnalyticsTableType, Date> getter) {
-    return Arrays.stream(AnalyticsTableType.values())
-        .filter(AnalyticsTableType::isLatestPartition)
-        .collect(Collectors.toMap(Function.identity(), getter, (a, b) -> a, LinkedHashMap::new));
+    Map<AnalyticsTableType, Date> updates = new EnumMap<>(AnalyticsTableType.class);
+    for (AnalyticsTableType type : AnalyticsTableType.values()) {
+      if (type.isLatestPartition()) {
+        updates.put(type, getter.apply(type));
+      }
+    }
+    return updates;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/DefaultSystemService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/DefaultSystemService.java
@@ -34,15 +34,21 @@ import static org.hisp.dhis.util.DateUtils.getPrettyInterval;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.calendar.CalendarService;
 import org.hisp.dhis.common.NonTransactional;
 import org.hisp.dhis.commons.util.SystemUtils;
@@ -151,6 +157,11 @@ public class DefaultSystemService implements SystemService, InitializingBean {
             getPrettyInterval(lastAnalyticsTablePartitionSuccess, now))
         .lastAnalyticsTablePartitionRuntime(
             settings.getLastSuccessfulLatestAnalyticsPartitionRuntime())
+        .lastAnalyticsTableSuccessByType(
+            getLastSuccessfulUpdateByType(settings::getLastSuccessfulAnalyticsTablesUpdate))
+        .lastAnalyticsTablePartitionSuccessByType(
+            getLastSuccessfulUpdateByType(
+                settings::getLastSuccessfulLatestAnalyticsPartitionUpdate))
         .lastSystemMonitoringSuccess(settings.getLastSuccessfulSystemMonitoringPush())
         .systemName(settings.getApplicationTitle())
         .instanceBaseUrl(dhisConfig.getServerBaseUrl())
@@ -161,6 +172,18 @@ public class DefaultSystemService implements SystemService, InitializingBean {
             getLastMetadataVersionSyncAttempt(
                 settings.getLastMetaDataSyncSuccess(), settings.getMetadataLastFailedTime()))
         .build();
+  }
+
+  /**
+   * Maps {@code getter} over every {@link AnalyticsTableType} that supports a latest partition (see
+   * {@link AnalyticsTableType#isLatestPartition()}) &mdash; the only types that have a per-type
+   * update-timestamp setting registered (DHIS2-21992).
+   */
+  static Map<AnalyticsTableType, Date> getLastSuccessfulUpdateByType(
+      Function<AnalyticsTableType, Date> getter) {
+    return Arrays.stream(AnalyticsTableType.values())
+        .filter(AnalyticsTableType::isLatestPartition)
+        .collect(Collectors.toMap(Function.identity(), getter, (a, b) -> a, LinkedHashMap::new));
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/system/DefaultSystemServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/system/DefaultSystemServiceTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.system;
+
+import static org.hisp.dhis.analytics.AnalyticsTableType.COMPLETENESS;
+import static org.hisp.dhis.analytics.AnalyticsTableType.DATA_VALUE;
+import static org.hisp.dhis.analytics.AnalyticsTableType.ENROLLMENT;
+import static org.hisp.dhis.analytics.AnalyticsTableType.EVENT;
+import static org.hisp.dhis.analytics.AnalyticsTableType.TRACKED_ENTITY_INSTANCE_EVENTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+import org.hisp.dhis.analytics.AnalyticsTableType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link DefaultSystemService}'s per-{@link AnalyticsTableType} update-timestamp mapping,
+ * added for DHIS2-21992 (Phase 1: System Info surface only).
+ *
+ * @author Jason P. Pickering <jason@dhis2.org>
+ */
+class DefaultSystemServiceTest {
+
+  @Test
+  void getLastSuccessfulUpdateByType_onlyIncludesLatestPartitionCapableTypes() {
+    Map<AnalyticsTableType, Date> result =
+        DefaultSystemService.getLastSuccessfulUpdateByType(type -> new Date(type.ordinal()));
+
+    assertEquals(
+        Set.of(DATA_VALUE, COMPLETENESS, EVENT, TRACKED_ENTITY_INSTANCE_EVENTS), result.keySet());
+  }
+
+  @Test
+  void getLastSuccessfulUpdateByType_excludesTypeWithoutLatestPartitionSupport() {
+    Map<AnalyticsTableType, Date> result =
+        DefaultSystemService.getLastSuccessfulUpdateByType(type -> new Date(type.ordinal()));
+
+    assertEquals(false, result.containsKey(ENROLLMENT));
+  }
+
+  @Test
+  void getLastSuccessfulUpdateByType_valuesComeFromTheGivenGetter() {
+    Date eventDate = new Date(123456L);
+    Map<AnalyticsTableType, Date> result =
+        DefaultSystemService.getLastSuccessfulUpdateByType(
+            type -> type == EVENT ? eventDate : new Date(0L));
+
+    assertEquals(eventDate, result.get(EVENT));
+    assertEquals(new Date(0L), result.get(DATA_VALUE));
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/system/DefaultSystemServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/system/DefaultSystemServiceTest.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.analytics.AnalyticsTableType.ENROLLMENT;
 import static org.hisp.dhis.analytics.AnalyticsTableType.EVENT;
 import static org.hisp.dhis.analytics.AnalyticsTableType.TRACKED_ENTITY_INSTANCE_EVENTS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.Date;
 import java.util.Map;
@@ -64,7 +65,7 @@ class DefaultSystemServiceTest {
     Map<AnalyticsTableType, Date> result =
         DefaultSystemService.getLastSuccessfulUpdateByType(type -> new Date(type.ordinal()));
 
-    assertEquals(false, result.containsKey(ENROLLMENT));
+    assertFalse(result.containsKey(ENROLLMENT));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -197,19 +197,49 @@ class SystemSettingsTest {
 
   @Test
   void testKeyLastSuccessfulAnalyticsTablesUpdate_PerType() {
-    for (AnalyticsTableType type : LATEST_PARTITION_TABLE_TYPES) {
-      assertEquals(
-          "keyLastSuccessfulAnalyticsTablesUpdate." + type.name(),
-          SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(type));
-    }
+    assertEquals(
+        "keyLastSuccessfulAnalyticsTablesUpdateDataValue",
+        SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType.DATA_VALUE));
+    assertEquals(
+        "keyLastSuccessfulAnalyticsTablesUpdateCompleteness",
+        SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType.COMPLETENESS));
+    assertEquals(
+        "keyLastSuccessfulAnalyticsTablesUpdateEvent",
+        SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType.EVENT));
+    assertEquals(
+        "keyLastSuccessfulAnalyticsTablesUpdateTrackedEntityInstanceEvents",
+        SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(
+            AnalyticsTableType.TRACKED_ENTITY_INSTANCE_EVENTS));
   }
 
   @Test
   void testKeyLastSuccessfulLatestAnalyticsPartitionUpdate_PerType() {
+    assertEquals(
+        "keyLastSuccessfulLatestAnalyticsPartitionUpdateDataValue",
+        SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(
+            AnalyticsTableType.DATA_VALUE));
+    assertEquals(
+        "keyLastSuccessfulLatestAnalyticsPartitionUpdateCompleteness",
+        SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(
+            AnalyticsTableType.COMPLETENESS));
+    assertEquals(
+        "keyLastSuccessfulLatestAnalyticsPartitionUpdateEvent",
+        SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(AnalyticsTableType.EVENT));
+    assertEquals(
+        "keyLastSuccessfulLatestAnalyticsPartitionUpdateTrackedEntityInstanceEvents",
+        SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(
+            AnalyticsTableType.TRACKED_ENTITY_INSTANCE_EVENTS));
+  }
+
+  @Test
+  void testKeyLastSuccessfulUpdate_PerType_NoDotSeparator() {
+    // regression guard: a literal "." in a flat settings key breaks JsonObject.get(path)-style
+    // dot-as-path-separator accessors (e.g. SystemSettingsControllerTest), which read a flat
+    // "keyXxx.EVENT" key as a nested lookup and silently report it missing
     for (AnalyticsTableType type : LATEST_PARTITION_TABLE_TYPES) {
-      assertEquals(
-          "keyLastSuccessfulLatestAnalyticsPartitionUpdate." + type.name(),
-          SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(type));
+      assertFalse(SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(type).contains("."));
+      assertFalse(
+          SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(type).contains("."));
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.analytics.AnalyticsCacheTtlMode;
+import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.jsontree.JsonBoolean;
 import org.hisp.dhis.jsontree.JsonDate;
@@ -102,7 +103,7 @@ class SystemSettingsTest {
   @Test
   void testKeysWithDefaults() {
     Set<String> keys = SystemSettings.keysWithDefaults();
-    assertEquals(148, keys.size());
+    assertEquals(156, keys.size());
     // just check some at random
     assertTrue(keys.contains("syncSkipSyncForDataChangedBefore"));
     assertTrue(keys.contains("keyTrackerDashboardLayout"));
@@ -110,6 +111,12 @@ class SystemSettingsTest {
     assertTrue(keys.contains("keyCustomTranslationsEnabled"));
     assertTrue(keys.contains(("keyCustomColor")));
     assertTrue(keys.contains(("keyCustomColorMobile")));
+    // the new per-table-type analytics update keys (DHIS2-21992)
+    for (AnalyticsTableType type : LATEST_PARTITION_TABLE_TYPES) {
+      assertTrue(keys.contains(SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(type)));
+      assertTrue(
+          keys.contains(SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(type)));
+    }
   }
 
   @Test
@@ -179,6 +186,71 @@ class SystemSettingsTest {
         SystemSettings.of(
             Map.of("keyLastSuccessfulResourceTablesUpdate", Settings.valueOf(new Date(123456L))));
     assertEquals(new Date(123456L), settings.getLastSuccessfulResourceTablesUpdate());
+  }
+
+  private static final List<AnalyticsTableType> LATEST_PARTITION_TABLE_TYPES =
+      List.of(
+          AnalyticsTableType.DATA_VALUE,
+          AnalyticsTableType.COMPLETENESS,
+          AnalyticsTableType.EVENT,
+          AnalyticsTableType.TRACKED_ENTITY_INSTANCE_EVENTS);
+
+  @Test
+  void testKeyLastSuccessfulAnalyticsTablesUpdate_PerType() {
+    for (AnalyticsTableType type : LATEST_PARTITION_TABLE_TYPES) {
+      assertEquals(
+          "keyLastSuccessfulAnalyticsTablesUpdate." + type.name(),
+          SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(type));
+    }
+  }
+
+  @Test
+  void testKeyLastSuccessfulLatestAnalyticsPartitionUpdate_PerType() {
+    for (AnalyticsTableType type : LATEST_PARTITION_TABLE_TYPES) {
+      assertEquals(
+          "keyLastSuccessfulLatestAnalyticsPartitionUpdate." + type.name(),
+          SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(type));
+    }
+  }
+
+  @Test
+  void testAsDate_LastSuccessfulAnalyticsTablesUpdatePerType() {
+    for (AnalyticsTableType type : LATEST_PARTITION_TABLE_TYPES) {
+      SystemSettings settings =
+          SystemSettings.of(
+              Map.of(
+                  SystemSettings.keyLastSuccessfulAnalyticsTablesUpdate(type),
+                  Settings.valueOf(new Date(123456L))));
+      assertEquals(new Date(123456L), settings.getLastSuccessfulAnalyticsTablesUpdate(type));
+    }
+  }
+
+  @Test
+  void testAsDate_LastSuccessfulLatestAnalyticsPartitionUpdatePerType() {
+    for (AnalyticsTableType type : LATEST_PARTITION_TABLE_TYPES) {
+      SystemSettings settings =
+          SystemSettings.of(
+              Map.of(
+                  SystemSettings.keyLastSuccessfulLatestAnalyticsPartitionUpdate(type),
+                  Settings.valueOf(new Date(654321L))));
+      assertEquals(
+          new Date(654321L), settings.getLastSuccessfulLatestAnalyticsPartitionUpdate(type));
+    }
+  }
+
+  @Test
+  void testLastSuccessfulAnalyticsTablesUpdatePerType_DefaultsToEpoch() {
+    SystemSettings settings = SystemSettings.of(Map.of());
+    assertEquals(
+        new Date(0L), settings.getLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType.EVENT));
+    assertEquals(
+        new Date(0L),
+        settings.getLastSuccessfulLatestAnalyticsPartitionUpdate(AnalyticsTableType.EVENT));
+    // a type with no registered per-type key (not one of the four above) must not throw, and
+    // defaults to epoch the same way
+    assertEquals(
+        new Date(0L),
+        settings.getLastSuccessfulAnalyticsTablesUpdate(AnalyticsTableType.ENROLLMENT));
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SystemControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SystemControllerTest.java
@@ -95,6 +95,11 @@ class SystemControllerTest extends H2ControllerIntegrationTestBase {
     // testing one sensitive and one non-sensitive property
     assertNotNull(info.getString("javaVersion").string());
     assertNotNull(info.getString("serverDate").string());
+    // per-AnalyticsTableType update timestamps (DHIS2-21992), surfaced alongside the legacy
+    // single-value fields; empty objects are expected here since no analytics table update has
+    // run in this test
+    assertTrue(info.getObject("lastAnalyticsTableSuccessByType").isObject());
+    assertTrue(info.getObject("lastAnalyticsTablePartitionSuccessByType").isObject());
   }
 
   @Test
@@ -104,6 +109,9 @@ class SystemControllerTest extends H2ControllerIntegrationTestBase {
     // testing one sensitive and one non-sensitive property
     assertNull(info.getString("javaVersion").string());
     assertNotNull(info.getString("serverDate").string());
+    // not sensitive, stays visible to non-superusers too, same as the legacy fields
+    assertTrue(info.getObject("lastAnalyticsTableSuccessByType").isObject());
+    assertTrue(info.getObject("lastAnalyticsTablePartitionSuccessByType").isObject());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Continuous analytics writes a single global "last successful update" timestamp regardless of which table types a run actually processed. A run using `skipTableTypes` to skip a type still advances that type's shared clock, so a later run treats everything before it as already handled and silently drops any changes made to the skipped type during the gap. Confirmed on both Postgres and Doris.

This PR is **Phase 1** of the fix: additive only, no existing read path is touched.

- `DefaultAnalyticsTableGenerator` now additionally stamps one system settings key per `AnalyticsTableType` actually processed (for the four types that support a latest partition: `DATA_VALUE`, `COMPLETENESS`, `EVENT`, `TRACKED_ENTITY_INSTANCE_EVENTS`), alongside the unchanged legacy unconditional writes.
- `SystemSettings` gains the corresponding registered per-type keys (required — `SystemSettingsService.put()` silently drops writes for keys not registered via `keysWithDefaults()`).
- System Info (`GET /api/system/info`) surfaces the new per-type maps immediately, alongside the untouched legacy scalar fields.

**Phase 2** (switching the read path in `AbstractJdbcTableManager`/`JdbcEventAnalyticsTableManager` to actually use these per-type keys — the change that fixes the bug) is deferred to a separate PR, since it touches the same files PR #24440 (Doris continuous analytics support) is modifying, and needs to be sequenced against that.

## Test plan

- [x] New `SystemSettingsTest` cases: per-type keys registered, correct defaults, correct `keysWithDefaults()` membership.
- [x] New `DefaultAnalyticsTableGeneratorTest`: skipped type gets no per-type key while processed types do (both full-update and latest-partition branches); a type without latest-partition support never gets a key attempt; legacy keys still written unconditionally (regression guard — this behavior had no prior test coverage).
- [x] New `DefaultSystemServiceTest`: per-type mapping only includes latest-partition-capable types, values come from the given settings getter.
- [x] Extended `SystemControllerTest`: new per-type fields appear in `GET /system/info` for both superuser and non-superuser (not sensitive).
- [x] Live-validated on a local server: triggered `POST /api/resourceTables/analytics?lastYears=0&skipAggregate=true`, confirmed via `GET /api/systemSettings` that `keyLastSuccessfulLatestAnalyticsPartitionUpdate.DATA_VALUE`/`.COMPLETENESS` stayed at epoch while `.EVENT`/`.TRACKED_ENTITY_INSTANCE_EVENTS` advanced, and the legacy shared key still advanced unconditionally as before.

🤖 AI Assisted