### PR TITLE
fix: force-initialize collections dropped by replicateUser's uninitialized-proxy merge skip (#24878) [2.42]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,6 +30,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
 import static org.hisp.dhis.external.conf.ConfigurationKey.LINKED_ACCOUNTS_ENABLED;
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.hisp.dhis.http.HttpClientAdapter.Accept;
@@ -600,6 +601,107 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
                 "/users/" + peter.getUid() + "/replica",
                 "{'username':'peter2','password':'Saf€sEcre1'}")
             .content());
+  }
+
+  @Test
+  @DisplayName("Replica should retain the source user's organisation units")
+  void testReplicateUserCopiesOrganisationUnits() {
+    OrganisationUnit orgUnit = createOrganisationUnit('R');
+    organisationUnitService.addOrganisationUnit(orgUnit);
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/" + peter.getUid(),
+            "[{'op':'add','path':'/organisationUnits','value':[{'id':'%s'}]}]"
+                .formatted(orgUnit.getUid())));
+
+    assertWebMessage(
+        "Created",
+        201,
+        "OK",
+        "User replica created",
+        POST(
+                "/users/" + peter.getUid() + "/replica",
+                "{'username':'peterreplica','password':'Saf€sEcre1'}")
+            .content());
+
+    User replica = userService.getUserByUsername("peterreplica");
+    assertEquals(1, replica.getOrganisationUnits().size());
+    assertTrue(replica.getOrganisationUnits().contains(orgUnit));
+  }
+
+  @Test
+  @DisplayName("Replica should retain the source user's user roles")
+  void testReplicateUserCopiesUserRoles() {
+    UserRole extraRole = createUserRole("ROLE_REPLICATE_TARGET", "F_USER_ADD");
+    userService.addUserRole(extraRole);
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/" + peter.getUid(),
+            "[{'op':'add','path':'/userRoles','value':[{'id':'%s'}]}]"
+                .formatted(extraRole.getUid())));
+
+    assertWebMessage(
+        "Created",
+        201,
+        "OK",
+        "User replica created",
+        POST(
+                "/users/" + peter.getUid() + "/replica",
+                "{'username':'peterreplica2','password':'Saf€sEcre1'}")
+            .content());
+
+    User replica = userService.getUserByUsername("peterreplica2");
+    Set<String> replicaRoleUids =
+        replica.getUserRoles().stream().map(BaseIdentifiableObject::getUid).collect(toSet());
+    assertTrue(
+        replicaRoleUids.contains(extraRole.getUid()),
+        "Replica should have inherited the role added to the source user");
+  }
+
+  @Test
+  @DisplayName("Replica should retain the source user's dimension constraints")
+  void testReplicateUserCopiesDimensionConstraints() {
+    CategoryOption categoryOption = createCategoryOption('D');
+    categoryService.addCategoryOption(categoryOption);
+    Category category = createCategory('D', categoryOption);
+    categoryService.addCategory(category);
+
+    CategoryOptionGroupSet categoryOptionGroupSet = new CategoryOptionGroupSet();
+    categoryOptionGroupSet.setAutoFields();
+    categoryOptionGroupSet.setDataDimensionType(DataDimensionType.DISAGGREGATION);
+    categoryOptionGroupSet.setName("cogsD");
+    categoryOptionGroupSet.setShortName("cogsD");
+    manager.save(categoryOptionGroupSet);
+
+    // Assigned via a real PATCH request (not a direct service call) so the source user is
+    // reloaded fresh, rather than reusing this test method's own Hibernate session/persistence
+    // context - a direct service call here would mask the very bug this test exists to catch.
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/" + peter.getUid(),
+            """
+            [{'op':'add','path':'/catDimensionConstraints','value':[{'id':'%s'}]},
+             {'op':'add','path':'/cogsDimensionConstraints','value':[{'id':'%s'}]}]"""
+                .formatted(category.getUid(), categoryOptionGroupSet.getUid())));
+
+    assertWebMessage(
+        "Created",
+        201,
+        "OK",
+        "User replica created",
+        POST(
+                "/users/" + peter.getUid() + "/replica",
+                "{'username':'peterreplica3','password':'Saf€sEcre1'}")
+            .content());
+
+    User replica = userService.getUserByUsername("peterreplica3");
+    assertEquals(Set.of(category), replica.getCatDimensionConstraints());
+    assertEquals(Set.of(categoryOptionGroupSet), replica.getCogsDimensionConstraints());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -51,7 +51,12 @@ import com.google.gson.JsonElement;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionGroupSet;
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.http.HttpStatus;
@@ -96,6 +101,8 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
   @Autowired private SystemSettingsService settingsService;
 
   @Autowired private OrganisationUnitService organisationUnitService;
+
+  @Autowired private CategoryService categoryService;
 
   @Autowired private SessionRegistry sessionRegistry;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -59,6 +59,7 @@ import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.CodeGenerator;
@@ -492,6 +493,19 @@ public class UserController
     if (existingUser == null) {
       return conflict("User not found: " + uid);
     }
+
+    // MetadataMergeService.merge() silently skips any collection that is still an
+    // uninitialized Hibernate proxy at merge time (to avoid triggering large lazy loads
+    // elsewhere), so force-initialize every collection it needs to copy here, or they get
+    // dropped from the replica with no error. "groups" is not in this list because it is
+    // re-established explicitly via userGroupService.addUserToGroups() below, independent of
+    // whatever merge() does with it.
+    Hibernate.initialize(existingUser.getOrganisationUnits());
+    Hibernate.initialize(existingUser.getDataViewOrganisationUnits());
+    Hibernate.initialize(existingUser.getTeiSearchOrganisationUnits());
+    Hibernate.initialize(existingUser.getUserRoles());
+    Hibernate.initialize(existingUser.getCogsDimensionConstraints());
+    Hibernate.initialize(existingUser.getCatDimensionConstraints());
 
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     validateCreateUser(existingUser, currentUser);


### PR DESCRIPTION
## Summary
- Cherry-pick of #24878 from 2.41 onto 2.42, resolving a merge conflict in `UserController.replicateUser` against 2.42's own `UserDetails`-based `currentUser` refactor.
- `DefaultMetadataMergeService.merge()` silently skips any collection that is still an uninitialized Hibernate proxy at merge time, so `replicateUser` was dropping `organisationUnits`, `dataViewOrganisationUnits`, `teiSearchOrganisationUnits`, `userRoles`, `cogsDimensionConstraints`, and `catDimensionConstraints` from the replica with no error.
- Force-initializes those collections right after loading `existingUser`, before the merge runs.

## Test plan
- [x] `mvn -o compile -pl dhis-web-api -am` passes
- [x] Cherry-picked commit includes the red→green `UserControllerTest` cases (org units, user roles, dimension constraints) from the original 2.41 fix
- [x] Verified no leftover conflict markers and that the resolved `currentUser` type (`UserDetails`) is compatible with `validateCreateUser`/`addUserToGroups`

🤖 Generated with [Claude Code](https://claude.com/claude-code)