### PR TITLE
fix: avoid loading full Option entities for program rule variable option sets

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,4 +46,12 @@ public interface OptionStore extends IdentifiableObjectStore<Option> {
   boolean existsAllOptions(@Nonnull UID optionSet, @Nonnull Collection<String> codes);
 
   Optional<Option> findOptionByCode(@Nonnull UID optionSet, @Nonnull String code);
+
+  /**
+   * Returns the options of the given option set as lightweight, transient {@link Option} instances
+   * carrying only name and code, ordered by sort order. Callers that don't need the full entity
+   * (uid, style/translations/attributeValues JSONB, etc.) should prefer this over {@code
+   * optionSet.getOptions()} to avoid materializing and JSONB-deserializing every option.
+   */
+  List<Option> findOptionsNameAndCode(@Nonnull UID optionSet);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -98,6 +98,18 @@ public class HibernateOptionStore extends HibernateIdentifiableObjectStore<Optio
             .setParameter("code", code)
             .list();
     return options.isEmpty() ? Optional.empty() : Optional.of(options.get(0));
+  }
+
+  @Override
+  public List<Option> findOptionsNameAndCode(@Nonnull UID optionSet) {
+    String hql =
+        "select new org.hisp.dhis.option.Option(o.name, o.code) "
+            + "from Option o where o.optionSet.uid = :optionSetId order by o.sortOrder";
+
+    Query<Option> query = getQuery(hql);
+    query.setParameter("optionSetId", optionSet.getValue());
+
+    return query.list();
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionStore.java
@@ -103,8 +103,9 @@ public class HibernateOptionStore extends HibernateIdentifiableObjectStore<Optio
   @Override
   public List<Option> findOptionsNameAndCode(@Nonnull UID optionSet) {
     String hql =
-        "select new org.hisp.dhis.option.Option(o.name, o.code) "
-            + "from Option o where o.optionSet.uid = :optionSetId order by o.sortOrder";
+        "select new org.hisp.dhis.option.Option(option.name, option.code) "
+            + "from OptionSet as optionset join optionset.options as option "
+            + "where optionset.uid = :optionSetId order by option.sortOrder";
 
     Query<Option> query = getQuery(hql);
     query.setParameter("optionSetId", optionSet.getValue());

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,9 +54,11 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.option.OptionStore;
 import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleAction;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
@@ -84,6 +86,7 @@ import org.springframework.stereotype.Service;
 @Service("org.hisp.dhis.tracker.imports.programrule.engine.ProgramRuleEntityMapperService")
 public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityMapperService {
   private final I18nManager i18nManager;
+  private final OptionStore optionStore;
 
   @Override
   public List<Rule> toRules(@Nonnull List<ProgramRule> programRules) {
@@ -443,12 +446,18 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
       return List.of();
     }
 
+    // Only name and code are ever used below, so a narrow store projection is fetched instead of
+    // the full OptionSet.getOptions() entity collection - that avoids materializing (and
+    // JSONB-deserializing the style/translations/attributeValues of) every Option just to read
+    // two plain varchar columns off each one.
     if (prv.hasDataElement() && prv.getDataElement().hasOptionSet()) {
-      return prv.getDataElement().getOptionSet().getOptions().stream()
+      return optionStore
+          .findOptionsNameAndCode(UID.of(prv.getDataElement().getOptionSet()))
+          .stream()
           .map(op -> new Option(op.getName(), op.getCode()))
           .toList();
     } else if (prv.hasTrackedEntityAttribute() && prv.getAttribute().hasOptionSet()) {
-      return prv.getAttribute().getOptionSet().getOptions().stream()
+      return optionStore.findOptionsNameAndCode(UID.of(prv.getAttribute().getOptionSet())).stream()
           .map(op -> new Option(op.getName(), op.getCode()))
           .toList();
     }

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Sets;
@@ -54,6 +55,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.dataelement.DataElement;
@@ -61,6 +63,7 @@ import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.option.OptionStore;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 import org.hisp.dhis.programrule.ProgramRule;
@@ -72,6 +75,8 @@ import org.hisp.dhis.rules.api.DataItem;
 import org.hisp.dhis.rules.models.AttributeType;
 import org.hisp.dhis.rules.models.Rule;
 import org.hisp.dhis.rules.models.RuleAction;
+import org.hisp.dhis.rules.models.RuleVariable;
+import org.hisp.dhis.rules.models.RuleVariableCurrentEvent;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.test.TrackerTestBase;
 import org.hisp.dhis.util.ObjectUtils;
@@ -99,9 +104,15 @@ class ProgramRuleEntityMapperServiceTest extends TrackerTestBase {
 
   private DataElement dataElement;
 
+  private OptionSet optionSet;
+
+  private DataElement dataElementWithOptionSet;
+
   @Mock private I18nManager i18nManager;
 
   @Mock private I18n i18n;
+
+  @Mock private OptionStore optionStore;
 
   @InjectMocks private DefaultProgramRuleEntityMapperService mapper;
 
@@ -116,14 +127,19 @@ class ProgramRuleEntityMapperServiceTest extends TrackerTestBase {
     DataElement dataElement1 = createDataElement('E');
     dataElement1.setFormName("DateElement_E");
 
-    OptionSet optionSet = new OptionSet();
+    optionSet = new OptionSet();
+    optionSet.setAutoFields();
+    // Deliberately different from what the optionStore mock returns in
+    // shouldMapOptionSetBackedVariableUsingOptionStoreNameAndCodeProjection, so that test fails
+    // loudly if the mapper ever regresses to reading this entity collection directly instead of
+    // going through optionStore.
     Option option = new Option();
-    option.setName("optionName");
-    option.setCode("optionCode");
+    option.setName("entityCollectionOptionName");
+    option.setCode("entityCollectionOptionCode");
 
     optionSet.setOptions(List.of(option));
 
-    DataElement dataElementWithOptionSet = createDataElement('F');
+    dataElementWithOptionSet = createDataElement('F');
     dataElementWithOptionSet.setFormName("dataElementWithOptionSet");
     dataElementWithOptionSet.setOptionSet(optionSet);
 
@@ -188,6 +204,30 @@ class ProgramRuleEntityMapperServiceTest extends TrackerTestBase {
     for (int i = 0; i < mappedProgramRules.size(); i++) {
       assertRule(programRules.get(i), mappedProgramRules.get(i));
     }
+  }
+
+  @Test
+  void shouldMapOptionSetBackedVariableUsingOptionStoreNameAndCodeProjection() {
+    ProgramRuleVariable optionSetVariable =
+        createProgramRuleVariable(
+            'G',
+            ProgramRuleVariableSourceType.DATAELEMENT_CURRENT_EVENT,
+            program,
+            dataElementWithOptionSet,
+            null);
+
+    when(optionStore.findOptionsNameAndCode(UID.of(optionSet)))
+        .thenReturn(List.of(new Option("projectedOptionName", "projectedOptionCode")));
+
+    List<RuleVariable> ruleVariables = mapper.toRuleVariables(List.of(optionSetVariable));
+
+    verify(optionStore).findOptionsNameAndCode(UID.of(optionSet));
+    assertEquals(1, ruleVariables.size());
+    RuleVariableCurrentEvent ruleVariable = (RuleVariableCurrentEvent) ruleVariables.get(0);
+    assertEquals(
+        List.of(
+            new org.hisp.dhis.rules.models.Option("projectedOptionName", "projectedOptionCode")),
+        ruleVariable.getOptions());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `DefaultProgramRuleEntityMapperService.getOptions()` loaded the full `OptionSet.getOptions()` entity collection just to read `name`/`code` off each `Option`, discarding everything else immediately.
- Every `Option` entity carries three JSONB columns (`style`, `translations`, `attributeValues`) whose Hibernate `UserType` does a full Jackson serialize/deserialize round trip on every access - DB load or L2 cache hit alike - none of which is ever used at this call site.
- Adds `OptionStore.findOptionsNameAndCode()`, a JPQL constructor-expression projection (`select new Option(o.name, o.code) from Option o where o.optionSet.uid = :id`) that never touches the JSONB columns at all, and uses it instead of `optionSet.getOptions()` here.

## Test plan
- [x] New unit test (`shouldMapOptionSetBackedVariableUsingOptionStoreNameAndCodeProjection`) uses deliberately divergent values between the (untouched) entity collection and the `optionStore` mock, plus an explicit `verify()`, so it can't pass by coincidence.
- [x] Mutation-tested: reverting to `optionSet.getOptions()` makes the new test fail with "zero interactions" on the `optionStore` mock, confirming it actually exercises this path.
- [x] Existing `ProgramRuleEntityMapperServiceTest` suite passes unchanged.
- [x] Spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)