### PR TITLE
fix: reject OAuth2 client PKCE opt-out

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
@@ -51,7 +51,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.NonTransactional;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -93,7 +92,6 @@ import org.springframework.util.StringUtils;
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@Slf4j
 @Service
 public class Dhis2OAuth2ClientServiceImpl
     implements Dhis2OAuth2ClientService, RegisteredClientRepository {
@@ -541,9 +539,8 @@ public class Dhis2OAuth2ClientServiceImpl
    * <p>{@code clientSettings} must parse with the same Jackson configuration {@link #toObject}
    * uses, and must carry both {@code settings.client.require-proof-key} and {@code
    * settings.client.require-authorization-consent} as booleans — Spring AS unboxes these on every
-   * authorize call, so a partial map would NPE at runtime. An explicit {@code
-   * require-proof-key:false} remains a supported (temporary) opt-out for legacy integrations, but
-   * is logged so the downgrade is auditable.
+   * authorize call, so a partial map would NPE at runtime. {@code
+   * settings.client.require-proof-key} must be {@code true}; disabling PKCE is rejected.
    */
   private void validateSettings(Dhis2OAuth2Client entity, Consumer<ErrorReport> errors) {
     String clientSettings = entity.getClientSettings();
@@ -556,11 +553,11 @@ public class Dhis2OAuth2ClientServiceImpl
         checkRequiredBooleanSetting(
             settings, ConfigurationSettingNames.Client.REQUIRE_AUTHORIZATION_CONSENT, errors);
         if (Boolean.FALSE.equals(proofKey)) {
-          log.warn(
-              "OAuth2 client '{}' explicitly opts out of PKCE (require-proof-key=false). This is a"
-                  + " temporary escape hatch for legacy integrations; new authorization-code"
-                  + " clients should use S256 PKCE.",
-              entity.getClientId());
+          errors.accept(
+              new ErrorReport(
+                  Dhis2OAuth2Client.class,
+                  ErrorCode.E4000,
+                  "PKCE cannot be disabled: settings.client.require-proof-key must be true."));
         }
       }
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/client/Dhis2OAuth2ClientServiceImpl.java
@@ -540,7 +540,9 @@ public class Dhis2OAuth2ClientServiceImpl
    * uses, and must carry both {@code settings.client.require-proof-key} and {@code
    * settings.client.require-authorization-consent} as booleans — Spring AS unboxes these on every
    * authorize call, so a partial map would NPE at runtime. {@code
-   * settings.client.require-proof-key} must be {@code true}; disabling PKCE is rejected.
+   * settings.client.require-proof-key} must be {@code true} for {@code authorization_code} clients;
+   * disabling PKCE is rejected. {@code client_credentials} clients (the DCR system registrar) are
+   * not subject to this check.
    */
   private void validateSettings(Dhis2OAuth2Client entity, Consumer<ErrorReport> errors) {
     String clientSettings = entity.getClientSettings();
@@ -552,7 +554,12 @@ public class Dhis2OAuth2ClientServiceImpl
                 settings, ConfigurationSettingNames.Client.REQUIRE_PROOF_KEY, errors);
         checkRequiredBooleanSetting(
             settings, ConfigurationSettingNames.Client.REQUIRE_AUTHORIZATION_CONSENT, errors);
-        if (Boolean.FALSE.equals(proofKey)) {
+        // PKCE applies to the authorization_code grant only. The DCR system registrar is
+        // client_credentials and is created with the SAS builder default (false on SAS 1.x);
+        // a full metadata export/import must be able to re-import it.
+        if (Boolean.FALSE.equals(proofKey)
+            && getAuthorizationGrantTypesSet(entity)
+                .contains(AuthorizationGrantType.AUTHORIZATION_CODE)) {
           errors.accept(
               new ErrorReport(
                   Dhis2OAuth2Client.class,

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2ClientControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/OAuth2ClientControllerTest.java
@@ -31,7 +31,6 @@ package org.hisp.dhis.webapi.controller.security;
 
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -561,8 +560,7 @@ class OAuth2ClientControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
-  void testExplicitProofKeyOptOutStillAccepted() {
-    // require-proof-key:false remains a supported, logged opt-out for legacy integrations.
+  void testExplicitProofKeyOptOutRejected() {
     String body =
         """
         {
@@ -575,12 +573,7 @@ class OAuth2ClientControllerTest extends H2ControllerIntegrationTestBase {
           "clientSettings":"{\\"@class\\":\\"java.util.Collections$UnmodifiableMap\\",\\"settings.client.require-proof-key\\":false,\\"settings.client.require-authorization-consent\\":true}"
         }
         """;
-    assertStatus(HttpStatus.CREATED, POST("/oAuth2Clients", body));
-
-    RegisteredClient registeredClient = clientService.findByClientId("client-proof-key-optout");
-    assertNotNull(registeredClient);
-    assertFalse(registeredClient.getClientSettings().isRequireProofKey());
-    assertTrue(registeredClient.getClientSettings().isRequireAuthorizationConsent());
+    assertStatus(HttpStatus.CONFLICT, POST("/oAuth2Clients", body));
   }
 
   private String createClient(String clientId, String name) {


### PR DESCRIPTION
## Change

Admin/metadata writes that set `settings.client.require-proof-key` to `false` are rejected with `E4000`. There is no longer a logged escape hatch for non-PKCE authorization-code clients.

Blank `clientSettings` still defaults to PKCE required + consent required. Already-persisted clients keep stored settings until updated.

## Tests

`testExplicitProofKeyOptOutRejected` replaces the old opt-out-accepted case.

AI Assisted