### PR TITLE
chore: Do not upgrade rule-engine in v41 [DHIS2-21730]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -285,6 +285,9 @@ updates:
       - dependency-name: "io.micrometer:micrometer-registry-prometheus" # updates have breaking changes which we won't backport
         versions:
           - ">= 1.13.0"
+      - dependency-name: "org.hisp.dhis.rules:rule-engine-jvm" # updates have breaking changes which we won't backport
+        versions:
+          - ">= 3.8.1"
   - package-ecosystem: "maven"
     directory: "/dhis-2/dhis-test-e2e"
     schedule:


### PR DESCRIPTION
Disable upgrades of rule-engine for v41 because starting from rule-engine version 3.8.2 there are unsupported features for v41.