### PR TITLE
chore: Downgrade rule-engine to 3.8.1 [DHIS2-21730](2.41)

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -78,7 +78,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>3.8.2</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>3.8.1</dhis2-rule-engine.version>
 
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.6</dhis-hisp-quick.version>


### PR DESCRIPTION
Downgrade rule-engine to 3.8.1 because next version has some features that are not compatible with Capture rule engine that is still used by frontend in v41. 

IT MUST BE MERGED TOGETHER WITH https://github.com/dhis2/dhis2-core/pull/24954, TO AVOID AUTOMATIC UPGRADE OF RULE-ENGINE VERSION.