### PR TITLE
feat: e2e analytics test SQL injection

### DIFF
--- a/dhis-2/dhis-test-e2e/README.md
+++ b/dhis-2/dhis-test-e2e/README.md
@@ -285,3 +285,28 @@ Example (`ind-expected-pregnancies.json`):
 Add a `List<Resource>` (or a single `Resource`) parameter to your test method; 
 the extension injects the created objects, each exposing `type`, `code`, and `uid`.
 
+
+### Seeding the e2e database with SQL
+
+`@DependsOn` provisions metadata through the API. When an
+analytics test instead needs rows the API cannot create, put a `.sql` file in
+`src/test/resources/db/seed/`. It is applied automatically at the start of an analytics run.
+
+The seeding mechanism is supposed to be used to populate run-time tables, not the system-generated
+analytics tables.
+
+`AnalyticsSetupExtension` applies the scripts in file-name order, clears the instance's application
+caches if any were applied, and only then exports the analytics tables. Seeded data therefore flows
+The seeded data is injected into Postgres tables directly and then exported, so it does not matter
+which target database you run the analytics against.
+
+Pass `-Ddb.seed.enabled=false` to skip the scripts without deleting them — useful for checking
+whether a seed script is what broke a test.
+
+The scripts write to the runtime tables over JDBC. `db.url` defaults to the `db` service of the
+compose stacks — the same Postgres database on the Doris and ClickHouse runs, which differ only in
+where analytics is exported to — so containerised runs need no configuration. A run against a
+locally started instance needs `-Ddb.url=…` of its own. When the directory holds no scripts nothing
+connects to any database, so runs against instances you cannot reach are unaffected.
+
+See `src/test/resources/db/seed/README.md` for the full contract and its limitations.

--- a/dhis-2/dhis-test-e2e/pom.xml
+++ b/dhis-2/dhis-test-e2e/pom.xml
@@ -41,6 +41,7 @@
     <aerogear-otp-java.version>1.0.0</aerogear-otp-java.version>
     <nimbus-jose-jwt.version>10.9.1</nimbus-jose-jwt.version>
     <jsr305.version>3.0.2</jsr305.version>
+    <postgresql.version>42.7.12</postgresql.version>
   </properties>
 
   <dependencies>
@@ -215,6 +216,11 @@
       <artifactId>jsr305</artifactId>
       <version>${jsr305.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${postgresql.version}</version>
     </dependency>
   </dependencies>
 

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/test/e2e/db/SqlSeeder.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/test/e2e/db/SqlSeeder.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.test.e2e.db;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hisp.dhis.test.e2e.helpers.config.TestConfiguration;
+
+/**
+ * Applies SQL scripts to the database of the instance under test, so tests can rely on data the
+ * static e2e database dump does not contain.
+ */
+public class SqlSeeder {
+  /** Directory holding the scripts, relative to the module root. */
+  public static final String SEED_DIR = "src/test/resources/db/seed";
+
+  /** Applies when {@code db.seed.timeout.seconds} is not set. */
+  private static final int DEFAULT_TIMEOUT_SECONDS = 1800;
+
+  private static final Logger logger = LogManager.getLogger(SqlSeeder.class.getName());
+
+  private SqlSeeder() {}
+
+  /**
+   * Applies every {@code .sql} file in {@link #SEED_DIR}, ordered by file name. Each file is sent
+   * as a single multi-statement query, which PostgreSQL applies atomically.
+   *
+   * @return the number of scripts applied
+   * @throws IllegalStateException if the scripts cannot be listed, read or applied
+   */
+  public static int applySeedScripts() {
+    // Checked before the directory is looked at, so that disabling seeding cannot fail on a
+    // missing directory.
+    if (!Optional.ofNullable(TestConfiguration.get().shouldApplySeedScripts()).orElse(true)) {
+      logger.info("SQL seeding is disabled by db.seed.enabled=false; skipping {}", SEED_DIR);
+      return 0;
+    }
+
+    List<Path> scripts = seedScripts(Path.of(SEED_DIR));
+
+    if (scripts.isEmpty()) {
+      logger.info("No SQL seed scripts in {}", SEED_DIR);
+      return 0;
+    }
+
+    String url = TestConfiguration.get().databaseUrl();
+    logger.info("Applying {} SQL seed script(s) to {}", scripts.size(), url);
+
+    try (Connection connection =
+        DriverManager.getConnection(
+            url,
+            TestConfiguration.get().databaseUsername(),
+            TestConfiguration.get().databasePassword())) {
+      for (Path script : scripts) {
+        apply(connection, script, timeoutSeconds());
+      }
+    } catch (SQLException e) {
+      throw new IllegalStateException(
+          "Could not connect to "
+              + url
+              + " to apply the SQL seed scripts in "
+              + SEED_DIR
+              + ". Pass -Ddb.url, -Ddb.username and -Ddb.password when the database of the instance"
+              + " under test is not the one at that url.",
+          e);
+    }
+
+    logger.info("Applied {} SQL seed script(s)", scripts.size());
+
+    return scripts.size();
+  }
+
+  private static void apply(Connection connection, Path script, int timeoutSeconds) {
+    logger.info("Applying SQL seed script {}", script);
+
+    try (Statement statement = connection.createStatement()) {
+      // A script blocked on a lock would otherwise run for as long as the CI job allows: nothing
+      // else bounds it, since the analytics profile disables JUnit's timeouts and they would not
+      // cover an extension callback anyway.
+      statement.setQueryTimeout(timeoutSeconds);
+      statement.execute(Files.readString(script));
+    } catch (IOException | SQLException e) {
+      throw new IllegalStateException("Failed to apply SQL seed script " + script, e);
+    }
+  }
+
+  private static int timeoutSeconds() {
+    return Optional.ofNullable(TestConfiguration.get().seedTimeoutSeconds())
+        .orElse(DEFAULT_TIMEOUT_SECONDS);
+  }
+
+  static List<Path> seedScripts(Path dir) {
+    if (!Files.isDirectory(dir)) {
+      throw new IllegalStateException(
+          "The SQL seed directory "
+              + dir
+              + " does not exist. It is committed to the repository, so this normally means the"
+              + " working directory is not the dhis-test-e2e module root. Current working directory:"
+              + " "
+              + Path.of("").toAbsolutePath()
+              + ".");
+    }
+
+    try (Stream<Path> files = Files.list(dir)) {
+      return files
+          .filter(Files::isRegularFile)
+          .filter(path -> path.getFileName().toString().endsWith(".sql"))
+          .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+          .toList();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to list the SQL seed scripts in " + dir, e);
+    }
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/test/e2e/helpers/config/Config.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/test/e2e/helpers/config/Config.java
@@ -67,4 +67,19 @@ public interface Config extends org.aeonbits.owner.Config {
 
   @Key("analytics.run.export")
   Boolean shouldRunAnalyticsExport();
+
+  @Key("db.url")
+  String databaseUrl();
+
+  @Key("db.username")
+  String databaseUsername();
+
+  @Key("db.password")
+  String databasePassword();
+
+  @Key("db.seed.enabled")
+  Boolean shouldApplySeedScripts();
+
+  @Key("db.seed.timeout.seconds")
+  Integer seedTimeoutSeconds();
 }

--- a/dhis-2/dhis-test-e2e/src/main/resources/config.properties
+++ b/dhis-2/dhis-test-e2e/src/main/resources/config.properties
@@ -18,3 +18,18 @@ test.track_called_endpoints=false
 
 selenium.url=http://selenium:4444
 #selenium.url=http://localhost:4444
+
+# Runtime (transactional) database of the instance under test. Only used to apply the SQL
+# seed scripts in src/test/resources/db/seed, so it can be left alone unless such scripts
+# exist. The default is the db service of the docker compose stacks, which is Postgres for
+# the Doris and ClickHouse runs too - only the analytics backend differs. Uncomment the
+# second line, or pass -Ddb.url, for an instance started outside compose.
+db.url=jdbc:postgresql://db/dhis
+#db.url=jdbc:postgresql://localhost:5432/dhis2
+db.username=dhis
+db.password=dhis
+# Set to false to skip the SQL seed scripts entirely, without deleting them.
+db.seed.enabled=true
+# Upper bound on how long a single seed script may run, in seconds. A script blocked on a
+# lock is otherwise unbounded.
+db.seed.timeout.seconds=1800

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/extensions/AnalyticsSetupExtension.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/extensions/AnalyticsSetupExtension.java
@@ -38,8 +38,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.logging.log4j.Logger;
 import org.hisp.dhis.test.e2e.actions.LoginActions;
+import org.hisp.dhis.test.e2e.actions.MaintenanceActions;
 import org.hisp.dhis.test.e2e.actions.ResourceTableActions;
 import org.hisp.dhis.test.e2e.actions.SystemActions;
+import org.hisp.dhis.test.e2e.db.SqlSeeder;
 import org.hisp.dhis.test.e2e.dto.ApiResponse;
 import org.hisp.dhis.test.e2e.helpers.config.TestConfiguration;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -64,39 +66,59 @@ public class AnalyticsSetupExtension implements BeforeAllCallback {
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    boolean shouldRunExport =
-        Optional.ofNullable(TestConfiguration.get().shouldRunAnalyticsExport()).orElse(true);
-
-    if (shouldRunExport && run.compareAndSet(false, true)) {
-      logger.info("Starting analytics table export.");
-
-      // Login into the current DHIS2 instance.
-      new LoginActions().loginAsAdmin();
-
-      StopWatch watcher = new StopWatch();
-      watcher.start();
-
-      // Invoke the analytics table generation process.
-      String analyticsApiPath = "/analytics";
-      String queryParams = System.getProperty("analytics.api.query.params");
-
-      if (queryParams != null && !queryParams.isEmpty()) {
-        analyticsApiPath += "?" + queryParams;
-        logger.info("Appending analytics query parameters: {}", queryParams);
-      }
-
-      ApiResponse response =
-          new ResourceTableActions().post(analyticsApiPath, new JsonObject()).validateStatus(200);
-
-      String analyticsTaskId = response.extractString("response.id");
-
-      // Wait until the process is completed.
-      new SystemActions().waitUntilTaskCompleted("ANALYTICS_TABLE", analyticsTaskId, TIMEOUT);
-
-      watcher.stop();
-
-      logger.info("Concluding analytics table export in {} minutes", watcher.getTime(MINUTES));
+    if (!run.compareAndSet(false, true)) {
+      return;
     }
+
+    if (SqlSeeder.applySeedScripts() > 0) {
+      clearApplicationCaches();
+    }
+
+    if (Optional.ofNullable(TestConfiguration.get().shouldRunAnalyticsExport()).orElse(true)) {
+      exportAnalyticsTables();
+    }
+  }
+
+  /**
+   * The seed scripts write straight to the database, so the instance under test still holds what it
+   * cached before they ran.
+   */
+  private void clearApplicationCaches() {
+    logger.info("Clearing application caches.");
+
+    new LoginActions().loginAsAdmin();
+    new MaintenanceActions().post("cacheClear", new JsonObject()).validateStatus(200);
+  }
+
+  private void exportAnalyticsTables() {
+    logger.info("Starting analytics table export.");
+
+    // Login into the current DHIS2 instance.
+    new LoginActions().loginAsAdmin();
+
+    StopWatch watcher = new StopWatch();
+    watcher.start();
+
+    // Invoke the analytics table generation process.
+    String analyticsApiPath = "/analytics";
+    String queryParams = System.getProperty("analytics.api.query.params");
+
+    if (queryParams != null && !queryParams.isEmpty()) {
+      analyticsApiPath += "?" + queryParams;
+      logger.info("Appending analytics query parameters: {}", queryParams);
+    }
+
+    ApiResponse response =
+        new ResourceTableActions().post(analyticsApiPath, new JsonObject()).validateStatus(200);
+
+    String analyticsTaskId = response.extractString("response.id");
+
+    // Wait until the process is completed.
+    new SystemActions().waitUntilTaskCompleted("ANALYTICS_TABLE", analyticsTaskId, TIMEOUT);
+
+    watcher.stop();
+
+    logger.info("Concluding analytics table export in {} minutes", watcher.getTime(MINUTES));
   }
 
   private static long minutes(int minutes) {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/test/e2e/db/SqlSeederTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/test/e2e/db/SqlSeederTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.test.e2e.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SqlSeederTest {
+
+  @Test
+  void seedScriptsFailsWhenDirectoryDoesNotExist(@TempDir Path dir) {
+    Path absent = dir.resolve("absent");
+
+    IllegalStateException e =
+        assertThrows(IllegalStateException.class, () -> SqlSeeder.seedScripts(absent));
+
+    assertTrue(
+        e.getMessage().contains(absent.toString()),
+        "the message should name the directory it looked in: " + e.getMessage());
+    assertTrue(
+        e.getMessage().contains("working directory"),
+        "the message should point at the likely cause: " + e.getMessage());
+  }
+
+  @Test
+  void seedScriptsIsEmptyWhenDirectoryHasNoScripts(@TempDir Path dir) throws IOException {
+    Files.writeString(dir.resolve("README.md"), "not a script");
+
+    assertTrue(SqlSeeder.seedScripts(dir).isEmpty());
+  }
+
+  @Test
+  void seedScriptsAreOrderedByFileName(@TempDir Path dir) throws IOException {
+    Files.writeString(dir.resolve("020-second.sql"), "select 2;");
+    Files.writeString(dir.resolve("010-first.sql"), "select 1;");
+    Files.writeString(dir.resolve("030-third.sql"), "select 3;");
+
+    List<String> names = fileNames(dir);
+
+    assertEquals(List.of("010-first.sql", "020-second.sql", "030-third.sql"), names);
+  }
+
+  @Test
+  void seedScriptsIgnoresNonSqlFiles(@TempDir Path dir) throws IOException {
+    Files.writeString(dir.resolve("010-applied.sql"), "select 1;");
+    Files.writeString(dir.resolve("020-notes.txt"), "ignored");
+    Files.writeString(dir.resolve("030-disabled.sql.off"), "ignored");
+    Files.createDirectory(dir.resolve("040-a-directory.sql"));
+
+    List<String> names = fileNames(dir);
+
+    assertEquals(List.of("010-applied.sql"), names);
+  }
+
+  private static List<String> fileNames(Path dir) {
+    return SqlSeeder.seedScripts(dir).stream().map(path -> path.getFileName().toString()).toList();
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/test/resources/db/seed/README.md
+++ b/dhis-2/dhis-test-e2e/src/test/resources/db/seed/README.md
@@ -1,0 +1,82 @@
+# E2E SQL seed scripts
+
+Every `*.sql` file in this directory is applied to the runtime database of the instance under test at
+the start of an analytics e2e run, immediately before the analytics tables are exported. Drop a file
+here and it is picked up.
+
+Applied by `org.hisp.dhis.test.e2e.db.SqlSeeder`, called from
+`org.hisp.dhis.helpers.extensions.AnalyticsSetupExtension`. Only the analytics suite runs that
+extension, so these scripts do not affect any other e2e test.
+
+## Contract
+
+- Files are applied in file-name order. Prefix them so the order is explicit: `010-`, `020-`.
+- Each file is sent as a single multi-statement query. PostgreSQL wraps that in one implicit
+  transaction, so a file that contains no transaction-control statements is applied atomically: if
+  any statement fails, none of that file's changes remain.
+- A file that issues its own `begin`/`commit`/`rollback` controls
+  its own transaction boundaries, and anything committed before a later failure stays committed.
+- Earlier files are **not** rolled back when a later one fails. The run stops at the first bad file,
+  leaving the database half-seeded for the rest of the run.
+- A failing script aborts the run: the first analytics test class fails in `beforeAll` with the
+  script name and PostgreSQL's error.
+- Scripts run against the **migrated** schema, not the schema of the Sierra Leone 2.39.6 dump. Write
+  them against the current data model.
+- Resolve internal ids by UID. Never hardcode them, they differ between dumps:
+
+  ```sql
+  insert into ...
+  select ou.organisationunitid, de.dataelementid
+  from organisationunit ou, dataelement de
+  where ou.uid = 'ImspTQPwCqd' and de.uid = 'fbfJHSPpUQD';
+  ```
+
+- When at least one script is applied, `/api/maintenance/cacheClear` is called before the export, so
+  metadata the instance cached at startup is re-read. Anything cached outside
+  `clearApplicationCaches()` will still be stale.
+- Seeded data reaches the analytics tables because the export runs afterwards. This holds for the
+  Postgres, Doris and ClickHouse jobs alike — all three seed the same runtime database.
+- It does **not** hold when you pass `-Danalytics.run.export=false`. The scripts are still applied,
+  but analytics results come from whatever the dump already contained.
+
+## What SQL you can use
+
+The scripts go through JDBC, not `psql`. That means no `\copy` or other meta-commands, no
+`COPY … FROM stdin`, and nothing that refuses to run inside a transaction, such as
+`CREATE INDEX CONCURRENTLY` or `VACUUM`.
+
+A single script may run for at most `db.seed.timeout.seconds` (default 1800). Past that it is
+cancelled and the run fails, so a script blocked on a lock cannot stall the job indefinitely.
+
+## Turning seeding off
+
+`db.seed.enabled=false` skips every script without deleting it:
+
+```sh
+mvn -Panalytics test -Ddb.seed.enabled=false ...
+```
+
+Nothing is read and no database connection is attempted, so this also works when the database is
+unreachable. Use it to check whether a failing test is caused by a seed script, or to run the suite
+against an instance you have no database access to while scripts are committed.
+
+## Connecting to the right database
+
+`db.url` defaults to `jdbc:postgresql://db/dhis`, the `db` service of the compose stacks. That is the
+runtime database for the Doris and ClickHouse runs too — those backends only change where analytics
+is exported to. For a run against a locally started instance, pass your own:
+
+```sh
+mvn -Panalytics test -Dinstance.url=http://localhost:8080/api \
+  -Duser.admin.username=admin -Duser.admin.password=district \
+  -Ddb.url=jdbc:postgresql://localhost:5432/e2e -Ddb.username=dhis -Ddb.password=dhis
+```
+
+If no scripts are present, no connection is attempted and these properties are ignored — which is
+what lets the suite keep running against instances whose database you cannot reach.
+
+## Warning
+
+The `*AutoTest` classes assert exact numbers. A script that adds data to metadata those tests
+already query will change their expected values and break them. Prefer introducing your own metadata
+over extending Sierra Leone's.


### PR DESCRIPTION
## Summary

The analytics e2e suite runs against a fixed Sierra Leone 2.39.6 dump, so adding a single row a new test needs today means regenerating and republishing that dump. Any .sql file dropped in `dhis-test-e2e/src/test/resources/db/seed/` is now applied to the runtime tables at the start of an analytics run, immediately before the analytics tables are exported.

The seeding can be disabled by setting the property `db.seed.enabled=false`.
