### PR TITLE
fix: sort events by enrollment org unit (DHIS2-21995)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -609,6 +609,7 @@ public enum ErrorCode {
   E7243("Duplicate stage dimension identifier: `{0}`"),
   E7244("Multiple stages in stage-specific dimensions are not allowed: `{0}`"),
   E7245("Program stage `{0}` does not belong to program `{1}`"),
+  E7246("Sorting by `{0}` requires ENROLLMENT_OU as a dimension or filter"),
 
   /* TE analytics */
   E7250("Dimension is not a fully qualified: `{0}`"),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -81,6 +81,7 @@ import org.hisp.dhis.analytics.QueryKey;
 import org.hisp.dhis.analytics.QueryParamsBuilder;
 import org.hisp.dhis.analytics.SortOrder;
 import org.hisp.dhis.analytics.TimeField;
+import org.hisp.dhis.analytics.event.data.ou.OrgUnitSqlConstants;
 import org.hisp.dhis.analytics.event.data.programindicator.disag.PiDisagInfo;
 import org.hisp.dhis.analytics.table.model.Partitions;
 import org.hisp.dhis.common.AnalyticsDateFilter;
@@ -1302,6 +1303,13 @@ public class EventQueryParams extends DataQueryParams {
 
   public boolean hasEnrollmentOu() {
     return hasEnrollmentOuDimension() || hasEnrollmentOuFilter();
+  }
+
+  /** Indicates whether any sort item reads an enrollment org unit column. */
+  public boolean hasEnrollmentOuSort() {
+    return Stream.concat(asc.stream(), desc.stream())
+        .map(QueryItem::getItemId)
+        .anyMatch(OrgUnitSqlConstants.RESULT_ALIASES::contains);
   }
 
   public List<DimensionalItemObject> getEnrollmentOuDimensionItems() {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -1305,11 +1305,12 @@ public class EventQueryParams extends DataQueryParams {
     return hasEnrollmentOuDimension() || hasEnrollmentOuFilter();
   }
 
-  /** Indicates whether any sort item reads an enrollment org unit column. */
-  public boolean hasEnrollmentOuSort() {
+  /** Returns the first sort item that reads an enrollment org unit column, if any. */
+  public Optional<String> getEnrollmentOuSortColumn() {
     return Stream.concat(asc.stream(), desc.stream())
         .map(QueryItem::getItemId)
-        .anyMatch(OrgUnitSqlConstants.RESULT_ALIASES::contains);
+        .filter(OrgUnitSqlConstants.RESULT_ALIASES::contains)
+        .findFirst();
   }
 
   public List<DimensionalItemObject> getEnrollmentOuDimensionItems() {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -138,6 +138,7 @@ import org.hisp.dhis.analytics.common.ProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.ou.OrgUnitSqlConstants;
 import org.hisp.dhis.analytics.event.data.ou.OrgUnitSqlCoordinator;
+import org.hisp.dhis.analytics.event.data.ou.OrgUnitSqlFragments;
 import org.hisp.dhis.analytics.event.data.programindicator.disag.PiDisagDataHandler;
 import org.hisp.dhis.analytics.event.data.programindicator.disag.PiDisagInfoInitializer;
 import org.hisp.dhis.analytics.event.data.programindicator.disag.PiDisagQueryGenerator;
@@ -342,6 +343,15 @@ public abstract class AbstractJdbcEventAnalyticsManager {
 
   private String getColumnExpression(
       CteContext cteContext, EventQueryParams params, QueryItem item) {
+    // Enrollment org unit columns are read from the joined enrollment analytics table. Everything
+    // below resolves columns on the event table.
+    Optional<String> enrollmentOuColumn =
+        OrgUnitSqlFragments.sortColumn(item.getItem().getUid(), sqlBuilder);
+
+    if (enrollmentOuColumn.isPresent()) {
+      return enrollmentOuColumn.get();
+    }
+
     DimensionItemType itemType = item.getItem().getDimensionItemType();
 
     if (itemType == null) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -75,6 +75,7 @@ import org.hisp.dhis.analytics.common.ColumnHeader;
 import org.hisp.dhis.analytics.event.EventDataQueryService;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.QueryItemLocator;
+import org.hisp.dhis.analytics.event.data.ou.OrgUnitSqlConstants;
 import org.hisp.dhis.analytics.event.data.queryitem.QueryItemFilterHandlerRegistry;
 import org.hisp.dhis.analytics.table.EnrollmentAnalyticsColumnName;
 import org.hisp.dhis.analytics.table.EventAnalyticsColumnName;
@@ -978,7 +979,7 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
       Program program,
       EventOutputType type,
       RequestTypeAware.EndpointItem endpointItem) {
-    if (isSortable(item)) {
+    if (isSortable(item, endpointItem)) {
       return new QueryItem(
           new BaseDimensionalItemObject(translateItemIfNecessary(item, endpointItem)));
     }
@@ -1264,6 +1265,17 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
 
     static boolean isSortable(String itemName) {
       return Arrays.stream(values()).map(SortableItems::getItemName).anyMatch(itemName::equals);
+    }
+
+    /**
+     * Enrollment org unit columns are projected by the ENROLLMENT_OU join, which only the event
+     * endpoint builds, so they are sortable there alone.
+     */
+    static boolean isSortable(String itemName, RequestTypeAware.EndpointItem endpointItem) {
+      if (OrgUnitSqlConstants.RESULT_ALIASES.contains(itemName)) {
+        return endpointItem == RequestTypeAware.EndpointItem.EVENT;
+      }
+      return isSortable(itemName);
     }
 
     static String translateItemIfNecessary(String item, RequestTypeAware.EndpointItem type) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
@@ -38,6 +38,7 @@ import static org.hisp.dhis.system.util.ValidationUtils.valueIsComparable;
 import static org.hisp.dhis.util.DateUtils.toMediumDate;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -96,6 +97,10 @@ public class DefaultEventQueryValidator implements EventQueryValidator {
     }
     if (!params.hasOrganisationUnits() && !params.hasEnrollmentOu()) {
       return new ErrorMessage(ErrorCode.E7200);
+    }
+    Optional<String> enrollmentOuSortColumn = params.getEnrollmentOuSortColumn();
+    if (enrollmentOuSortColumn.isPresent() && !params.hasEnrollmentOu()) {
+      return new ErrorMessage(ErrorCode.E7246, enrollmentOuSortColumn.get());
     }
     if (!params.getDuplicateDimensions().isEmpty()) {
       return new ErrorMessage(ErrorCode.E7201, params.getDuplicateDimensions());

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/ou/OrgUnitSqlConstants.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/ou/OrgUnitSqlConstants.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.analytics.event.data.ou;
 
 import static org.hisp.dhis.analytics.AnalyticsConstants.ANALYTICS_TBL_ALIAS;
 
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.analytics.common.ColumnHeader;
@@ -53,4 +54,8 @@ public final class OrgUnitSqlConstants {
   public static final String ENROLLMENT_OU_RESULT_ALIAS = ColumnHeader.ENROLLMENT_OU.getItem();
   public static final String ENROLLMENT_OU_NAME_RESULT_ALIAS =
       ColumnHeader.ENROLLMENT_OU_NAME.getItem();
+
+  /** The output columns contributed by the ENROLLMENT_OU join. */
+  public static final Set<String> RESULT_ALIASES =
+      Set.of(ENROLLMENT_OU_RESULT_ALIAS, ENROLLMENT_OU_NAME_RESULT_ALIAS);
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/ou/OrgUnitSqlCoordinator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/ou/OrgUnitSqlCoordinator.java
@@ -53,7 +53,7 @@ public final class OrgUnitSqlCoordinator {
 
   /**
    * Adds the ENROLLMENT_OU join to a {@link SelectBuilder} query when enrollment OU is used as a
-   * filter or dimension.
+   * filter, dimension or sort.
    *
    * @param sb builder being assembled
    * @param params query parameters
@@ -61,7 +61,7 @@ public final class OrgUnitSqlCoordinator {
    */
   public static void addJoinIfNeeded(
       SelectBuilder sb, EventQueryParams params, SqlBuilder sqlBuilder) {
-    if (!params.hasEnrollmentOu()) {
+    if (!needsJoin(params)) {
       return;
     }
 
@@ -82,9 +82,17 @@ public final class OrgUnitSqlCoordinator {
    */
   public static void appendLegacyJoin(
       StringBuilder sql, EventQueryParams params, SqlBuilder sqlBuilder) {
-    if (params.hasEnrollmentOu()) {
+    if (needsJoin(params)) {
       sql.append(OrgUnitSqlFragments.innerJoinClause(enrollmentTableName(params), sqlBuilder));
     }
+  }
+
+  /**
+   * Indicates whether the enrollment analytics table must be joined. Sorting on an enrollment OU
+   * column needs the join even when enrollment OU is not requested as a dimension or filter.
+   */
+  private static boolean needsJoin(EventQueryParams params) {
+    return params.hasEnrollmentOu() || params.hasEnrollmentOuSort();
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/ou/OrgUnitSqlCoordinator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/ou/OrgUnitSqlCoordinator.java
@@ -53,7 +53,7 @@ public final class OrgUnitSqlCoordinator {
 
   /**
    * Adds the ENROLLMENT_OU join to a {@link SelectBuilder} query when enrollment OU is used as a
-   * filter, dimension or sort.
+   * filter or dimension.
    *
    * @param sb builder being assembled
    * @param params query parameters
@@ -61,7 +61,7 @@ public final class OrgUnitSqlCoordinator {
    */
   public static void addJoinIfNeeded(
       SelectBuilder sb, EventQueryParams params, SqlBuilder sqlBuilder) {
-    if (!needsJoin(params)) {
+    if (!params.hasEnrollmentOu()) {
       return;
     }
 
@@ -82,17 +82,9 @@ public final class OrgUnitSqlCoordinator {
    */
   public static void appendLegacyJoin(
       StringBuilder sql, EventQueryParams params, SqlBuilder sqlBuilder) {
-    if (needsJoin(params)) {
+    if (params.hasEnrollmentOu()) {
       sql.append(OrgUnitSqlFragments.innerJoinClause(enrollmentTableName(params), sqlBuilder));
     }
-  }
-
-  /**
-   * Indicates whether the enrollment analytics table must be joined. Sorting on an enrollment OU
-   * column needs the join even when enrollment OU is not requested as a dimension or filter.
-   */
-  private static boolean needsJoin(EventQueryParams params) {
-    return params.hasEnrollmentOu() || params.hasEnrollmentOuSort();
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/ou/OrgUnitSqlFragments.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/ou/OrgUnitSqlFragments.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.analytics.event.data.ou;
 
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.db.sql.SqlBuilder;
@@ -95,6 +96,28 @@ public final class OrgUnitSqlFragments {
             OrgUnitSqlConstants.ENROLLMENT_OU_NAME_COLUMN)
         + " as "
         + OrgUnitSqlConstants.ENROLLMENT_OU_NAME_RESULT_ALIAS;
+  }
+
+  /**
+   * Builds the sort column for an enrollment OU output column, reading it from the joined
+   * enrollment analytics table.
+   *
+   * @param item the output column name to sort on
+   * @param sqlBuilder database-specific SQL builder for column quoting
+   * @return the qualified enrollment table column, or empty when the item is not an enrollment OU
+   *     output column
+   */
+  public static Optional<String> sortColumn(String item, SqlBuilder sqlBuilder) {
+    String column = null;
+
+    if (OrgUnitSqlConstants.ENROLLMENT_OU_RESULT_ALIAS.equals(item)) {
+      column = OrgUnitSqlConstants.ENROLLMENT_OU_COLUMN;
+    } else if (OrgUnitSqlConstants.ENROLLMENT_OU_NAME_RESULT_ALIAS.equals(item)) {
+      column = OrgUnitSqlConstants.ENROLLMENT_OU_NAME_COLUMN;
+    }
+
+    return Optional.ofNullable(column)
+        .map(col -> sqlBuilder.quote(OrgUnitSqlConstants.ENROLLMENT_TABLE_ALIAS, col));
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -1485,6 +1485,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
             .addAscSortItem(
                 new QueryItem(
                     new BaseDimensionalItemObject(ColumnHeader.ENROLLMENT_OU_NAME.getItem())))
+            .withEnrollmentOuDimension(List.of(createOrganisationUnit('A')))
             .build();
 
     String sortClause =
@@ -1504,6 +1505,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
             .withEndDate(to)
             .addDescSortItem(
                 new QueryItem(new BaseDimensionalItemObject(ColumnHeader.ENROLLMENT_OU.getItem())))
+            .withEnrollmentOuDimension(List.of(createOrganisationUnit('A')))
             .build();
 
     String sortClause =
@@ -1511,46 +1513,6 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
             new CteContext(org.hisp.dhis.analytics.common.EndpointItem.EVENT), params);
 
     assertThat(sortClause, containsString("enrl.\"ou\" desc nulls last"));
-  }
-
-  @Test
-  void testExperimentalFromClauseIncludesEnrollmentOuJoinWhenSorting() {
-    EventQueryParams params =
-        new EventQueryParams.Builder()
-            .withProgram(programA)
-            .withTableName("analytics_event_test")
-            .withStartDate(from)
-            .withEndDate(to)
-            .addAscSortItem(
-                new QueryItem(
-                    new BaseDimensionalItemObject(ColumnHeader.ENROLLMENT_OU_NAME.getItem())))
-            .build();
-
-    SelectBuilder sb = new SelectBuilder();
-    eventSubject.addFromClause(sb, params);
-    String fromClause = sb.build();
-
-    assertThat(fromClause, containsString("analytics_enrollment_"));
-    assertThat(fromClause, containsString("enrl"));
-  }
-
-  @Test
-  void testFromClauseIncludesEnrollmentOuJoinWhenSorting() {
-    EventQueryParams params =
-        new EventQueryParams.Builder()
-            .withProgram(programA)
-            .withTableName("analytics_event_test")
-            .withStartDate(from)
-            .withEndDate(to)
-            .addAscSortItem(
-                new QueryItem(
-                    new BaseDimensionalItemObject(ColumnHeader.ENROLLMENT_OU_NAME.getItem())))
-            .build();
-
-    String fromClause = eventSubject.getFromClause(params);
-
-    assertThat(fromClause, containsString("inner join analytics_enrollment_"));
-    assertThat(fromClause, containsString("enrl on ax.\"enrollment\" = enrl.\"enrollment\""));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -205,7 +205,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
   private final UUID uuidB = UUID.fromString("1786142e-6d51-48e3-8bbe-9cc2a2836120");
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     programA = createProgram('A');
     dataElementA = createDataElement('A', ValueType.INTEGER, AggregationType.SUM);
     dataElementA.setUid("fWIAEtYVEGk");

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -86,6 +86,7 @@ import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
+import org.hisp.dhis.analytics.common.ColumnHeader;
 import org.hisp.dhis.analytics.common.CteContext;
 import org.hisp.dhis.analytics.common.ProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.analytics.event.EventQueryParams;
@@ -1471,6 +1472,85 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest {
 
     assertThat(selectClause, containsString("enrl.\"ou\" as enrollmentou"));
     assertThat(selectClause, containsString("enrl.\"ouname\" as enrollmentouname"));
+  }
+
+  @Test
+  void testSortClauseReadsEnrollmentOuNameFromEnrollmentTable() {
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .withProgram(programA)
+            .withTableName("analytics_event_test")
+            .withStartDate(from)
+            .withEndDate(to)
+            .addAscSortItem(
+                new QueryItem(
+                    new BaseDimensionalItemObject(ColumnHeader.ENROLLMENT_OU_NAME.getItem())))
+            .build();
+
+    String sortClause =
+        eventSubject.getCteAwareSortClause(
+            new CteContext(org.hisp.dhis.analytics.common.EndpointItem.EVENT), params);
+
+    assertThat(sortClause, containsString("enrl.\"ouname\" asc nulls last"));
+  }
+
+  @Test
+  void testSortClauseReadsEnrollmentOuFromEnrollmentTable() {
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .withProgram(programA)
+            .withTableName("analytics_event_test")
+            .withStartDate(from)
+            .withEndDate(to)
+            .addDescSortItem(
+                new QueryItem(new BaseDimensionalItemObject(ColumnHeader.ENROLLMENT_OU.getItem())))
+            .build();
+
+    String sortClause =
+        eventSubject.getCteAwareSortClause(
+            new CteContext(org.hisp.dhis.analytics.common.EndpointItem.EVENT), params);
+
+    assertThat(sortClause, containsString("enrl.\"ou\" desc nulls last"));
+  }
+
+  @Test
+  void testExperimentalFromClauseIncludesEnrollmentOuJoinWhenSorting() {
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .withProgram(programA)
+            .withTableName("analytics_event_test")
+            .withStartDate(from)
+            .withEndDate(to)
+            .addAscSortItem(
+                new QueryItem(
+                    new BaseDimensionalItemObject(ColumnHeader.ENROLLMENT_OU_NAME.getItem())))
+            .build();
+
+    SelectBuilder sb = new SelectBuilder();
+    eventSubject.addFromClause(sb, params);
+    String fromClause = sb.build();
+
+    assertThat(fromClause, containsString("analytics_enrollment_"));
+    assertThat(fromClause, containsString("enrl"));
+  }
+
+  @Test
+  void testFromClauseIncludesEnrollmentOuJoinWhenSorting() {
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .withProgram(programA)
+            .withTableName("analytics_event_test")
+            .withStartDate(from)
+            .withEndDate(to)
+            .addAscSortItem(
+                new QueryItem(
+                    new BaseDimensionalItemObject(ColumnHeader.ENROLLMENT_OU_NAME.getItem())))
+            .build();
+
+    String fromClause = eventSubject.getFromClause(params);
+
+    assertThat(fromClause, containsString("inner join analytics_enrollment_"));
+    assertThat(fromClause, containsString("enrl on ax.\"enrollment\" = enrl.\"enrollment\""));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryServiceTest.java
@@ -513,6 +513,48 @@ class DefaultEventDataQueryServiceTest {
     assertEquals("created", params.getDesc().get(0).getItemId());
   }
 
+  @Test
+  void getFromRequestAcceptsAscendingEnrollmentOuNameSortForEventEndpoint() {
+    lenient()
+        .when(queryItemLocator.getQueryItemFromDimension(anyString(), any(), any()))
+        .thenThrow(new IllegalQueryException(ErrorCode.E7224, "enrollmentouname"));
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, EVENT).asc(Set.of("enrollmentouname")).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getAsc().size());
+    assertEquals("enrollmentouname", params.getAsc().get(0).getItemId());
+  }
+
+  @Test
+  void getFromRequestAcceptsDescendingEnrollmentOuSortForEventEndpoint() {
+    lenient()
+        .when(queryItemLocator.getQueryItemFromDimension(anyString(), any(), any()))
+        .thenThrow(new IllegalQueryException(ErrorCode.E7224, "enrollmentou"));
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, EVENT).desc(Set.of("enrollmentou")).build();
+
+    EventQueryParams params = subject.getFromRequest(request);
+
+    assertEquals(1, params.getDesc().size());
+    assertEquals("enrollmentou", params.getDesc().get(0).getItemId());
+  }
+
+  @Test
+  void getFromRequestRejectsEnrollmentOuNameSortForEnrollmentEndpoint() {
+    when(queryItemLocator.getQueryItemFromDimension(
+            "enrollmentouname", program, EventOutputType.ENROLLMENT))
+        .thenThrow(new IllegalQueryException(ErrorCode.E7224, "enrollmentouname"));
+    EventDataQueryRequest request =
+        baseRequestBuilder(QUERY, ENROLLMENT).asc(Set.of("enrollmentouname")).build();
+
+    IllegalQueryException exception =
+        assertThrows(IllegalQueryException.class, () -> subject.getFromRequest(request));
+
+    assertEquals(ErrorCode.E7224, exception.getErrorCode());
+  }
+
   private QueryItem createDateQueryItem(String columnName) {
     return new QueryItem(
         new BaseDimensionalItemObject(columnName),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventQueryValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventQueryValidatorTest.java
@@ -104,7 +104,7 @@ class EventQueryValidatorTest extends TestBase {
   @InjectMocks private DefaultEventQueryValidator eventQueryValidator;
 
   @BeforeEach
-  public void setUpTest() {
+  void setUpTest() {
     prA = createProgram('A');
     prB = createProgram('B');
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventQueryValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventQueryValidatorTest.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.analytics.OrgUnitField;
 import org.hisp.dhis.analytics.QueryValidator;
 import org.hisp.dhis.analytics.TimeField;
+import org.hisp.dhis.analytics.common.ColumnHeader;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.table.EventAnalyticsColumnName;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
@@ -835,6 +836,38 @@ class EventQueryValidatorTest extends TestBase {
    * @param errorCode the {@link ErrorCode}.
    * @param params the {@link DataQueryParams}.
    */
+  @Test
+  void validateFailureEnrollmentOuSortWithoutEnrollmentOu() {
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .withProgram(prA)
+            .withStartDate(new DateTime(2010, 6, 1, 0, 0).toDate())
+            .withEndDate(new DateTime(2012, 3, 20, 0, 0).toDate())
+            .withOrganisationUnits(List.of(ouA))
+            .addAscSortItem(
+                new QueryItem(
+                    new BaseDimensionalItemObject(ColumnHeader.ENROLLMENT_OU_NAME.getItem())))
+            .build();
+
+    assertValidationError(ErrorCode.E7246, params);
+  }
+
+  @Test
+  void validateSuccessEnrollmentOuSortWithEnrollmentOuDimension() {
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .withProgram(prA)
+            .withStartDate(new DateTime(2010, 6, 1, 0, 0).toDate())
+            .withEndDate(new DateTime(2012, 3, 20, 0, 0).toDate())
+            .withEnrollmentOuDimension(List.of(ouA))
+            .addAscSortItem(
+                new QueryItem(
+                    new BaseDimensionalItemObject(ColumnHeader.ENROLLMENT_OU_NAME.getItem())))
+            .build();
+
+    eventQueryValidator.validate(params);
+  }
+
   private void assertValidationError(ErrorCode errorCode, EventQueryParams params) {
     IllegalQueryException ex =
         assertThrows(IllegalQueryException.class, () -> eventQueryValidator.validate(params));

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery7AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery7AutoTest.java
@@ -855,4 +855,168 @@ public class EventsQuery7AutoTest extends AnalyticsApiTest {
     validateRowValueByName(response, actualHeaders, 2, "ouname", "Ngelehun CHC");
     validateRowValueByName(response, actualHeaders, 2, "lastupdated", "2018-04-12 16:05:16.957");
   }
+
+  @Test
+  public void eventsSortedByEnrollmentOuNameAscending() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("asc=enrollmentouname")
+            .add("headers=enrollmentouname,ouname")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("page=1")
+            .add("dimension=pe:2022,ENROLLMENT_OU:Gtnbmf4LkOz;DiszpKrYNg8");
+
+    // When
+    ApiResponse response = actions.query().get("ur1Edk5Oe2n", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        10,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":false},\"items\":{\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"Gtnbmf4LkOz\":{\"name\":\"Motorbong MCHP\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"enrollmentou\":{\"name\":\"Enrollment org. unit\"},\"pe\":{},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"2022\":{\"name\":\"2022\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"}},\"dimensions\":{\"enrollmentou\":[\"Gtnbmf4LkOz\",\"DiszpKrYNg8\"],\"pe\":[]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "enrollmentouname",
+        "Enrollment org unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "enrollmentouname", "Motorbong MCHP");
+    validateRowValueByName(response, actualHeaders, 0, "ouname", "Ngelehun CHC");
+
+    // Validate selected values for row index 3
+    validateRowValueByName(response, actualHeaders, 3, "enrollmentouname", "Motorbong MCHP");
+    validateRowValueByName(response, actualHeaders, 3, "ouname", "Ngelehun CHC");
+
+    // Validate selected values for row index 6
+    validateRowValueByName(response, actualHeaders, 6, "enrollmentouname", "Motorbong MCHP");
+    validateRowValueByName(response, actualHeaders, 6, "ouname", "Ngelehun CHC");
+
+    // Validate selected values for row index 9
+    validateRowValueByName(response, actualHeaders, 9, "enrollmentouname", "Ngelehun CHC");
+    validateRowValueByName(response, actualHeaders, 9, "ouname", "Ngelehun CHC");
+  }
+
+  @Test
+  public void eventsSortedByEnrollmentOuNameDescending() throws JSONException {
+    // Read the 'expect.postgis' system property at runtime to adapt assertions.
+    boolean expectPostgis = isPostgres();
+
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("headers=enrollmentouname,ouname")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("pageSize=10")
+            .add("page=3")
+            .add("dimension=pe:2022,ENROLLMENT_OU:Gtnbmf4LkOz;DiszpKrYNg8")
+            .add("desc=enrollmentouname");
+
+    // When
+    ApiResponse response = actions.query().get("ur1Edk5Oe2n", JSON, JSON, params);
+
+    // Then
+    // 1. Validate Response Structure (Counts, Headers, Height/Width)
+    //    This helper checks basic counts and dimensions, adapting based on the runtime
+    // 'expectPostgis' flag.
+    validateResponseStructure(
+        response,
+        expectPostgis,
+        10,
+        2,
+        2); // Pass runtime flag, row count, and expected header counts
+
+    // 2. Extract Headers into a List of Maps for easy access by name
+    List<Map<String, Object>> actualHeaders =
+        response.extractList("headers", Map.class).stream()
+            .map(obj -> (Map<String, Object>) obj) // Ensure correct type
+            .collect(Collectors.toList());
+
+    // 3. Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":3,\"pageSize\":10,\"isLastPage\":false},\"items\":{\"DiszpKrYNg8\":{\"name\":\"Ngelehun CHC\"},\"Gtnbmf4LkOz\":{\"name\":\"Motorbong MCHP\"},\"EPEcjy3FWmI\":{\"name\":\"Lab monitoring\"},\"enrollmentou\":{\"name\":\"Enrollment org. unit\"},\"pe\":{},\"ur1Edk5Oe2n\":{\"name\":\"TB program\"},\"jdRD35YwbRH\":{\"name\":\"Sputum smear microscopy test\"},\"2022\":{\"name\":\"2022\"},\"ZkbAXlQUYJG\":{\"name\":\"TB visit\"}},\"dimensions\":{\"enrollmentou\":[\"Gtnbmf4LkOz\",\"DiszpKrYNg8\"],\"pe\":[]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // 4. Validate Headers By Name (conditionally checking PostGIS headers).
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "enrollmentouname",
+        "Enrollment org unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeaderPropertiesByName(
+        response,
+        actualHeaders,
+        "ouname",
+        "Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+
+    // rowContext not found or empty in the response, skipping assertions.
+
+    // 7. Assert row values by name at specific indices (sorted results).
+    // Validate selected values for row index 0
+    validateRowValueByName(response, actualHeaders, 0, "enrollmentouname", "Ngelehun CHC");
+    validateRowValueByName(response, actualHeaders, 0, "ouname", "Ngelehun CHC");
+
+    // Validate selected values for row index 3
+    validateRowValueByName(response, actualHeaders, 3, "enrollmentouname", "Ngelehun CHC");
+    validateRowValueByName(response, actualHeaders, 3, "ouname", "Ngelehun CHC");
+
+    // Validate selected values for row index 6
+    validateRowValueByName(response, actualHeaders, 6, "enrollmentouname", "Motorbong MCHP");
+    validateRowValueByName(response, actualHeaders, 6, "ouname", "Ngelehun CHC");
+
+    // Validate selected values for row index 9
+    validateRowValueByName(response, actualHeaders, 9, "enrollmentouname", "Motorbong MCHP");
+    validateRowValueByName(response, actualHeaders, 9, "ouname", "Ngelehun CHC");
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/event-query.json
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/generator/scenarios/event-query.json
@@ -349,6 +349,20 @@
       "version": {
         "min": 41
       }
+    },
+    {
+      "name": "eventsSortedByEnrollmentOuNameAscending",
+      "query": "/api/analytics/events/query/ur1Edk5Oe2n.json?dimension=pe:2022,ENROLLMENT_OU:Gtnbmf4LkOz;DiszpKrYNg8&headers=enrollmentouname,ouname&displayProperty=NAME&totalPages=false&pageSize=10&page=1&asc=enrollmentouname",
+      "version": {
+        "min": 44
+      }
+    },
+    {
+      "name": "eventsSortedByEnrollmentOuNameDescending",
+      "query": "/api/analytics/events/query/ur1Edk5Oe2n.json?dimension=pe:2022,ENROLLMENT_OU:Gtnbmf4LkOz;DiszpKrYNg8&headers=enrollmentouname,ouname&displayProperty=NAME&totalPages=false&pageSize=10&page=3&desc=enrollmentouname",
+      "version": {
+        "min": 44
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

`asc=enrollmentouname` on `/api/analytics/events/query` failed with 409 `E7224 Item identifier does not reference any data element, attribute or indicator part of the program`, even though `enrollmentouname` and `enrollmentou` both appear as response headers whenever `ENROLLMENT_OU` is requested. 

Both columns now sort on the events endpoint, reading from the joined enrollment
analytics table.
Using `enrollmentouname` as sort param  without `ENROLLMENT_OU` in the request, fails with a dedicated error.

| File | Why |
|---|---|
| `DefaultEventDataQueryService.java` *(start here)* | Where the sort was rejected. `SortableItems` gains an endpoint-aware `isSortable`. |
| `OrgUnitSqlFragments.java` | `sortColumn` maps the two output columns to their enrollment table columns. |
| `AbstractJdbcEventAnalyticsManager.java` | `getColumnExpression` resolves those columns before the generic item lookup. |
| `DefaultEventQueryValidator.java` | Rejects a sort on those columns when `ENROLLMENT_OU` is absent. |
| `ErrorCode.java` | New `E7246`. |
| `EventQueryParams.java` | `getEnrollmentOuSortColumn` finds the offending sort item for the message. |
| `OrgUnitSqlConstants.java` | `RESULT_ALIASES` holds the two column names in one place. 


## Fix

Three parts, one per "layer" the sort passes through.

**Sortability** is now endpoint-aware. The `ENROLLMENT_OU` SQL lives entirely in
`JdbcEventAnalyticsManager`, so the two columns sort on the events endpoint alone;
`/enrollments/query` keeps returning E7224 for them.

**Column resolution** points at the enrollment analytics table. Both values reach the grid through `enrl."ou" as enrollmentou` and `enrl."ouname" as enrollmentouname` off a join, so the ORDER BY names `enrl."ou"` and `enrl."ouname"` rather than the output alias.

**Validation** covers the case where nothing projects those columns. The join that supplies them only exists when `ENROLLMENT_OU` is a dimension or filter, so a sort naming them in any other request has nothing to order by. `DefaultEventQueryValidator` returns E7246, "Sorting by `enrollmentouname` requires ENROLLMENT_OU as a dimension or filter", instead of letting the query reach the database.
The above behaviour was discussed with @janhenrikoverland  and confirmed.

## Failing e2e tests

The Clickhouse e2e tests are failing because of an open issue with subexpression (see https://dhis2.atlassian.net/browse/DHIS2-21973)