### PR TITLE
perf: project program stage data elements in preheat DHIS2-21979 [2.43]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/notification/BaseNotificationMessageRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/notification/BaseNotificationMessageRenderer.java
@@ -47,8 +47,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DeliveryChannel;
 import org.hisp.dhis.common.RegexUtils;
-import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.util.DateUtils;
@@ -191,38 +189,6 @@ public abstract class BaseNotificationMessageRenderer<T> implements Notification
 
   /** Returns the set of ExpressionTypes supported by the implementor. */
   protected abstract Set<ExpressionType> getSupportedExpressionTypes();
-
-  /**
-   * Renders the display value for a {@link DataElement} within the context of an event.
-   *
-   * <p>This method performs the following:
-   *
-   * <ul>
-   *   <li>Returns a placeholder if the {@code DataElement} is not part of the program stage.
-   *   <li>Returns a confidential replacement if the underlying value is {@code null}.
-   *   <li>Resolves OptionSet codes to their corresponding display names when applicable.
-   *   <li>Otherwise, returns the raw data value.
-   * </ul>
-   *
-   * @param dv the {@link EventDataValue} containing the stored value
-   * @param dataElement the {@link DataElement} associated with the value
-   * @return a rendered, user-friendly value suitable for notifications or messages
-   */
-  protected String renderDataElementValue(EventDataValue dv, DataElement dataElement) {
-    if (dataElement == null) {
-      return DE_NOT_IN_STAGE;
-    }
-    String value = dv.getValue();
-
-    if (value == null) {
-      return CONFIDENTIAL_VALUE_REPLACEMENT;
-    }
-
-    // If the DV has an OptionSet -> substitute value with the name of the
-    // Option
-
-    return dataElement.hasOptionSet() ? getOptionName(dataElement.getOptionSet(), value) : value;
-  }
 
   // -------------------------------------------------------------------------
   // Internal methods

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/ProgramNotificationMessageRendererTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/ProgramNotificationMessageRendererTest.java
@@ -305,6 +305,8 @@ class ProgramNotificationMessageRendererTest extends PostgresIntegrationTestBase
     programNotificationTemplate.setAutoFields();
     programNotificationTemplate.setUid("PNT-1");
     programNotificationTemplateStore.save(programNotificationTemplate);
+    // the renderer reads the metadata with SQL, so flush what was built through Hibernate
+    clearSession();
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/SingleEventNotificationMessageRendererTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/SingleEventNotificationMessageRendererTest.java
@@ -118,6 +118,8 @@ class SingleEventNotificationMessageRendererTest extends PostgresIntegrationTest
     createProgramStage();
     createEvent();
     createNotificationTemplate();
+    // the renderer reads the metadata with SQL, so flush what was built through Hibernate
+    clearSession();
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/notification/TrackerNotificationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/notification/TrackerNotificationTest.java
@@ -37,12 +37,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.message.Message;
 import org.hisp.dhis.message.MessageConversation;
+import org.hisp.dhis.option.Option;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Program;
@@ -61,6 +64,7 @@ import org.hisp.dhis.tracker.TestSetup;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
+import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.domain.Enrollment;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
@@ -168,6 +172,50 @@ class TrackerNotificationTest extends PostgresIntegrationTestBase {
         .until(() -> !manager.getAll(MessageConversation.class).isEmpty());
 
     assertContainsOnly(List.of("event_completion_subject"), messageSubjects());
+  }
+
+  @Test
+  void shouldRenderDataElementValueInEventCompletionNotification() {
+    addLifecycleTemplate(
+        "de_subject", "value is #{DATAEL00001}", NotificationTrigger.COMPLETION, programStage);
+
+    importEnrollmentWithCompletedEvent(
+        Set.of(
+            DataValue.builder()
+                .dataElement(MetadataIdentifier.ofUid("DATAEL00001"))
+                .value("rendered")
+                .build()));
+
+    await()
+        .atMost(3, TimeUnit.SECONDS)
+        .until(() -> !manager.getAll(MessageConversation.class).isEmpty());
+
+    assertContainsOnly(List.of("value is rendered"), messageTexts());
+  }
+
+  @Test
+  void shouldRenderOptionNameInEventCompletionNotificationWhenDataElementHasOptionSet() {
+    // the fixture names the option like its code, rename it so resolving the code is observable
+    Option option = manager.get(Option.class, "IHYwYAtvjCY");
+    option.setName("Option one");
+    manager.update(option);
+
+    // DATAEL00005 is a data element of NpsdDv6kKSO with option set VWzgQENmzPK
+    addLifecycleTemplate(
+        "option_subject", "value is #{DATAEL00005}", NotificationTrigger.COMPLETION, programStage);
+
+    importEnrollmentWithCompletedEvent(
+        Set.of(
+            DataValue.builder()
+                .dataElement(MetadataIdentifier.ofUid("DATAEL00005"))
+                .value(option.getCode())
+                .build()));
+
+    await()
+        .atMost(3, TimeUnit.SECONDS)
+        .until(() -> !manager.getAll(MessageConversation.class).isEmpty());
+
+    assertContainsOnly(List.of("value is Option one"), messageTexts());
   }
 
   @Test
@@ -322,6 +370,10 @@ class TrackerNotificationTest extends PostgresIntegrationTestBase {
   }
 
   private void importEnrollmentWithCompletedEvent() {
+    importEnrollmentWithCompletedEvent(Set.of());
+  }
+
+  private void importEnrollmentWithCompletedEvent(Set<DataValue> dataValues) {
     UID enrollmentUid = UID.generate();
     Enrollment enrollment =
         Enrollment.builder()
@@ -344,6 +396,7 @@ class TrackerNotificationTest extends PostgresIntegrationTestBase {
             .status(EventStatus.COMPLETED)
             .occurredAt(Instant.now())
             .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
+            .dataValues(dataValues)
             .build();
     assertNoErrors(
         trackerImportService.importTracker(
@@ -357,6 +410,13 @@ class TrackerNotificationTest extends PostgresIntegrationTestBase {
   private List<String> messageSubjects() {
     return manager.getAll(MessageConversation.class).stream()
         .map(MessageConversation::getSubject)
+        .toList();
+  }
+
+  private List<String> messageTexts() {
+    return manager.getAll(MessageConversation.class).stream()
+        .flatMap(conversation -> conversation.getMessages().stream())
+        .map(Message::getText)
         .toList();
   }
 
@@ -394,6 +454,15 @@ class TrackerNotificationTest extends PostgresIntegrationTestBase {
 
   private void addLifecycleTemplate(String subject, NotificationTrigger trigger, ProgramStage ps) {
     ProgramNotificationTemplate template = addNotificationTemplate(subject, trigger);
+    ps.getNotificationTemplates().add(template);
+    manager.update(ps);
+  }
+
+  private void addLifecycleTemplate(
+      String subject, String messageTemplate, NotificationTrigger trigger, ProgramStage ps) {
+    ProgramNotificationTemplate template = addNotificationTemplate(subject, trigger);
+    template.setMessageTemplate(messageTemplate);
+    manager.update(template);
     ps.getNotificationTemplates().add(template);
     manager.update(ps);
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/programrule/ProgramRuleAssignActionTest.java
@@ -108,6 +108,9 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
 
   private DataElement optionDataElement;
 
+  /** Not a data element of program stage {@code NpsdDv6kKSO}. */
+  private DataElement dataElementNotInStage;
+
   private TrackedEntityAttribute attribute1;
 
   @BeforeAll
@@ -122,6 +125,8 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     dataElement2 = bundle.getPreheat().get(PreheatIdentifier.UID, DataElement.class, "DATAEL00002");
     optionDataElement =
         bundle.getPreheat().get(PreheatIdentifier.UID, DataElement.class, "DATAEL00005");
+    dataElementNotInStage =
+        bundle.getPreheat().get(PreheatIdentifier.UID, DataElement.class, "GieVkTxp4HG");
     attribute1 =
         bundle.getPreheat().get(PreheatIdentifier.UID, TrackedEntityAttribute.class, "dIVt4l5vIOa");
     TrackedEntityAttribute attribute2 =
@@ -330,6 +335,57 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     assertHasOnlyWarnings(importReport, E1308);
   }
 
+  /**
+   * The rule engine runs after validation and {@code DataValuesValidator} runs again afterwards, on
+   * the payload the ASSIGN mutated. An ASSIGN to a data element absent from the payload adds a data
+   * value, so that second pass sees a data element the first pass never did.
+   *
+   * <p>Nothing rejects it because the data elements of the program stage are projected from the
+   * payload's data elements plus the data elements of all program rule actions, which {@link
+   * org.hisp.dhis.tracker.imports.TrackerIdentifierCollector} preheats. Narrowing that collection
+   * would leave the assigned data element out of the projection and E1305 would reject valid data.
+   */
+  @Test
+  void shouldImportWithWarningWhenAssignedDataElementIsNotInThePayload() throws IOException {
+    // DATAEL00002 belongs to program stage NpsdDv6kKSO but the payload only carries DATAEL00001
+    assignConstantToDataElementProgramRule();
+    TrackerImportParams params = new TrackerImportParams();
+    params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
+
+    ImportReport importReport = trackerImportService.importTracker(params, eventWithDataValue());
+
+    // E1305 would be reported here if the assigned data element were not part of the projection
+    Assertions.assertAll(
+        () -> assertNoErrors(importReport),
+        () -> assertHasOnlyWarnings(importReport, E1308),
+        () ->
+            assertContainsOnly(
+                List.of("ASSIGNED"), getValueForAssignedDataElement(UID.of("D9PbzJY8bZZ"))));
+  }
+
+  /**
+   * A rule effect is only executed if its target data element belongs to the event's program stage,
+   * a check {@code RuleActionEventMapper} makes against the projected data elements. A data element
+   * outside the stage must not be assigned.
+   */
+  @Test
+  void shouldNotAssignWhenDataElementIsNotPartOfTheProgramStage() throws IOException {
+    // GieVkTxp4HG is not a data element of program stage NpsdDv6kKSO
+    assignConstantToDataElementNotInStageProgramRule();
+    TrackerImportParams params = new TrackerImportParams();
+    params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
+
+    ImportReport importReport = trackerImportService.importTracker(params, eventWithDataValue());
+
+    clearSession();
+
+    Assertions.assertAll(
+        () -> assertNoErrors(importReport),
+        () ->
+            assertIsEmpty(
+                getValueForDataElement(UID.of("D9PbzJY8bZZ"), dataElementNotInStage.getUid())));
+  }
+
   @Test
   void shouldImportWhenAssigningToCalculatedValueProgramRuleVariable() throws IOException {
     assignToCalculatedValueProgramRule();
@@ -355,9 +411,27 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     return TrackerObjects.builder().events(List.of(event)).build();
   }
 
+  /**
+   * Event {@code D9PbzJY8bZZ} on program stage {@code NpsdDv6kKSO}, carrying a data value for
+   * {@code DATAEL00001} only. The payload has no {@code occurredAt}, which E1031 rejects, so one is
+   * set here. Its value does not matter to the callers.
+   */
+  private TrackerObjects eventWithDataValue() throws IOException {
+    TrackerObjects trackerObjects =
+        testSetup.fromJson("tracker/programrule/event_with_data_value.json");
+    org.hisp.dhis.tracker.imports.domain.TrackerEvent event = trackerObjects.getEvents().get(0);
+    event.setOccurredAt(DateUtils.instantFromDateAsString("2019-01-28"));
+
+    return TrackerObjects.builder().events(List.of(event)).build();
+  }
+
   private List<String> getValueForAssignedDataElement(UID eventUid) {
+    return getValueForDataElement(eventUid, "DATAEL00002");
+  }
+
+  private List<String> getValueForDataElement(UID eventUid, String dataElementUid) {
     return manager.get(TrackerEvent.class, eventUid.getValue()).getEventDataValues().stream()
-        .filter(dv -> dv.getDataElement().equals("DATAEL00002"))
+        .filter(dv -> dv.getDataElement().equals(dataElementUid))
         .map(EventDataValue::getValue)
         .toList();
   }
@@ -396,6 +470,29 @@ class ProgramRuleAssignActionTest extends PostgresIntegrationTestBase {
     programRuleAction.setData("1");
     programRuleAction.setContent("#{prv_cal_val}");
 
+    programRuleActionService.addProgramRuleAction(programRuleAction);
+    programRule.getProgramRuleActions().add(programRuleAction);
+    programRuleService.updateProgramRule(programRule);
+  }
+
+  /** Assigns a constant to a data element of the program stage that the payload does not carry. */
+  private void assignConstantToDataElementProgramRule() {
+    ProgramRule programRule = createProgramRule('H', program, null, "true");
+    programRuleService.addProgramRule(programRule);
+    ProgramRuleAction programRuleAction =
+        createProgramRuleAction(programRule, ASSIGN, dataElement2, "'ASSIGNED'");
+    programRuleActionService.addProgramRuleAction(programRuleAction);
+    programRule.getProgramRuleActions().add(programRuleAction);
+    programRuleService.updateProgramRule(programRule);
+  }
+
+  /** Assigns a constant to a data element that is not part of the event's program stage. */
+  private void assignConstantToDataElementNotInStageProgramRule() {
+    ProgramRule programRule = createProgramRule('J', program, null, "true");
+    programRuleService.addProgramRule(programRule);
+    // GieVkTxp4HG is a NUMBER data element
+    ProgramRuleAction programRuleAction =
+        createProgramRuleAction(programRule, ASSIGN, dataElementNotInStage, "1");
     programRuleActionService.addProgramRuleAction(programRuleAction);
     programRule.getProgramRuleActions().add(programRuleAction);
     programRuleService.updateProgramRule(programRule);

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/config/TrackerPreheatConfig.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/config/TrackerPreheatConfig.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.tracker.imports.preheat.supplier.PreheatStrategyScanner;
 import org.hisp.dhis.tracker.imports.preheat.supplier.PreheatSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.ProgramOrgUnitsSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.ProgramOwnerSupplier;
+import org.hisp.dhis.tracker.imports.preheat.supplier.ProgramStageDataElementsSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.TrackedEntityEnrollmentSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.TrackerEventProgramStageMapSupplier;
 import org.hisp.dhis.tracker.imports.preheat.supplier.UniqueAttributesSupplier;
@@ -63,6 +64,7 @@ public class TrackerPreheatConfig {
           EnrollmentsWithAtLeastOneEventSupplier.class,
           TrackerEventProgramStageMapSupplier.class,
           ProgramOrgUnitsSupplier.class,
+          ProgramStageDataElementsSupplier.class,
           ProgramOwnerSupplier.class,
           UniqueAttributesSupplier.class,
           CurrentUserSupplier.class,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/ProgramStageDataElements.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/ProgramStageDataElements.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.preheat;
+
+import java.util.Set;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+
+/**
+ * Data elements of a program stage, projected instead of loaded as Hibernate entities. These
+ * replace walking {@link org.hisp.dhis.program.ProgramStage#getProgramStageDataElements()} on a
+ * preheated stage, which is no longer mapped. See {@link
+ * org.hisp.dhis.tracker.imports.preheat.supplier.ProgramStageDataElementsSupplier} for what is
+ * projected and why.
+ *
+ * @param compulsory identifiers of the compulsory data elements, in the requested idScheme
+ * @param members identifiers of the projected data elements, in the requested idScheme
+ * @param memberUids the same data elements as {@code members}, keyed by uid rather than the
+ *     requested idScheme, as program rules only know uids
+ */
+public record ProgramStageDataElements(
+    Set<MetadataIdentifier> compulsory, Set<MetadataIdentifier> members, Set<UID> memberUids) {
+
+  public static final ProgramStageDataElements EMPTY =
+      new ProgramStageDataElements(Set.of(), Set.of(), Set.of());
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
@@ -47,6 +47,7 @@ import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -311,6 +312,28 @@ public class TrackerPreheat {
    * payload.
    */
   @Getter @Setter private Map<String, List<String>> programWithOrgUnitsMap;
+
+  /**
+   * Projected data elements of a program stage, keyed by program stage uid. Set by {@link
+   * org.hisp.dhis.tracker.imports.preheat.supplier.ProgramStageDataElementsSupplier}, which
+   * documents what is projected and why.
+   */
+  private final Map<UID, ProgramStageDataElements> programStageDataElements = new HashMap<>();
+
+  public void putProgramStageDataElements(
+      @Nonnull UID programStage, @Nonnull ProgramStageDataElements dataElements) {
+    programStageDataElements.put(programStage, dataElements);
+  }
+
+  /**
+   * Returns the projected data elements of the given program stage, never null. An unknown stage
+   * yields empty sets, matching the previous behaviour of a stage with no data elements.
+   */
+  @Nonnull
+  public ProgramStageDataElements getProgramStageDataElements(@Nonnull ProgramStage programStage) {
+    return programStageDataElements.getOrDefault(
+        UID.of(programStage), ProgramStageDataElements.EMPTY);
+  }
 
   public TrackerPreheat() {}
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramStageMapper.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramStageMapper.java
@@ -58,7 +58,8 @@ public interface ProgramStageMapper extends PreheatMapper<ProgramStage> {
   @Mapping(target = "program", qualifiedByName = "program")
   @Mapping(target = "repeatable")
   @Mapping(target = "referral")
-  @Mapping(target = "programStageDataElements")
+  // programStageDataElements is deliberately not mapped, as it initialized one DataElement entity
+  // per element. Read TrackerPreheat#getProgramStageDataElements instead.
   @Mapping(target = "enableUserAssignment")
   @Mapping(target = "validationStrategy")
   @Mapping(target = "featureType")

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/ProgramStageDataElementsSupplier.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/ProgramStageDataElementsSupplier.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.preheat.supplier;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.hisp.dhis.attribute.AttributeValues;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.TrackerIdSchemeParam;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.tracker.imports.preheat.ProgramStageDataElements;
+import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Projects the data elements of the preheated program stages instead of loading them as Hibernate
+ * entities.
+ *
+ * <p>A program stage can have thousands of data elements while an event references a handful.
+ * Mapping the {@code programStageDataElements} association initialized every one of them, which
+ * dominated preheat on wide programs. Only three things are asked of that association during import
+ * and all of them need an identifier and nothing else:
+ *
+ * <ul>
+ *   <li>the compulsory data elements, to report one missing from the event (E1303) or being deleted
+ *       by it (E1076)
+ *   <li>whether a payload data element belongs to the stage (E1305)
+ *   <li>whether a program rule effect targets a data element of the stage
+ * </ul>
+ *
+ * <p>The last two are membership tests whose probes are known up front, so a data element that
+ * neither the payload nor the rules mention cannot change their outcome and does not need to be
+ * fetched. What is loaded is therefore bounded by the compulsory count plus the payload and rule
+ * width, rather than by the width of the program.
+ *
+ * <p>Data elements referenced by the payload or by program rules are loaded as full entities
+ * elsewhere, as validation needs their value type and option set. This supplier does not replace
+ * that, it only avoids loading the rest of the stage.
+ */
+@Component
+public class ProgramStageDataElementsSupplier extends JdbcAbstractPreheatSupplier {
+
+  /**
+   * Unioned rather than {@code or}ed: an {@code or} spanning both tables cannot be served by an
+   * index, so Postgres reads every row of the stage and filters afterwards. Split, the second
+   * branch uses {@code dataelement_uid_key}.
+   *
+   * <p>{@code = any(array)} rather than {@code in (...)} so that an empty data element array stays
+   * valid SQL matching nothing, instead of the syntax error {@code in ()} would be.
+   */
+  private static final String SQL =
+      """
+      select psde.programstageid, psde.compulsory, de.uid, de.code, de.name, de.attributevalues
+      from programstagedataelement psde
+      join dataelement de on de.dataelementid = psde.dataelementid
+      where psde.programstageid = any(:programStageIds)
+        and psde.compulsory
+      union
+      select psde.programstageid, psde.compulsory, de.uid, de.code, de.name, de.attributevalues
+      from programstagedataelement psde
+      join dataelement de on de.dataelementid = psde.dataelementid
+      where psde.programstageid = any(:programStageIds)
+        and de.uid = any(:dataElementUids)
+      """;
+
+  protected ProgramStageDataElementsSupplier(JdbcTemplate jdbcTemplate) {
+    super(jdbcTemplate);
+  }
+
+  @Override
+  public void preheatAdd(TrackerObjects trackerObjects, TrackerPreheat preheat) {
+    // Stages named by the payload, plus the stages of every preheated program. An event in an
+    // event program does not carry a program stage, EventProgramPreProcessor derives it from the
+    // program, but that runs after preheat. Projecting the program's stages as well means the
+    // derived stage is covered. Without this E1305 rejects every data value of such an event.
+    Map<Long, ProgramStage> programStagesById =
+        Stream.concat(
+                preheat.getAll(ProgramStage.class).stream(),
+                preheat.getAll(Program.class).stream()
+                    .map(Program::getProgramStages)
+                    .filter(Objects::nonNull)
+                    .flatMap(Collection::stream))
+            .collect(Collectors.toMap(IdentifiableObject::getId, ps -> ps, (a, b) -> a));
+
+    if (programStagesById.isEmpty()) {
+      return;
+    }
+
+    // Data elements of the payload and of the program rules, both preheated by
+    // TrackerIdentifierCollector, so reading their uids costs nothing. Program rules only ever
+    // refer to data elements by uid.
+    //
+    // Note the rule ones are only preheated under idScheme=UID. The collector adds them as uids but
+    // into the same identifier set as the payload's, which is then queried in the payload's
+    // idScheme, so under CODE|NAME|ATTRIBUTE they do not load and drop out of this probe set. That
+    // is pre-existing, see AbstractSchemaStrategy#generateRestrictionFromIdentifiers.
+    Set<String> dataElementUids =
+        preheat.getAll(DataElement.class).stream()
+            .map(IdentifiableObject::getUid)
+            .collect(Collectors.toSet());
+
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+    parameters.addValue("programStageIds", programStagesById.keySet().toArray(new Long[0]));
+    parameters.addValue("dataElementUids", dataElementUids.toArray(new String[0]));
+
+    TrackerIdSchemeParam idScheme = preheat.getIdSchemes().getDataElementIdScheme();
+
+    Map<Long, Set<MetadataIdentifier>> compulsory = new HashMap<>();
+    Map<Long, Set<MetadataIdentifier>> members = new HashMap<>();
+    Map<Long, Set<UID>> memberUids = new HashMap<>();
+
+    jdbcTemplate.query(
+        SQL,
+        parameters,
+        rs -> {
+          long programStageId = rs.getLong("programstageid");
+          MetadataIdentifier identifier = toMetadataIdentifier(idScheme, rs);
+
+          members.computeIfAbsent(programStageId, k -> new HashSet<>()).add(identifier);
+          memberUids
+              .computeIfAbsent(programStageId, k -> new HashSet<>())
+              .add(UID.of(rs.getString("uid")));
+          if (rs.getBoolean("compulsory")) {
+            compulsory.computeIfAbsent(programStageId, k -> new HashSet<>()).add(identifier);
+          }
+        });
+
+    programStagesById.forEach(
+        (programStageId, programStage) ->
+            preheat.putProgramStageDataElements(
+                UID.of(programStage),
+                new ProgramStageDataElements(
+                    compulsory.getOrDefault(programStageId, Set.of()),
+                    members.getOrDefault(programStageId, Set.of()),
+                    memberUids.getOrDefault(programStageId, Set.of()))));
+  }
+
+  /**
+   * Builds the identifier in the requested idScheme. Every column an idScheme can resolve to is
+   * projected, so this has to pick the right one where {@link
+   * TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)} would read it off the entity.
+   */
+  private static MetadataIdentifier toMetadataIdentifier(
+      TrackerIdSchemeParam idScheme, ResultSet rs) throws SQLException {
+    return switch (idScheme.getIdScheme()) {
+      case UID -> idScheme.toMetadataIdentifier(rs.getString("uid"));
+      case CODE -> idScheme.toMetadataIdentifier(rs.getString("code"));
+      case NAME -> idScheme.toMetadataIdentifier(rs.getString("name"));
+      case ATTRIBUTE -> {
+        String attributeValues = rs.getString("attributevalues");
+        yield idScheme.toMetadataIdentifier(
+            attributeValues == null
+                ? null
+                : AttributeValues.of(attributeValues).get(idScheme.getAttributeUid()));
+      }
+    };
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/ProgramStageDataElementsSupplier.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/ProgramStageDataElementsSupplier.java
@@ -83,9 +83,10 @@ import org.springframework.stereotype.Component;
 public class ProgramStageDataElementsSupplier extends JdbcAbstractPreheatSupplier {
 
   /**
-   * Unioned rather than {@code or}ed: an {@code or} spanning both tables cannot be served by an
-   * index, so Postgres reads every row of the stage and filters afterwards. Split, the second
-   * branch uses {@code dataelement_uid_key}.
+   * Unioned rather than {@code or}ed, which measured faster on a program with thousands of data
+   * elements: an {@code or} spanning both tables leaves Postgres pairing the stage's rows with the
+   * payload's data elements and discarding the non-matches with a join filter, then sorting to
+   * deduplicate.
    *
    * <p>{@code = any(array)} rather than {@code in (...)} so that an empty data element array stays
    * valid SQL matching nothing, instead of the syntax error {@code in ()} would be.

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleActionEventMapper.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/RuleActionEventMapper.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.security.acl.AclService;
@@ -86,11 +85,11 @@ class RuleActionEventMapper {
       return List.of();
     }
 
-    // Pre-build the set of data element UIDs for this program stage so that
-    // isDataElementPartOfProgramStage does not stream over the collection per effect.
+    // Data elements of the stage, projected by ProgramStageDataElementsSupplier. Rules refer to
+    // data elements by uid, so the uid set is the one to probe.
     Set<String> stageDataElementUids =
-        programStage.getDataElements().stream()
-            .map(IdentifiableObject::getUid)
+        bundle.getPreheat().getProgramStageDataElements(programStage).memberUids().stream()
+            .map(UID::getValue)
             .collect(Collectors.toSet());
 
     return ruleValidationEffects.stream()

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
@@ -37,6 +37,7 @@ import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1009;
 
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -119,7 +120,7 @@ public class ValidationUtils {
   public static List<MetadataIdentifier> validateDeletionMandatoryDataValue(
       Event event,
       @Nonnull ProgramStage programStage,
-      List<MetadataIdentifier> mandatoryDataElements) {
+      Collection<MetadataIdentifier> mandatoryDataElements) {
     if (!needsToValidateDataValues(event, programStage)) {
       return List.of();
     }
@@ -137,7 +138,7 @@ public class ValidationUtils {
       TrackerBundle bundle,
       Event event,
       @Nonnull ProgramStage programStage,
-      List<MetadataIdentifier> mandatoryDataElements) {
+      Collection<MetadataIdentifier> mandatoryDataElements) {
     if (!needsToValidateDataValues(event, programStage)) {
       return List.of();
     }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidator.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidator.java
@@ -38,14 +38,12 @@ import static org.hisp.dhis.tracker.imports.validation.validator.ValidationUtils
 import static org.hisp.dhis.tracker.imports.validation.validator.ValidationUtils.validateOptionSet;
 import static org.hisp.dhis.tracker.imports.validation.validator.ValidationUtils.validateValueType;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.domain.Event;
@@ -86,11 +84,8 @@ class DataValuesValidator implements Validator<Event> {
 
   private void validateMandatoryDataValues(
       Reporter reporter, TrackerBundle bundle, Event event, ProgramStage programStage) {
-    final List<MetadataIdentifier> mandatoryDataElements =
-        programStage.getProgramStageDataElements().stream()
-            .filter(ProgramStageDataElement::isCompulsory)
-            .map(de -> bundle.getPreheat().getIdSchemes().toMetadataIdentifier(de.getDataElement()))
-            .toList();
+    final Set<MetadataIdentifier> mandatoryDataElements =
+        bundle.getPreheat().getProgramStageDataElements(programStage).compulsory();
 
     validateMandatoryDataValue(bundle, event, programStage, mandatoryDataElements)
         .forEach(de -> reporter.addError(event, E1303, de));
@@ -121,9 +116,7 @@ class DataValuesValidator implements Validator<Event> {
       Reporter reporter, TrackerBundle bundle, Event event, ProgramStage programStage) {
     TrackerPreheat preheat = bundle.getPreheat();
     final Set<MetadataIdentifier> dataElements =
-        programStage.getProgramStageDataElements().stream()
-            .map(de -> preheat.getIdSchemes().toMetadataIdentifier(de.getDataElement()))
-            .collect(Collectors.toSet());
+        preheat.getProgramStageDataElements(programStage).members();
 
     Set<MetadataIdentifier> payloadDataElements =
         event.getDataValues().stream().map(DataValue::getDataElement).collect(Collectors.toSet());

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/ProgramStageDataElementFetcher.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/ProgramStageDataElementFetcher.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.program.notification;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fetches the data elements of a program stage that a notification template references. Projects
+ * the columns the renderer needs via SQL rather than loading entities.
+ *
+ * <p>Walking {@link org.hisp.dhis.program.ProgramStage#getProgramStageDataElements()} instead would
+ * initialize one DataElement entity per element of the stage, thousands on wide programs, and a
+ * stage coming from the tracker importer is preheat mapped and does not carry that association at
+ * all. This query is bounded by the number of template placeholders instead.
+ *
+ * <p>Restricting to the stage's data elements means a placeholder naming a data element that exists
+ * but is not part of the stage is absent from the result, which is what makes the renderer report
+ * it as such.
+ */
+@Component
+@RequiredArgsConstructor
+class ProgramStageDataElementFetcher {
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  /**
+   * One row per option of each referenced data element, or a single row with no option when it has
+   * no option set. Options are resolved in memory by the renderer, which knows the value to match.
+   */
+  private static final String SQL =
+      """
+      select de.uid as de_uid, de.optionsetid, ov.code as option_code, ov.name as option_name
+      from programstagedataelement psde
+      join dataelement de on de.dataelementid = psde.dataelementid
+      left join optionvalue ov on ov.optionsetid = de.optionsetid
+      where psde.programstageid = :programStageId
+        and de.uid = any(:dataElementUids)
+      """;
+
+  Map<String, ProgramStageDataElementInfo> fetch(long programStageId, Set<String> dataElementUids) {
+    if (dataElementUids.isEmpty()) {
+      return Map.of();
+    }
+
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+    parameters.addValue("programStageId", programStageId);
+    parameters.addValue("dataElementUids", dataElementUids.toArray(new String[0]));
+
+    Map<String, Map<String, String>> optionsByDataElement = new HashMap<>();
+    Set<String> withOptionSet = new HashSet<>();
+    jdbcTemplate.query(
+        SQL,
+        parameters,
+        rs -> {
+          String dataElementUid = rs.getString("de_uid");
+          Map<String, String> options =
+              optionsByDataElement.computeIfAbsent(dataElementUid, k -> new HashMap<>());
+          rs.getLong("optionsetid");
+          if (!rs.wasNull()) {
+            withOptionSet.add(dataElementUid);
+          }
+          String code = rs.getString("option_code");
+          if (code != null) {
+            options.put(code, rs.getString("option_name"));
+          }
+        });
+
+    Map<String, ProgramStageDataElementInfo> result = new HashMap<>(optionsByDataElement.size());
+    optionsByDataElement.forEach(
+        (uid, options) ->
+            result.put(uid, new ProgramStageDataElementInfo(withOptionSet.contains(uid), options)));
+    return result;
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/ProgramStageDataElementInfo.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/ProgramStageDataElementInfo.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.program.notification;
+
+import java.util.Map;
+
+/**
+ * Pre-fetched data element metadata for rendering {@code #{dataElement}} placeholders. Only data
+ * elements of the event's program stage are fetched, so a placeholder whose uid is absent is not
+ * part of the stage and renders as such.
+ *
+ * @param hasOptionSet whether the data element has an option set. Kept separate from {@code
+ *     optionCodeToName} as an option set with no options still renders as a missing option rather
+ *     than as the raw value.
+ * @param optionCodeToName option code to name of the data element's option set. The value to render
+ *     is looked up in here, mirroring what the renderer used to walk the option set for.
+ */
+record ProgramStageDataElementInfo(boolean hasOptionSet, Map<String, String> optionCodeToName) {}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/ProgramStageNotificationMessageRenderer.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/ProgramStageNotificationMessageRenderer.java
@@ -33,13 +33,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.notification.BaseNotificationMessageRenderer;
 import org.hisp.dhis.notification.TemplateVariable;
@@ -55,6 +53,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProgramStageNotificationMessageRenderer
     extends BaseNotificationMessageRenderer<TrackerEvent> {
+
+  private final ProgramStageDataElementFetcher programStageDataElementFetcher;
 
   public static final ImmutableMap<TemplateVariable, Function<TrackerEvent, String>>
       VARIABLE_RESOLVERS =
@@ -144,18 +144,18 @@ public class ProgramStageNotificationMessageRenderer
   protected Map<String, String> resolveDataElementValues(
       Set<String> elementKeys, TrackerEvent entity) {
     if (elementKeys.isEmpty()) {
-      return Maps.newHashMap();
+      return Map.of();
     }
 
-    Map<String, DataElement> dataElementsMap = new HashMap<>();
-    entity.getProgramStage().getDataElements().forEach(de -> dataElementsMap.put(de.getUid(), de));
+    Map<String, ProgramStageDataElementInfo> dataElements =
+        programStageDataElementFetcher.fetch(entity.getProgramStage().getId(), elementKeys);
 
     return entity.getEventDataValues().stream()
         .filter(dv -> elementKeys.contains(dv.getDataElement()))
         .collect(
             Collectors.toMap(
                 EventDataValue::getDataElement,
-                dv -> renderDataElementValue(dv, dataElementsMap.get(dv.getDataElement()))));
+                dv -> renderValue(dv, dataElements.get(dv.getDataElement()))));
   }
 
   @Override
@@ -181,5 +181,37 @@ public class ProgramStageNotificationMessageRenderer
     return av.getAttribute().hasOptionSet()
         ? getOptionName(av.getAttribute().getOptionSet(), value)
         : value;
+  }
+
+  /**
+   * Renders the display value for a {@link ProgramStageDataElementInfo} within the context of an
+   * event.
+   *
+   * <p>This method performs the following:
+   *
+   * <ul>
+   *   <li>Returns a placeholder if the data element is not part of the program stage.
+   *   <li>Returns a confidential replacement if the underlying value is {@code null}.
+   *   <li>Resolves OptionSet codes to their corresponding display names when applicable.
+   *   <li>Otherwise, returns the raw data value.
+   * </ul>
+   *
+   * @param dv the {@link EventDataValue} containing the stored value
+   * @param dataElement the projected data element associated with the value, null when it is not
+   *     part of the program stage
+   * @return a rendered, user-friendly value suitable for notifications or messages
+   */
+  private static String renderValue(EventDataValue dv, ProgramStageDataElementInfo dataElement) {
+    if (dataElement == null) {
+      return DE_NOT_IN_STAGE;
+    }
+    String value = dv.getValue();
+    if (value == null) {
+      return CONFIDENTIAL_VALUE_REPLACEMENT;
+    }
+    if (!dataElement.hasOptionSet()) {
+      return value;
+    }
+    return dataElement.optionCodeToName().getOrDefault(value, OPTION_SET_NOT_FOUND);
   }
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/SingleEventNotificationMessageRenderer.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/program/notification/SingleEventNotificationMessageRenderer.java
@@ -32,13 +32,11 @@ package org.hisp.dhis.tracker.program.notification;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.notification.BaseNotificationMessageRenderer;
 import org.hisp.dhis.notification.TemplateVariable;
@@ -50,6 +48,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SingleEventNotificationMessageRenderer
     extends BaseNotificationMessageRenderer<SingleEvent> {
+
+  private final ProgramStageDataElementFetcher programStageDataElementFetcher;
 
   public static final ImmutableMap<TemplateVariable, Function<SingleEvent, String>>
       VARIABLE_RESOLVERS =
@@ -109,18 +109,18 @@ public class SingleEventNotificationMessageRenderer
   protected Map<String, String> resolveDataElementValues(
       Set<String> elementKeys, SingleEvent entity) {
     if (elementKeys.isEmpty()) {
-      return Maps.newHashMap();
+      return Map.of();
     }
 
-    Map<String, DataElement> dataElementsMap = new HashMap<>();
-    entity.getProgramStage().getDataElements().forEach(de -> dataElementsMap.put(de.getUid(), de));
+    Map<String, ProgramStageDataElementInfo> dataElements =
+        programStageDataElementFetcher.fetch(entity.getProgramStage().getId(), elementKeys);
 
     return entity.getEventDataValues().stream()
         .filter(dv -> elementKeys.contains(dv.getDataElement()))
         .collect(
             Collectors.toMap(
                 EventDataValue::getDataElement,
-                dv -> renderDataElementValue(dv, dataElementsMap.get(dv.getDataElement()))));
+                dv -> renderValue(dv, dataElements.get(dv.getDataElement()))));
   }
 
   @Override
@@ -131,5 +131,37 @@ public class SingleEventNotificationMessageRenderer
   @Override
   protected Set<ExpressionType> getSupportedExpressionTypes() {
     return SUPPORTED_EXPRESSION_TYPES;
+  }
+
+  /**
+   * Renders the display value for a {@link ProgramStageDataElementInfo} within the context of an
+   * event.
+   *
+   * <p>This method performs the following:
+   *
+   * <ul>
+   *   <li>Returns a placeholder if the data element is not part of the program stage.
+   *   <li>Returns a confidential replacement if the underlying value is {@code null}.
+   *   <li>Resolves OptionSet codes to their corresponding display names when applicable.
+   *   <li>Otherwise, returns the raw data value.
+   * </ul>
+   *
+   * @param dv the {@link EventDataValue} containing the stored value
+   * @param dataElement the projected data element associated with the value, null when it is not
+   *     part of the program stage
+   * @return a rendered, user-friendly value suitable for notifications or messages
+   */
+  private static String renderValue(EventDataValue dv, ProgramStageDataElementInfo dataElement) {
+    if (dataElement == null) {
+      return DE_NOT_IN_STAGE;
+    }
+    String value = dv.getValue();
+    if (value == null) {
+      return CONFIDENTIAL_VALUE_REPLACEMENT;
+    }
+    if (!dataElement.hasOptionSet()) {
+      return value;
+    }
+    return dataElement.optionCodeToName().getOrDefault(value, OPTION_SET_NOT_FOUND);
   }
 }

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramStageMapperTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/mappers/ProgramStageMapperTest.java
@@ -29,13 +29,12 @@
  */
 package org.hisp.dhis.tracker.imports.preheat.mappers;
 
+import static org.hisp.dhis.test.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.tracker.imports.preheat.mappers.AttributeCreator.attributeValues;
 import static org.hisp.dhis.tracker.imports.preheat.mappers.AttributeCreator.setIdSchemeFields;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.hisp.dhis.attribute.AttributeValues;
 import org.hisp.dhis.dataelement.DataElement;
@@ -91,15 +90,9 @@ class ProgramStageMapperTest {
         AttributeValues.of(Map.of("m0GpPuMUfFW", "yellow")),
         mapped.getProgram().getAttributeValues());
 
-    Optional<ProgramStageDataElement> actual =
-        mapped.getProgramStageDataElements().stream().findFirst();
-    assertTrue(actual.isPresent());
-    ProgramStageDataElement value = actual.get();
-    assertEquals("khBzbxTLo8k", value.getDataElement().getUid());
-    assertEquals("clouds", value.getDataElement().getName());
-    assertEquals("orange", value.getDataElement().getCode());
-    assertEquals(
-        AttributeValues.of(Map.of("m0GpPuMUfFW", "purple")),
-        value.getDataElement().getAttributeValues());
+    // programStageDataElements is deliberately not mapped, as initializing it loaded one
+    // DataElement entity per element. ProgramStageDataElementsSupplier projects what the import
+    // needs instead.
+    assertIsEmpty(mapped.getProgramStageDataElements());
   }
 }

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.tracker.imports.domain.DataValue;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackerEvent;
+import org.hisp.dhis.tracker.imports.preheat.ProgramStageDataElements;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
@@ -82,6 +83,8 @@ class DataValuesValidatorTest {
   private static final String PROGRAM_STAGE_UID = "programStageUid";
 
   private static final String DATA_ELEMENT_UID = "dataElement";
+
+  private static final String MANDATORY_DATA_ELEMENT_UID = UID.generate().getValue();
 
   private static final String ORGANISATION_UNIT_UID = UID.generate().getValue();
 
@@ -137,6 +140,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         TrackerEvent.builder()
@@ -159,6 +163,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         TrackerEvent.builder()
@@ -183,7 +188,7 @@ class DataValuesValidatorTest {
     programStage.setAutoFields();
     ProgramStageDataElement mandatoryStageElement1 = new ProgramStageDataElement();
     DataElement mandatoryElement1 = new DataElement();
-    mandatoryElement1.setUid("MANDATORY_DE");
+    mandatoryElement1.setUid(MANDATORY_DATA_ELEMENT_UID);
     mandatoryStageElement1.setDataElement(mandatoryElement1);
     mandatoryStageElement1.setCompulsory(true);
     ProgramStageDataElement mandatoryStageElement2 = new ProgramStageDataElement();
@@ -194,6 +199,7 @@ class DataValuesValidatorTest {
     programStage.setProgramStageDataElements(
         Set.of(mandatoryStageElement1, mandatoryStageElement2));
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         TrackerEvent.builder()
@@ -219,7 +225,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_COMPLETE);
     ProgramStageDataElement mandatoryStageElement1 = new ProgramStageDataElement();
     DataElement mandatoryElement1 = new DataElement();
-    mandatoryElement1.setUid("MANDATORY_DE");
+    mandatoryElement1.setUid(MANDATORY_DATA_ELEMENT_UID);
     mandatoryStageElement1.setDataElement(mandatoryElement1);
     mandatoryStageElement1.setCompulsory(true);
     ProgramStageDataElement mandatoryStageElement2 = new ProgramStageDataElement();
@@ -230,6 +236,7 @@ class DataValuesValidatorTest {
     programStage.setProgramStageDataElements(
         Set.of(mandatoryStageElement1, mandatoryStageElement2));
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         TrackerEvent.builder()
@@ -258,7 +265,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_UPDATE_AND_INSERT);
     ProgramStageDataElement mandatoryStageElement1 = new ProgramStageDataElement();
     DataElement mandatoryElement1 = new DataElement();
-    mandatoryElement1.setUid("MANDATORY_DE");
+    mandatoryElement1.setUid(MANDATORY_DATA_ELEMENT_UID);
     mandatoryStageElement1.setDataElement(mandatoryElement1);
     mandatoryStageElement1.setCompulsory(true);
     ProgramStageDataElement mandatoryStageElement2 = new ProgramStageDataElement();
@@ -269,8 +276,10 @@ class DataValuesValidatorTest {
     programStage.setProgramStageDataElements(
         Set.of(mandatoryStageElement1, mandatoryStageElement2));
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
     when(preheat.getTrackerEvent(eventUid))
-        .thenReturn(event(eventUid, savedStatus, Set.of("MANDATORY_DE", DATA_ELEMENT_UID)));
+        .thenReturn(
+            event(eventUid, savedStatus, Set.of(MANDATORY_DATA_ELEMENT_UID, DATA_ELEMENT_UID)));
 
     Event event =
         TrackerEvent.builder()
@@ -299,7 +308,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_UPDATE_AND_INSERT);
     ProgramStageDataElement mandatoryStageElement1 = new ProgramStageDataElement();
     DataElement mandatoryElement1 = new DataElement();
-    mandatoryElement1.setUid("MANDATORY_DE");
+    mandatoryElement1.setUid(MANDATORY_DATA_ELEMENT_UID);
     mandatoryStageElement1.setDataElement(mandatoryElement1);
     mandatoryStageElement1.setCompulsory(true);
     ProgramStageDataElement mandatoryStageElement2 = new ProgramStageDataElement();
@@ -310,6 +319,7 @@ class DataValuesValidatorTest {
     programStage.setProgramStageDataElements(
         Set.of(mandatoryStageElement1, mandatoryStageElement2));
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
     when(preheat.getTrackerEvent(eventUid)).thenReturn(event(eventUid, savedStatus));
 
     Event event =
@@ -344,6 +354,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement, true);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue dataValue = dataValue();
     dataValue.setDataElement(MetadataIdentifier.ofCode("DE_424050"));
@@ -380,6 +391,7 @@ class DataValuesValidatorTest {
     mandatoryStageElement1.setCompulsory(true);
     programStage.setProgramStageDataElements(Set.of(mandatoryStageElement1));
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue notPresentDataValue = dataValue();
     notPresentDataValue.setDataElement(MetadataIdentifier.ofUid("de_not_present_in_program_stage"));
@@ -415,6 +427,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue dataValue = dataValue();
     dataValue.setDataElement(MetadataIdentifier.ofCode("DE_424050"));
@@ -443,6 +456,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         TrackerEvent.builder()
@@ -469,6 +483,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement, false);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -494,6 +509,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement, true);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -520,6 +536,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_UPDATE_AND_INSERT);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -547,6 +564,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_UPDATE_AND_INSERT);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
     when(preheat.getTrackerEvent(eventUid))
         .thenReturn(new org.hisp.dhis.tracker.model.TrackerEvent());
 
@@ -575,6 +593,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_UPDATE_AND_INSERT);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -601,6 +620,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_COMPLETE);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -627,6 +647,7 @@ class DataValuesValidatorTest {
     programStage.setValidationStrategy(ValidationStrategy.ON_COMPLETE);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -652,6 +673,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement, true);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue("1");
@@ -677,6 +699,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement, true);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue("1");
@@ -702,6 +725,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement, true);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue("1");
@@ -727,6 +751,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement, false);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setValue(null);
@@ -752,6 +777,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     FileResource fileResource = new FileResource();
     fileResource.setAssigned(true);
@@ -789,6 +815,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     FileResource fileResource = new FileResource();
     fileResource.setAssigned(true);
@@ -878,6 +905,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         TrackerEvent.builder()
@@ -909,6 +937,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         TrackerEvent.builder()
@@ -941,6 +970,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         TrackerEvent.builder()
@@ -973,6 +1003,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         TrackerEvent.builder()
@@ -998,6 +1029,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         TrackerEvent.builder()
@@ -1026,6 +1058,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(validDataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     Event event =
         TrackerEvent.builder()
@@ -1048,6 +1081,7 @@ class DataValuesValidatorTest {
     ProgramStage programStage = programStage(dataElement());
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(PROGRAM_STAGE_UID)))
         .thenReturn(programStage);
+    stubProgramStageDataElements(programStage);
 
     DataValue validDataValue = dataValue();
     validDataValue.setDataElement(MetadataIdentifier.ofUid(DATA_ELEMENT_UID));
@@ -1130,6 +1164,33 @@ class DataValuesValidatorTest {
         new ProgramStageDataElement(programStage, dataElement);
     programStageDataElement.setCompulsory(compulsory);
     return Set.of(programStageDataElement);
+  }
+
+  /**
+   * Stubs the projected data elements of the given stage from its {@code programStageDataElements},
+   * which is what {@link
+   * org.hisp.dhis.tracker.imports.preheat.supplier.ProgramStageDataElementsSupplier} produces at
+   * runtime. The association itself is not mapped into the preheat anymore, so the validator reads
+   * the projection instead.
+   */
+  private void stubProgramStageDataElements(ProgramStage programStage) {
+    Set<ProgramStageDataElement> psdes = programStage.getProgramStageDataElements();
+    // read the idScheme off the mock, as the supplier does, so tests overriding it are honoured.
+    // build the value before stubbing, calling a mock inside thenReturn nests the stubbing.
+    TrackerIdSchemeParams schemes = preheat.getIdSchemes();
+    ProgramStageDataElements projected =
+        new ProgramStageDataElements(
+            psdes.stream()
+                .filter(ProgramStageDataElement::isCompulsory)
+                .map(psde -> schemes.toMetadataIdentifier(psde.getDataElement()))
+                .collect(Collectors.toSet()),
+            psdes.stream()
+                .map(psde -> schemes.toMetadataIdentifier(psde.getDataElement()))
+                .collect(Collectors.toSet()),
+            psdes.stream()
+                .map(psde -> UID.of(psde.getDataElement().getUid()))
+                .collect(Collectors.toSet()));
+    when(preheat.getProgramStageDataElements(programStage)).thenReturn(projected);
   }
 
   private OrganisationUnit organisationUnit() {


### PR DESCRIPTION
Backport of #24773.

Differs from master: `BaseNotificationMessageRenderer.renderDataElementValue` is deleted there, but
2.43's copy has a null value to `CONFIDENTIAL_VALUE_REPLACEMENT` branch master no longer has. That
branch is restored in the two replacement `renderValue` methods, so behaviour is unchanged.
