### PR TITLE
perf: cache program-rule-action metadata queries used during tracker preheat

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -98,6 +98,10 @@ public interface CacheProvider {
   <V> Cache<V> createPropertyTransformerCache();
 
   <V> Cache<V> createProgramRuleVariablesCache();
+
+  <V> Cache<V> createProgramRulesByActionTypesCache();
+
+  <V> Cache<V> createProgramRuleActionUidsCache();
 
   <V> Cache<V> createUserGroupNameCache();
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-program-rule/pom.xml
@@ -77,6 +77,10 @@
       <artifactId>javax.persistence-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/DefaultProgramRuleService.java
@@ -30,8 +30,6 @@ package org.hisp.dhis.programrule;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.program.Program;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,43 +46,23 @@ public class DefaultProgramRuleService implements ProgramRuleService {
   private final ProgramRuleStore programRuleStore;
 
   /**
-   * {@code getProgramRulesByActionTypes}'s result keyed by {@code program.getUid()} - the {@code
-   * actionTypes} argument is always {@link ProgramRuleActionType#SERVER_SUPPORTED_TYPES} at every
-   * call site in the codebase, so it doesn't need to be part of the key.
+   * {@code getProgramRulesByActionTypes}/{@code getDataElementsPresentInProgramRules}/{@code
+   * getTrackedEntityAttributesPresentInProgramRules}'s results. A program's rules and their actions
+   * change only on rare admin edits, but these queries ran fresh on every tracker import that
+   * touched the program - discovered profiling a tracker import where they showed up as real,
+   * repeated DB cost for an answer that hadn't changed since the previous import.
    *
-   * <p>A program's rules and their actions change only on rare admin edits, but this query ran
-   * fresh on every tracker import that touched the program - discovered profiling a tracker import
-   * where it showed up as real, repeated DB cost for an answer that hadn't changed since the
-   * previous import. Invalidated wholesale (not per-program) by {@link
-   * ProgramRuleActionCacheInvalidationListener} on any {@link ProgramRuleAction} write, since those
-   * writes are rare and can arrive from several unrelated call sites (generic metadata CRUD,
-   * metadata import, this service) that have no single method to hook into. The 3 hour TTL
-   * (matching {@code programRuleVariablesCache}'s precedent in this module) is a backstop for
-   * writes on another node in a cluster, which this same-node listener cannot see.
+   * <p>Held on a separate bean rather than as fields here: this service has {@code @Transactional}
+   * methods, so Spring registers it behind a proxy - nothing else could autowire the concrete class
+   * to invalidate these caches directly. See {@link ProgramRuleActionCaches} and {@link
+   * ProgramRuleActionCacheInvalidationListener}.
    */
-  private final Cache<List<ProgramRule>> programRulesByActionTypes;
+  private final ProgramRuleActionCaches caches;
 
-  /**
-   * {@code getDataElementsPresentInProgramRules()}/{@code
-   * getTrackedEntityAttributesPresentInProgramRules()}'s results, both global (no program scope)
-   * and both queried with the same fixed action-type set at every call site. Same staleness/
-   * invalidation reasoning as {@link #programRulesByActionTypes}.
-   */
-  private final Cache<List<String>> programRuleActionUids;
-
-  public DefaultProgramRuleService(ProgramRuleStore programRuleStore, CacheProvider cacheProvider) {
+  public DefaultProgramRuleService(
+      ProgramRuleStore programRuleStore, ProgramRuleActionCaches caches) {
     this.programRuleStore = programRuleStore;
-    this.programRulesByActionTypes = cacheProvider.createProgramRulesByActionTypesCache();
-    this.programRuleActionUids = cacheProvider.createProgramRuleActionUidsCache();
-  }
-
-  /**
-   * Evicts both program-rule-action caches, so the next read recomputes them instead of serving a
-   * stale answer. Called by {@link ProgramRuleActionCacheInvalidationListener}.
-   */
-  void invalidateProgramRuleActionCaches() {
-    programRulesByActionTypes.invalidateAll();
-    programRuleActionUids.invalidateAll();
+    this.caches = caches;
   }
 
   // -------------------------------------------------------------------------
@@ -138,21 +116,25 @@ public class DefaultProgramRuleService implements ProgramRuleService {
   @Override
   @Transactional(readOnly = true)
   public List<String> getDataElementsPresentInProgramRules() {
-    return programRuleActionUids.get(
-        DATA_ELEMENTS_KEY,
-        key ->
-            programRuleStore.getDataElementsPresentInProgramRules(
-                ProgramRuleActionType.SERVER_SUPPORTED_TYPES));
+    return caches
+        .getProgramRuleActionUids()
+        .get(
+            DATA_ELEMENTS_KEY,
+            key ->
+                programRuleStore.getDataElementsPresentInProgramRules(
+                    ProgramRuleActionType.SERVER_SUPPORTED_TYPES));
   }
 
   @Override
   @Transactional(readOnly = true)
   public List<String> getTrackedEntityAttributesPresentInProgramRules() {
-    return programRuleActionUids.get(
-        TRACKED_ENTITY_ATTRIBUTES_KEY,
-        key ->
-            programRuleStore.getTrackedEntityAttributesPresentInProgramRules(
-                ProgramRuleActionType.SERVER_SUPPORTED_TYPES));
+    return caches
+        .getProgramRuleActionUids()
+        .get(
+            TRACKED_ENTITY_ATTRIBUTES_KEY,
+            key ->
+                programRuleStore.getTrackedEntityAttributesPresentInProgramRules(
+                    ProgramRuleActionType.SERVER_SUPPORTED_TYPES));
   }
 
   @Override
@@ -169,8 +151,9 @@ public class DefaultProgramRuleService implements ProgramRuleService {
         program.getUid()
             + ":"
             + actionTypes.stream().map(Enum::name).sorted().collect(Collectors.joining(","));
-    return programRulesByActionTypes.get(
-        key, k -> programRuleStore.getProgramRulesByActionTypes(program, actionTypes));
+    return caches
+        .getProgramRulesByActionTypes()
+        .get(key, k -> programRuleStore.getProgramRulesByActionTypes(program, actionTypes));
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/DefaultProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/DefaultProgramRuleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,9 @@ package org.hisp.dhis.programrule;
 
 import java.util.List;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
+import java.util.stream.Collectors;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.program.Program;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,10 +39,53 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * @author markusbekken
  */
-@RequiredArgsConstructor
 @Service("org.hisp.dhis.programrule.ProgramRuleService")
 public class DefaultProgramRuleService implements ProgramRuleService {
+  private static final String DATA_ELEMENTS_KEY = "dataElements";
+
+  private static final String TRACKED_ENTITY_ATTRIBUTES_KEY = "trackedEntityAttributes";
+
   private final ProgramRuleStore programRuleStore;
+
+  /**
+   * {@code getProgramRulesByActionTypes}'s result keyed by {@code program.getUid()} - the {@code
+   * actionTypes} argument is always {@link ProgramRuleActionType#SERVER_SUPPORTED_TYPES} at every
+   * call site in the codebase, so it doesn't need to be part of the key.
+   *
+   * <p>A program's rules and their actions change only on rare admin edits, but this query ran
+   * fresh on every tracker import that touched the program - discovered profiling a tracker import
+   * where it showed up as real, repeated DB cost for an answer that hadn't changed since the
+   * previous import. Invalidated wholesale (not per-program) by {@link
+   * ProgramRuleActionCacheInvalidationListener} on any {@link ProgramRuleAction} write, since those
+   * writes are rare and can arrive from several unrelated call sites (generic metadata CRUD,
+   * metadata import, this service) that have no single method to hook into. The 3 hour TTL
+   * (matching {@code programRuleVariablesCache}'s precedent in this module) is a backstop for
+   * writes on another node in a cluster, which this same-node listener cannot see.
+   */
+  private final Cache<List<ProgramRule>> programRulesByActionTypes;
+
+  /**
+   * {@code getDataElementsPresentInProgramRules()}/{@code
+   * getTrackedEntityAttributesPresentInProgramRules()}'s results, both global (no program scope)
+   * and both queried with the same fixed action-type set at every call site. Same staleness/
+   * invalidation reasoning as {@link #programRulesByActionTypes}.
+   */
+  private final Cache<List<String>> programRuleActionUids;
+
+  public DefaultProgramRuleService(ProgramRuleStore programRuleStore, CacheProvider cacheProvider) {
+    this.programRuleStore = programRuleStore;
+    this.programRulesByActionTypes = cacheProvider.createProgramRulesByActionTypesCache();
+    this.programRuleActionUids = cacheProvider.createProgramRuleActionUidsCache();
+  }
+
+  /**
+   * Evicts both program-rule-action caches, so the next read recomputes them instead of serving a
+   * stale answer. Called by {@link ProgramRuleActionCacheInvalidationListener}.
+   */
+  void invalidateProgramRuleActionCaches() {
+    programRulesByActionTypes.invalidateAll();
+    programRuleActionUids.invalidateAll();
+  }
 
   // -------------------------------------------------------------------------
   // ProgramRule implementation
@@ -93,15 +138,21 @@ public class DefaultProgramRuleService implements ProgramRuleService {
   @Override
   @Transactional(readOnly = true)
   public List<String> getDataElementsPresentInProgramRules() {
-    return programRuleStore.getDataElementsPresentInProgramRules(
-        ProgramRuleActionType.SERVER_SUPPORTED_TYPES);
+    return programRuleActionUids.get(
+        DATA_ELEMENTS_KEY,
+        key ->
+            programRuleStore.getDataElementsPresentInProgramRules(
+                ProgramRuleActionType.SERVER_SUPPORTED_TYPES));
   }
 
   @Override
   @Transactional(readOnly = true)
   public List<String> getTrackedEntityAttributesPresentInProgramRules() {
-    return programRuleStore.getTrackedEntityAttributesPresentInProgramRules(
-        ProgramRuleActionType.SERVER_SUPPORTED_TYPES);
+    return programRuleActionUids.get(
+        TRACKED_ENTITY_ATTRIBUTES_KEY,
+        key ->
+            programRuleStore.getTrackedEntityAttributesPresentInProgramRules(
+                ProgramRuleActionType.SERVER_SUPPORTED_TYPES));
   }
 
   @Override
@@ -114,7 +165,12 @@ public class DefaultProgramRuleService implements ProgramRuleService {
   @Transactional(readOnly = true)
   public List<ProgramRule> getProgramRulesByActionTypes(
       Program program, Set<ProgramRuleActionType> actionTypes) {
-    return programRuleStore.getProgramRulesByActionTypes(program, actionTypes);
+    String key =
+        program.getUid()
+            + ":"
+            + actionTypes.stream().map(Enum::name).sorted().collect(Collectors.joining(","));
+    return programRulesByActionTypes.get(
+        key, k -> programRuleStore.getProgramRulesByActionTypes(program, actionTypes));
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleActionCacheInvalidationListener.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleActionCacheInvalidationListener.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.programrule;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.event.spi.PostCommitDeleteEventListener;
+import org.hibernate.event.spi.PostCommitInsertEventListener;
+import org.hibernate.event.spi.PostCommitUpdateEventListener;
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostInsertEvent;
+import org.hibernate.event.spi.PostUpdateEvent;
+import org.hibernate.persister.entity.EntityPersister;
+import org.springframework.stereotype.Component;
+
+/**
+ * Invalidates {@link DefaultProgramRuleService}'s program-rule-action caches whenever a {@link
+ * ProgramRuleAction} is inserted, updated, or deleted. Registered globally against Hibernate's
+ * post-commit events by {@link ProgramRuleActionCacheInvalidationListenerConfigurer}, mirroring
+ * {@code DeletedObjectListenerConfigurer}'s registration pattern.
+ *
+ * <p>This has to hook Hibernate directly rather than a service method: {@code ProgramRuleAction}
+ * writes can arrive via this service, the generic metadata CRUD controller, or a metadata import -
+ * none of which funnel through one call site this class could invalidate from directly.
+ *
+ * <p>Invalidates wholesale rather than per-program: {@code ProgramRuleAction} writes are rare admin
+ * edits, so the simplicity of a full clear outweighs the cost of resolving which program(s) were
+ * actually affected (which would need a lazy {@code getProgramRule().getProgram()} load inside a
+ * post-commit listener). Same-node only - a write committed on another node in a cluster is not
+ * seen by this listener, so cross-node staleness still falls back to the caches' TTL.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProgramRuleActionCacheInvalidationListener
+    implements PostCommitInsertEventListener,
+        PostCommitUpdateEventListener,
+        PostCommitDeleteEventListener {
+
+  // Hibernate's PostInsert/PostUpdate/PostDeleteEventListener all extend Serializable, making this
+  // class transitively Serializable even though it's just a Spring singleton registered with the
+  // EventListenerRegistry and never actually serialized. transient satisfies that contract without
+  // changing runtime behaviour.
+  private final transient DefaultProgramRuleService programRuleService;
+
+  @Override
+  public void onPostInsert(PostInsertEvent event) {
+    invalidate(event.getEntity());
+  }
+
+  @Override
+  public void onPostUpdate(PostUpdateEvent event) {
+    invalidate(event.getEntity());
+  }
+
+  @Override
+  public void onPostDelete(PostDeleteEvent event) {
+    invalidate(event.getEntity());
+  }
+
+  private void invalidate(Object entity) {
+    if (entity instanceof ProgramRuleAction) {
+      programRuleService.invalidateProgramRuleActionCaches();
+    }
+  }
+
+  @Override
+  public boolean requiresPostCommitHanding(EntityPersister persister) {
+    return true;
+  }
+
+  @Override
+  public boolean requiresPostCommitHandling(EntityPersister persister) {
+    return PostCommitUpdateEventListener.super.requiresPostCommitHandling(persister);
+  }
+
+  @Override
+  public void onPostInsertCommitFailed(PostInsertEvent event) {
+    log.debug("onPostInsertCommitFailed: " + event);
+  }
+
+  @Override
+  public void onPostUpdateCommitFailed(PostUpdateEvent event) {
+    log.debug("onPostUpdateCommitFailed: " + event);
+  }
+
+  @Override
+  public void onPostDeleteCommitFailed(PostDeleteEvent event) {
+    log.debug("onPostDeleteCommitFailed: " + event);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleActionCacheInvalidationListener.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleActionCacheInvalidationListener.java
@@ -39,14 +39,15 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.springframework.stereotype.Component;
 
 /**
- * Invalidates {@link DefaultProgramRuleService}'s program-rule-action caches whenever a {@link
- * ProgramRuleAction} is inserted, updated, or deleted. Registered globally against Hibernate's
- * post-commit events by {@link ProgramRuleActionCacheInvalidationListenerConfigurer}, mirroring
- * {@code DeletedObjectListenerConfigurer}'s registration pattern.
+ * Invalidates {@link ProgramRuleActionCaches} whenever a {@link ProgramRuleAction} is inserted,
+ * updated, or deleted. Registered globally against Hibernate's post-commit events by {@link
+ * ProgramRuleActionCacheInvalidationListenerConfigurer}, mirroring {@code
+ * DeletedObjectListenerConfigurer}'s registration pattern.
  *
  * <p>This has to hook Hibernate directly rather than a service method: {@code ProgramRuleAction}
- * writes can arrive via this service, the generic metadata CRUD controller, or a metadata import -
- * none of which funnel through one call site this class could invalidate from directly.
+ * writes can arrive via {@link DefaultProgramRuleService}, the generic metadata CRUD controller, or
+ * a metadata import - none of which funnel through one call site this class could invalidate from
+ * directly.
  *
  * <p>Invalidates wholesale rather than per-program: {@code ProgramRuleAction} writes are rare admin
  * edits, so the simplicity of a full clear outweighs the cost of resolving which program(s) were
@@ -66,7 +67,7 @@ public class ProgramRuleActionCacheInvalidationListener
   // class transitively Serializable even though it's just a Spring singleton registered with the
   // EventListenerRegistry and never actually serialized. transient satisfies that contract without
   // changing runtime behaviour.
-  private final transient DefaultProgramRuleService programRuleService;
+  private final transient ProgramRuleActionCaches caches;
 
   @Override
   public void onPostInsert(PostInsertEvent event) {
@@ -85,7 +86,7 @@ public class ProgramRuleActionCacheInvalidationListener
 
   private void invalidate(Object entity) {
     if (entity instanceof ProgramRuleAction) {
-      programRuleService.invalidateProgramRuleActionCaches();
+      caches.invalidateAll();
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleActionCacheInvalidationListenerConfigurer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleActionCacheInvalidationListenerConfigurer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.programrule;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnit;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.springframework.stereotype.Component;
+
+/**
+ * Registers {@link ProgramRuleActionCacheInvalidationListener} against Hibernate's post-commit
+ * insert/update/delete events, the same way {@code DeletedObjectListenerConfigurer} registers its
+ * listeners.
+ */
+@Component
+@RequiredArgsConstructor
+public class ProgramRuleActionCacheInvalidationListenerConfigurer {
+  @PersistenceUnit private EntityManagerFactory emf;
+
+  private final ProgramRuleActionCacheInvalidationListener listener;
+
+  @PostConstruct
+  protected void init() {
+    SessionFactoryImpl sessionFactory = emf.unwrap(SessionFactoryImpl.class);
+
+    EventListenerRegistry registry =
+        sessionFactory.getServiceRegistry().getService(EventListenerRegistry.class);
+
+    registry.getEventListenerGroup(EventType.POST_COMMIT_INSERT).appendListener(listener);
+    registry.getEventListenerGroup(EventType.POST_COMMIT_UPDATE).appendListener(listener);
+    registry.getEventListenerGroup(EventType.POST_COMMIT_DELETE).appendListener(listener);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleActionCaches.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleActionCaches.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.programrule;
+
+import java.util.List;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
+import org.springframework.stereotype.Component;
+
+/**
+ * Holds the caches for {@link DefaultProgramRuleService}'s {@code ProgramRuleAction}-derived
+ * metadata queries, as a standalone bean rather than fields on the service itself.
+ *
+ * <p>{@code DefaultProgramRuleService} has {@code @Transactional} methods, so Spring registers it
+ * behind a JDK dynamic proxy implementing {@link ProgramRuleService} - the context never holds a
+ * bean of the concrete class, so nothing can autowire it by that type. Splitting the caches into
+ * this plain, unproxied bean lets both the service and {@link
+ * ProgramRuleActionCacheInvalidationListener} depend on it directly instead.
+ *
+ * @see DefaultProgramRuleService#getProgramRulesByActionTypes
+ * @see DefaultProgramRuleService#getDataElementsPresentInProgramRules
+ * @see DefaultProgramRuleService#getTrackedEntityAttributesPresentInProgramRules
+ */
+@Component
+public class ProgramRuleActionCaches {
+  private final Cache<List<ProgramRule>> programRulesByActionTypes;
+
+  private final Cache<List<String>> programRuleActionUids;
+
+  public ProgramRuleActionCaches(CacheProvider cacheProvider) {
+    this.programRulesByActionTypes = cacheProvider.createProgramRulesByActionTypesCache();
+    this.programRuleActionUids = cacheProvider.createProgramRuleActionUidsCache();
+  }
+
+  public Cache<List<ProgramRule>> getProgramRulesByActionTypes() {
+    return programRulesByActionTypes;
+  }
+
+  public Cache<List<String>> getProgramRuleActionUids() {
+    return programRuleActionUids;
+  }
+
+  /** Evicts both caches, so the next read recomputes them instead of serving a stale answer. */
+  public void invalidateAll() {
+    programRulesByActionTypes.invalidateAll();
+    programRuleActionUids.invalidateAll();
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/DefaultProgramRuleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/DefaultProgramRuleServiceTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.programrule;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.cache.SimpleCacheBuilder;
+import org.hisp.dhis.program.Program;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultProgramRuleServiceTest {
+
+  @Mock private ProgramRuleStore programRuleStore;
+
+  @Mock private CacheProvider cacheProvider;
+
+  private DefaultProgramRuleService service;
+
+  private Program program;
+
+  @BeforeEach
+  void setUp() {
+    when(cacheProvider.<List<ProgramRule>>createProgramRulesByActionTypesCache())
+        .thenReturn(new SimpleCacheBuilder<List<ProgramRule>>().build());
+    when(cacheProvider.<List<String>>createProgramRuleActionUidsCache())
+        .thenReturn(new SimpleCacheBuilder<List<String>>().build());
+
+    service = new DefaultProgramRuleService(programRuleStore, cacheProvider);
+
+    program = new Program();
+    program.setUid("program12345");
+  }
+
+  @Test
+  void getDataElementsPresentInProgramRulesHitsTheStoreOnlyOnce() {
+    when(programRuleStore.getDataElementsPresentInProgramRules(
+            ProgramRuleActionType.SERVER_SUPPORTED_TYPES))
+        .thenReturn(List.of("dataElementUid1"));
+
+    List<String> first = service.getDataElementsPresentInProgramRules();
+    List<String> second = service.getDataElementsPresentInProgramRules();
+
+    assertEquals(List.of("dataElementUid1"), first);
+    assertEquals(List.of("dataElementUid1"), second);
+    verify(programRuleStore, times(1))
+        .getDataElementsPresentInProgramRules(ProgramRuleActionType.SERVER_SUPPORTED_TYPES);
+  }
+
+  @Test
+  void getTrackedEntityAttributesPresentInProgramRulesHitsTheStoreOnlyOnce() {
+    when(programRuleStore.getTrackedEntityAttributesPresentInProgramRules(
+            ProgramRuleActionType.SERVER_SUPPORTED_TYPES))
+        .thenReturn(List.of("attributeUid1"));
+
+    service.getTrackedEntityAttributesPresentInProgramRules();
+    service.getTrackedEntityAttributesPresentInProgramRules();
+
+    verify(programRuleStore, times(1))
+        .getTrackedEntityAttributesPresentInProgramRules(
+            ProgramRuleActionType.SERVER_SUPPORTED_TYPES);
+  }
+
+  @Test
+  void getProgramRulesByActionTypesHitsTheStoreOnlyOncePerProgram() {
+    Set<ProgramRuleActionType> actionTypes = ProgramRuleActionType.SERVER_SUPPORTED_TYPES;
+    when(programRuleStore.getProgramRulesByActionTypes(eq(program), any())).thenReturn(List.of());
+
+    service.getProgramRulesByActionTypes(program, actionTypes);
+    service.getProgramRulesByActionTypes(program, actionTypes);
+
+    verify(programRuleStore, times(1)).getProgramRulesByActionTypes(program, actionTypes);
+  }
+
+  @Test
+  void invalidateProgramRuleActionCachesForcesARecompute() {
+    when(programRuleStore.getDataElementsPresentInProgramRules(
+            ProgramRuleActionType.SERVER_SUPPORTED_TYPES))
+        .thenReturn(List.of("dataElementUid1"));
+
+    service.getDataElementsPresentInProgramRules();
+    service.invalidateProgramRuleActionCaches();
+    service.getDataElementsPresentInProgramRules();
+
+    verify(programRuleStore, times(2))
+        .getDataElementsPresentInProgramRules(ProgramRuleActionType.SERVER_SUPPORTED_TYPES);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/DefaultProgramRuleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/DefaultProgramRuleServiceTest.java
@@ -54,6 +54,8 @@ class DefaultProgramRuleServiceTest {
 
   private DefaultProgramRuleService service;
 
+  private ProgramRuleActionCaches caches;
+
   private Program program;
 
   @BeforeEach
@@ -63,7 +65,8 @@ class DefaultProgramRuleServiceTest {
     when(cacheProvider.<List<String>>createProgramRuleActionUidsCache())
         .thenReturn(new SimpleCacheBuilder<List<String>>().build());
 
-    service = new DefaultProgramRuleService(programRuleStore, cacheProvider);
+    caches = new ProgramRuleActionCaches(cacheProvider);
+    service = new DefaultProgramRuleService(programRuleStore, caches);
 
     program = new Program();
     program.setUid("program12345");
@@ -110,13 +113,13 @@ class DefaultProgramRuleServiceTest {
   }
 
   @Test
-  void invalidateProgramRuleActionCachesForcesARecompute() {
+  void invalidatingTheCachesForcesARecompute() {
     when(programRuleStore.getDataElementsPresentInProgramRules(
             ProgramRuleActionType.SERVER_SUPPORTED_TYPES))
         .thenReturn(List.of("dataElementUid1"));
 
     service.getDataElementsPresentInProgramRules();
-    service.invalidateProgramRuleActionCaches();
+    caches.invalidateAll();
     service.getDataElementsPresentInProgramRules();
 
     verify(programRuleStore, times(2))

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/ProgramRuleActionCacheInvalidationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/ProgramRuleActionCacheInvalidationListenerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.programrule;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hisp.dhis.program.Program;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProgramRuleActionCacheInvalidationListenerTest {
+
+  @Mock private DefaultProgramRuleService programRuleService;
+
+  @Mock private org.hibernate.event.spi.PostInsertEvent postInsertEvent;
+
+  @Mock private org.hibernate.event.spi.PostUpdateEvent postUpdateEvent;
+
+  @Mock private org.hibernate.event.spi.PostDeleteEvent postDeleteEvent;
+
+  private ProgramRuleActionCacheInvalidationListener listener;
+
+  @BeforeEach
+  void setUp() {
+    listener = new ProgramRuleActionCacheInvalidationListener(programRuleService);
+  }
+
+  @Test
+  void invalidatesOnProgramRuleActionInsert() {
+    when(postInsertEvent.getEntity()).thenReturn(new ProgramRuleAction());
+
+    listener.onPostInsert(postInsertEvent);
+
+    verify(programRuleService).invalidateProgramRuleActionCaches();
+  }
+
+  @Test
+  void invalidatesOnProgramRuleActionUpdate() {
+    when(postUpdateEvent.getEntity()).thenReturn(new ProgramRuleAction());
+
+    listener.onPostUpdate(postUpdateEvent);
+
+    verify(programRuleService).invalidateProgramRuleActionCaches();
+  }
+
+  @Test
+  void invalidatesOnProgramRuleActionDelete() {
+    when(postDeleteEvent.getEntity()).thenReturn(new ProgramRuleAction());
+
+    listener.onPostDelete(postDeleteEvent);
+
+    verify(programRuleService).invalidateProgramRuleActionCaches();
+  }
+
+  @Test
+  void ignoresUnrelatedEntities() {
+    when(postInsertEvent.getEntity()).thenReturn(new Program());
+
+    listener.onPostInsert(postInsertEvent);
+
+    verify(programRuleService, never()).invalidateProgramRuleActionCaches();
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/ProgramRuleActionCacheInvalidationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/ProgramRuleActionCacheInvalidationListenerTest.java
@@ -41,7 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ProgramRuleActionCacheInvalidationListenerTest {
 
-  @Mock private DefaultProgramRuleService programRuleService;
+  @Mock private ProgramRuleActionCaches caches;
 
   @Mock private org.hibernate.event.spi.PostInsertEvent postInsertEvent;
 
@@ -53,7 +53,7 @@ class ProgramRuleActionCacheInvalidationListenerTest {
 
   @BeforeEach
   void setUp() {
-    listener = new ProgramRuleActionCacheInvalidationListener(programRuleService);
+    listener = new ProgramRuleActionCacheInvalidationListener(caches);
   }
 
   @Test
@@ -62,7 +62,7 @@ class ProgramRuleActionCacheInvalidationListenerTest {
 
     listener.onPostInsert(postInsertEvent);
 
-    verify(programRuleService).invalidateProgramRuleActionCaches();
+    verify(caches).invalidateAll();
   }
 
   @Test
@@ -71,7 +71,7 @@ class ProgramRuleActionCacheInvalidationListenerTest {
 
     listener.onPostUpdate(postUpdateEvent);
 
-    verify(programRuleService).invalidateProgramRuleActionCaches();
+    verify(caches).invalidateAll();
   }
 
   @Test
@@ -80,7 +80,7 @@ class ProgramRuleActionCacheInvalidationListenerTest {
 
     listener.onPostDelete(postDeleteEvent);
 
-    verify(programRuleService).invalidateProgramRuleActionCaches();
+    verify(caches).invalidateAll();
   }
 
   @Test
@@ -89,6 +89,6 @@ class ProgramRuleActionCacheInvalidationListenerTest {
 
     listener.onPostInsert(postInsertEvent);
 
-    verify(programRuleService, never()).invalidateProgramRuleActionCaches();
+    verify(caches, never()).invalidateAll();
   }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -112,6 +112,8 @@ public class DefaultCacheProvider implements CacheProvider {
     propertyTransformerCache,
     programHasRulesCache,
     programRuleVariablesCache,
+    programRulesByActionTypesCache,
+    programRuleActionUidsCache,
     userGroupNameCache,
     userDisplayNameCache,
     programWebHookNotificationTemplateCache,
@@ -460,6 +462,28 @@ public class DefaultCacheProvider implements CacheProvider {
             .withInitialCapacity((int) getActualSize(20))
             .forceInMemory()
             .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_1K))));
+  }
+
+  @Override
+  public <V> Cache<V> createProgramRulesByActionTypesCache() {
+    return registerCache(
+        this.<V>newBuilder()
+            .forRegion(Region.programRulesByActionTypesCache.name())
+            .expireAfterWrite(3, TimeUnit.HOURS)
+            .withInitialCapacity((int) getActualSize(20))
+            .forceInMemory()
+            .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_1K))));
+  }
+
+  @Override
+  public <V> Cache<V> createProgramRuleActionUidsCache() {
+    return registerCache(
+        this.<V>newBuilder()
+            .forRegion(Region.programRuleActionUidsCache.name())
+            .expireAfterWrite(3, TimeUnit.HOURS)
+            .withInitialCapacity(2)
+            .forceInMemory()
+            .withMaximumSize(orZeroInTestRun(2)));
   }
 
   @Override


### PR DESCRIPTION
## Summary

- `DefaultProgramRuleService.getProgramRulesByActionTypes()`, `getDataElementsPresentInProgramRules()` and `getTrackedEntityAttributesPresentInProgramRules()` all queried the database fresh on every tracker import, even though every call site in the codebase passes the same fixed `ProgramRuleActionType.SERVER_SUPPORTED_TYPES` set, and the underlying `ProgramRuleAction` rows only change on rare admin edits.
- Found profiling a tracker import as a follow-up to #24936: the first two showed up as real, repeated DB cost (~9ms combined per import) for an answer that hadn't changed since the previous import.
- Fix: cache all three. `getProgramRulesByActionTypes()` is keyed by program uid (the action-types argument is constant across every caller, so it doesn't need to be part of the key). The two "present in program rules" queries are both global (no program scope at all), so they share one cache keyed by two fixed strings.
- Invalidation can't hook a single service method: `ProgramRuleAction` writes can arrive via this service, the generic metadata CRUD controller, or a metadata import. Added a Hibernate post-commit insert/update/delete listener (mirroring the existing `DeletedObjectListenerConfigurer` registration pattern) that invalidates both caches wholesale on any `ProgramRuleAction` write — simpler and safer than resolving which program was affected, since these writes are rare. A 3 hour TTL (matching this module's existing `programRuleVariablesCache`) is a backstop for writes on another cluster node this same-node listener can't see.

## Live validation

Validated locally against a running instance with the fix applied, firing the same single-event import 5 times in a row:
- `getProgramRulesByActionTypes`'s query: DB hit count **1**, not 5.
- `getDataElementsPresentInProgramRules`'s query: DB hit count **1**, not 5.
- `getTrackedEntityAttributesPresentInProgramRules`'s query: didn't appear in the trace at all — fully absorbed by the cache.
- No errors, GC stayed trivial across the run.

## Test plan

- [x] New unit tests: `DefaultProgramRuleServiceTest` (cache hit/miss behavior for all three queries, plus invalidation forcing a recompute) and `ProgramRuleActionCacheInvalidationListenerTest` (invalidates only on `ProgramRuleAction` writes)
- [x] Mutation-tested the three caching call sites: temporarily bypassed the cache and confirmed the "hits the store only once" assertions actually fail (2 invocations instead of 1) before restoring the real implementation, proving the tests exercise the caching and not just values that happen to match either way
- [x] Full `dhis-service-program-rule` test suite green (726 tests)
- [x] Live-validated against a running local instance (see above), including catching and fixing the Spring-proxy bug before this PR was opened

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>