### PR TITLE
fix: force-initialize collections dropped by replicateUser's uninitia…

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,6 +30,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
 import static org.hisp.dhis.external.conf.ConfigurationKey.LINKED_ACCOUNTS_ENABLED;
 import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.hisp.dhis.http.HttpClientAdapter.Accept;
@@ -50,7 +51,12 @@ import com.google.gson.JsonElement;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionGroupSet;
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.http.HttpStatus;
@@ -95,6 +101,8 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
   @Autowired private SystemSettingsService settingsService;
 
   @Autowired private OrganisationUnitService organisationUnitService;
+
+  @Autowired private CategoryService categoryService;
 
   @Autowired private SessionRegistry sessionRegistry;
 
@@ -600,6 +608,107 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
                 "/users/" + peter.getUid() + "/replica",
                 "{'username':'peter2','password':'Saf€sEcre1'}")
             .content());
+  }
+
+  @Test
+  @DisplayName("Replica should retain the source user's organisation units")
+  void testReplicateUserCopiesOrganisationUnits() {
+    OrganisationUnit orgUnit = createOrganisationUnit('R');
+    organisationUnitService.addOrganisationUnit(orgUnit);
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/" + peter.getUid(),
+            "[{'op':'add','path':'/organisationUnits','value':[{'id':'%s'}]}]"
+                .formatted(orgUnit.getUid())));
+
+    assertWebMessage(
+        "Created",
+        201,
+        "OK",
+        "User replica created",
+        POST(
+                "/users/" + peter.getUid() + "/replica",
+                "{'username':'peterreplica','password':'Saf€sEcre1'}")
+            .content());
+
+    User replica = userService.getUserByUsername("peterreplica");
+    assertEquals(1, replica.getOrganisationUnits().size());
+    assertTrue(replica.getOrganisationUnits().contains(orgUnit));
+  }
+
+  @Test
+  @DisplayName("Replica should retain the source user's user roles")
+  void testReplicateUserCopiesUserRoles() {
+    UserRole extraRole = createUserRole("ROLE_REPLICATE_TARGET", "F_USER_ADD");
+    userService.addUserRole(extraRole);
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/" + peter.getUid(),
+            "[{'op':'add','path':'/userRoles','value':[{'id':'%s'}]}]"
+                .formatted(extraRole.getUid())));
+
+    assertWebMessage(
+        "Created",
+        201,
+        "OK",
+        "User replica created",
+        POST(
+                "/users/" + peter.getUid() + "/replica",
+                "{'username':'peterreplica2','password':'Saf€sEcre1'}")
+            .content());
+
+    User replica = userService.getUserByUsername("peterreplica2");
+    Set<String> replicaRoleUids =
+        replica.getUserRoles().stream().map(BaseIdentifiableObject::getUid).collect(toSet());
+    assertTrue(
+        replicaRoleUids.contains(extraRole.getUid()),
+        "Replica should have inherited the role added to the source user");
+  }
+
+  @Test
+  @DisplayName("Replica should retain the source user's dimension constraints")
+  void testReplicateUserCopiesDimensionConstraints() {
+    CategoryOption categoryOption = createCategoryOption('D');
+    categoryService.addCategoryOption(categoryOption);
+    Category category = createCategory('D', categoryOption);
+    categoryService.addCategory(category);
+
+    CategoryOptionGroupSet categoryOptionGroupSet = new CategoryOptionGroupSet();
+    categoryOptionGroupSet.setAutoFields();
+    categoryOptionGroupSet.setDataDimensionType(DataDimensionType.DISAGGREGATION);
+    categoryOptionGroupSet.setName("cogsD");
+    categoryOptionGroupSet.setShortName("cogsD");
+    manager.save(categoryOptionGroupSet);
+
+    // Assigned via a real PATCH request (not a direct service call) so the source user is
+    // reloaded fresh, rather than reusing this test method's own Hibernate session/persistence
+    // context - a direct service call here would mask the very bug this test exists to catch.
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/" + peter.getUid(),
+            """
+            [{'op':'add','path':'/catDimensionConstraints','value':[{'id':'%s'}]},
+             {'op':'add','path':'/cogsDimensionConstraints','value':[{'id':'%s'}]}]"""
+                .formatted(category.getUid(), categoryOptionGroupSet.getUid())));
+
+    assertWebMessage(
+        "Created",
+        201,
+        "OK",
+        "User replica created",
+        POST(
+                "/users/" + peter.getUid() + "/replica",
+                "{'username':'peterreplica3','password':'Saf€sEcre1'}")
+            .content());
+
+    User replica = userService.getUserByUsername("peterreplica3");
+    assertEquals(Set.of(category), replica.getCatDimensionConstraints());
+    assertEquals(Set.of(categoryOptionGroupSet), replica.getCogsDimensionConstraints());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -59,6 +59,7 @@ import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.CodeGenerator;
@@ -492,6 +493,19 @@ public class UserController
     if (existingUser == null) {
       return conflict("User not found: " + uid);
     }
+
+    // MetadataMergeService.merge() silently skips any collection that is still an
+    // uninitialized Hibernate proxy at merge time (to avoid triggering large lazy loads
+    // elsewhere), so force-initialize every collection it needs to copy here, or they get
+    // dropped from the replica with no error. "groups" is not in this list because it is
+    // re-established explicitly via userGroupService.addUserToGroups() below, independent of
+    // whatever merge() does with it.
+    Hibernate.initialize(existingUser.getOrganisationUnits());
+    Hibernate.initialize(existingUser.getDataViewOrganisationUnits());
+    Hibernate.initialize(existingUser.getTeiSearchOrganisationUnits());
+    Hibernate.initialize(existingUser.getUserRoles());
+    Hibernate.initialize(existingUser.getCogsDimensionConstraints());
+    Hibernate.initialize(existingUser.getCatDimensionConstraints());
 
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     validateCreateUser(existingUser, currentUser);


### PR DESCRIPTION
…lized-proxy merge skip (#24878) [2.42] (#24935)

* fix: force-initialize collections dropped by replicateUser's uninitialized-proxy merge skip (#24878)

* fix: force-initialize org-unit collections before replicateUser merge

DefaultMetadataMergeService.merge() silently skips any collection property that is still an uninitialized Hibernate proxy at merge time (a guard added to avoid triggering large lazy loads elsewhere). UserController.replicateUser loads existingUser via a plain get-by-uid with no eager fetch, so organisationUnits/dataViewOrganisationUnits/teiSearchOrganisationUnits can still be uninitialized when merge() runs, and get dropped from the replica with no error - confirmed on a production 2.41 instance (source user had 1 usermembership row, replica had 0).

Force-initialize those three collections right after loading existingUser so the merge can't silently skip them, regardless of session/cache timing.



* fix: force-initialize userRoles and dimension-constraint collections too

Same defect as the org-unit fix: DefaultMetadataMergeService.merge() silently skips any collection still uninitialized at merge time. userRoles, cogsDimensionConstraints, and catDimensionConstraints have no explicit re-copy step (unlike groups, which is re-established separately via addUserToGroups()), so they're exposed to the same silent-drop bug - userRoles being the most severe, since it would leave a replicated user with no authorities at all.

Added red->green tests for both. Note: an earlier draft of each test passed even without the fix, because the test code itself touched the source user's collection within the same Hibernate session the replication request later reused, accidentally pre-initializing it. Rewrote both to go through real PATCH requests instead of direct service calls, which is what actually produced honest failures - this is also the likely explanation for why this bug reproduces inconsistently across environments in general (session/first- level-cache sharing, not caching config or timing).



---------



* fix: add missing category/DataDimensionType imports and categoryService field in UserControllerTest

The cherry-picked replicateUser dimension-constraint test referenced Category, CategoryOption, CategoryOptionGroupSet, and DataDimensionType without importing them, and used categoryService without declaring it - a clean cherry-pick from 2.41, but the class didn't previously depend on CategoryService so the field was never added. This failed test-compile on CI (unit-test, integration-test, integration-h2-test, sonarqube all failed with the same "cannot find symbol" errors).



---------


(cherry picked from commit 74bc573dbcfa67e187ba847234e0b7d82adcda3e)