### PR TITLE
feat: bound tracker export requests by a configurable timeout DHIS2-21390

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -457,18 +457,15 @@ public enum ConfigurationKey {
   /**
    * Maximum number of seconds a tracker export request may spend querying the database before it is
    * canceled and the request fails with 504. The budget is shared by all queries of one request.
-   * {@code 0} disables the timeout. (default: 55)
+   * {@code 0} disables the timeout. (default: 0)
    *
    * <p>Because the underlying JDBC timeout has whole second granularity and the remaining budget is
    * rounded up, a request can take up to one second longer than this value.
    *
-   * <p>55 rather than 60 to stay under the reverse proxy. nginx defaults {@code proxy_read_timeout}
-   * to 60s and exports send nothing until they are done, so both timers measure the same silence:
-   * at 60s each they race. If the proxy wins it returns its own 504, this code never runs and the
-   * query is never cancelled, which is the thing this timeout exists to do. Keep this value below
-   * {@code proxy_read_timeout}, and raise that above this one when allowing longer exports.
+   * <p>Set this below any timeout in front of DHIS2, such as a reverse proxy or load balancer. If
+   * the proxy times out first it returns its own 504 while the query is never cancelled.
    */
-  TRACKER_EXPORT_TIMEOUT("tracker.export.timeout", "55", false),
+  TRACKER_EXPORT_TIMEOUT("tracker.export.timeout", "0", false),
 
   /** Use unlogged tables during analytics export. (default: ON) */
   ANALYTICS_TABLE_UNLOGGED("analytics.table.unlogged", Constants.ON),

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -457,12 +457,18 @@ public enum ConfigurationKey {
   /**
    * Maximum number of seconds a tracker export request may spend querying the database before it is
    * canceled and the request fails with 504. The budget is shared by all queries of one request.
-   * {@code 0} disables the timeout. (default: 10)
+   * {@code 0} disables the timeout. (default: 55)
    *
    * <p>Because the underlying JDBC timeout has whole second granularity and the remaining budget is
    * rounded up, a request can take up to one second longer than this value.
+   *
+   * <p>55 rather than 60 to stay under the reverse proxy. nginx defaults {@code proxy_read_timeout}
+   * to 60s and exports send nothing until they are done, so both timers measure the same silence:
+   * at 60s each they race. If the proxy wins it returns its own 504, this code never runs and the
+   * query is never cancelled, which is the thing this timeout exists to do. Keep this value below
+   * {@code proxy_read_timeout}, and raise that above this one when allowing longer exports.
    */
-  TRACKER_EXPORT_TIMEOUT("tracker.export.timeout", "10", false),
+  TRACKER_EXPORT_TIMEOUT("tracker.export.timeout", "55", false),
 
   /** Use unlogged tables during analytics export. (default: ON) */
   ANALYTICS_TABLE_UNLOGGED("analytics.table.unlogged", Constants.ON),

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -454,6 +454,16 @@ public enum ConfigurationKey {
 
   PROGRAM_TEMPORARY_OWNERSHIP_TIMEOUT("tracker.temporary.ownership.timeout", "3", false),
 
+  /**
+   * Maximum number of seconds a tracker export request may spend querying the database before it is
+   * canceled and the request fails with 504. The budget is shared by all queries of one request.
+   * {@code 0} disables the timeout. (default: 10)
+   *
+   * <p>Because the underlying JDBC timeout has whole second granularity and the remaining budget is
+   * rounded up, a request can take up to one second longer than this value.
+   */
+  TRACKER_EXPORT_TIMEOUT("tracker.export.timeout", "10", false),
+
   /** Use unlogged tables during analytics export. (default: ON) */
   ANALYTICS_TABLE_UNLOGGED("analytics.table.unlogged", Constants.ON),
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -455,9 +455,11 @@ public enum ConfigurationKey {
   PROGRAM_TEMPORARY_OWNERSHIP_TIMEOUT("tracker.temporary.ownership.timeout", "3", false),
 
   /**
-   * Maximum number of seconds a tracker export request may spend querying the database before it is
-   * canceled and the request fails with 504. The budget is shared by all queries of one request.
-   * {@code 0} disables the timeout. (default: 0)
+   * Maximum number of seconds a tracker export request may spend running queries before they are
+   * canceled and the request fails with 504. The budget is shared by all queries of one request but
+   * covers only the time they run, not the wait for a connection, which the pool bounds separately
+   * via {@code connection.pool.timeout} and answers with a 503. {@code 0} disables the timeout.
+   * (default: 0)
    *
    * <p>Because the underlying JDBC timeout has whole second granularity and the remaining budget is
    * rounded up, a request can take up to one second longer than this value.

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/config/SlowQueryDataSourceProxy.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/config/SlowQueryDataSourceProxy.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.test.config;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+import javax.sql.DataSource;
+import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Test-only datasource proxy that makes selected statements artificially slow by wrapping them in a
+ * {@code pg_sleep}. This exists so a test can trip a query timeout against real production SQL.
+ *
+ * <p>To use, add
+ *
+ * <pre>{@code
+ * @ContextConfiguration(classes = {SlowQueryDataSourceProxy.class})
+ * }</pre>
+ *
+ * to the test class, then arm it around the code under test:
+ *
+ * <pre>{@code
+ * SlowQueryDataSourceProxy.sleepBefore("select te.trackedentityid, te.uid", Duration.ofSeconds(5));
+ * // ... run the code under test ...
+ * SlowQueryDataSourceProxy.disarm();
+ * }</pre>
+ *
+ * <p>The matched statement is wrapped so the production SQL itself is unchanged and still yields
+ * exactly one ResultSet with its original columns. The sleep runs on the same {@code Statement} as
+ * the query, so a {@code setQueryTimeout} armed for that statement cancels mid-sleep, which is what
+ * makes the timeout observable.
+ *
+ * <p>Matching is a case-insensitive substring test on the SQL text, and matched statements are
+ * counted so a test can assert the injection actually happened rather than passing because the
+ * sleep never fired.
+ */
+@Component
+public class SlowQueryDataSourceProxy implements BeanPostProcessor {
+
+  /** SQL pattern (lower case) to the sleep in seconds applied to statements matching it. */
+  private static final Map<String, Double> SLEEPS = new ConcurrentHashMap<>();
+
+  private static final AtomicInteger MATCHES = new AtomicInteger();
+
+  /**
+   * Arms the proxy: every subsequent statement whose SQL contains {@code sqlPattern}
+   * (case-insensitive) is slowed down by {@code sleep}. May be called more than once to slow down
+   * several different statements within one request.
+   */
+  public static void sleepBefore(String sqlPattern, Duration sleep) {
+    SLEEPS.put(sqlPattern.toLowerCase(Locale.ROOT), sleep.toMillis() / 1000.0);
+  }
+
+  /**
+   * Stops slowing down statements but keeps the match count. Call as soon as the code under test
+   * returns, so no sleep bleeds into the assertions that follow.
+   */
+  public static void disarm() {
+    SLEEPS.clear();
+  }
+
+  /** Disarms the proxy and clears the match count. Call in an {@code @AfterEach}. */
+  public static void reset() {
+    disarm();
+    MATCHES.set(0);
+  }
+
+  /** How many statements have been slowed down since the last {@link #reset()}. */
+  public static int matches() {
+    return MATCHES.get();
+  }
+
+  /** The sleep armed for the first pattern this query matches, or null if none matches. */
+  private static Double matchingSleep(String query) {
+    if (SLEEPS.isEmpty()) {
+      return null;
+    }
+    String lower = query.toLowerCase(Locale.ROOT);
+    for (Map.Entry<String, Double> sleep : SLEEPS.entrySet()) {
+      if (lower.contains(sleep.getKey())) {
+        return sleep.getValue();
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Object postProcessAfterInitialization(@Nonnull Object bean, @Nonnull String beanName)
+      throws BeansException {
+    if (bean instanceof DataSource originalDataSource && beanName.equals("actualDataSource")) {
+      return ProxyDataSourceBuilder.create(originalDataSource)
+          .name("slow-query-datasource-proxy")
+          .queryTransformer(
+              info -> {
+                String query = info.getQuery();
+                Double sleepSeconds = matchingSleep(query);
+                if (sleepSeconds == null) {
+                  return query;
+                }
+                MATCHES.incrementAndGet();
+                // The sleep has to live inside the same single statement: a separate
+                // "select pg_sleep(n);" prefix returns a second ResultSet, which JdbcTemplate
+                // rejects with "Multiple ResultSets were returned by the query". Wrapping the
+                // original query keeps exactly one ResultSet with the original columns.
+                //
+                // The sleep goes in a CTE that the query's WHERE cannot be pushed into, so it is
+                // evaluated exactly once. Putting it in a joined subquery instead makes PostgreSQL
+                // evaluate it per output row, which multiplies the delay by the row count.
+                return "with __sleep as materialized (select pg_sleep("
+                    + sleepSeconds
+                    + ") as slept) select __slow.* from ("
+                    + query
+                    + ") __slow where (select count(*) from __sleep) >= 0";
+              })
+          .build();
+    }
+    return bean;
+  }
+}

--- a/dhis-2/dhis-test-performance/docker/dhis-l2cache-off.conf
+++ b/dhis-2/dhis-test-performance/docker/dhis-l2cache-off.conf
@@ -14,6 +14,9 @@ connection.password = dhis
 
 system.update_notifications_enabled = off
 
+# Below gatling.http.requestTimeout (60s) so DHIS2 times out and cancels the query first.
+tracker.export.timeout = 50
+
 tracker.import.preheat.cache.enabled = off
 
 hibernate.cache.use_second_level_cache = off

--- a/dhis-2/dhis-test-performance/docker/dhis-l2cache-on.conf
+++ b/dhis-2/dhis-test-performance/docker/dhis-l2cache-on.conf
@@ -17,6 +17,9 @@ connection.password = dhis
 
 system.update_notifications_enabled = off
 
+# Below gatling.http.requestTimeout (60s) so DHIS2 times out and cancels the query first.
+tracker.export.timeout = 50
+
 tracker.import.preheat.cache.enabled = off
 
 # Monitoring metrics scraped by the measurement sidecars (/api/metrics)

--- a/dhis-2/dhis-test-performance/docker/dhis-metrics.conf
+++ b/dhis-2/dhis-test-performance/docker/dhis-metrics.conf
@@ -11,6 +11,9 @@ connection.password = dhis
 
 system.update_notifications_enabled = off
 
+# Below gatling.http.requestTimeout (60s) so DHIS2 times out and cancels the query first.
+tracker.export.timeout = 50
+
 tracker.import.preheat.cache.enabled = off
 
 # Enable monitoring metrics for performance analysis

--- a/dhis-2/dhis-test-performance/docker/dhis.conf
+++ b/dhis-2/dhis-test-performance/docker/dhis.conf
@@ -6,6 +6,9 @@ connection.password = dhis
 
 system.update_notifications_enabled = off
 
+# Below gatling.http.requestTimeout (60s) so DHIS2 times out and cancels the query first.
+tracker.export.timeout = 50
+
 # Debugging: prepend SQL comments with request context for query attribution.
 # This can influence performance as unique comments prevent prepared statement caching.
 #monitoring.sql.context = on

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/MvcTestConfig.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/MvcTestConfig.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.webapi.mvc.CustomRequestMappingHandlerMapping;
 import org.hisp.dhis.webapi.mvc.UrlParamsMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.interceptor.AuthorityInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.SystemSettingsInterceptor;
+import org.hisp.dhis.webapi.mvc.interceptor.TrackerExportDeadlineInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.UserContextInterceptor;
 import org.hisp.dhis.webapi.mvc.messageconverter.FilteredPageHttpMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.JsonMessageConverter;
@@ -98,6 +99,8 @@ public class MvcTestConfig implements WebMvcConfigurer {
 
   @Autowired private SystemSettingsInterceptor settingsInterceptor;
 
+  @Autowired private TrackerExportDeadlineInterceptor trackerExportDeadlineInterceptor;
+
   @Autowired private NodeService nodeService;
 
   @Autowired private CurrentUserHandlerMethodArgumentResolver currentUserArgResolver;
@@ -143,6 +146,9 @@ public class MvcTestConfig implements WebMvcConfigurer {
     registry.addInterceptor(new UserContextInterceptor());
     registry.addInterceptor(authorityInterceptor);
     registry.addInterceptor(settingsInterceptor);
+    registry
+        .addInterceptor(trackerExportDeadlineInterceptor)
+        .addPathPatterns(TrackerExportDeadlineInterceptor.PATH_PATTERNS);
     mapping.setInterceptors(registry.getInterceptors().toArray());
 
     mapping.setContentNegotiationManager(
@@ -180,6 +186,9 @@ public class MvcTestConfig implements WebMvcConfigurer {
 
     registry.addInterceptor(new UserContextInterceptor());
     registry.addInterceptor(authorityInterceptor);
+    registry
+        .addInterceptor(trackerExportDeadlineInterceptor)
+        .addPathPatterns(TrackerExportDeadlineInterceptor.PATH_PATTERNS);
   }
 
   @Bean

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportTimeoutTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportTimeoutTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.test.config.PostgresTestConfigOverride;
+import org.hisp.dhis.test.config.SlowQueryDataSourceProxy;
+import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.webapi.controller.tracker.TestSetup;
+import org.hisp.dhis.webapi.controller.tracker.export.ExportTimeoutTest.DhisConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Tests that tracker export requests are bounded by {@code tracker.export.timeout} and that
+ * exceeding the budget returns 504 and leaves no PostgreSQL backend running.
+ *
+ * <p>Real export SQL is made slow by {@link SlowQueryDataSourceProxy}, which wraps the matched
+ * statement in a {@code pg_sleep} at the datasource boundary so production queries stay untouched.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ContextConfiguration(classes = {DhisConfig.class, SlowQueryDataSourceProxy.class})
+class ExportTimeoutTest extends PostgresControllerIntegrationTestBase {
+
+  /**
+   * Budget the export endpoints get in this test. Every test here runs until it is cancelled, so
+   * each costs roughly this much and the budget is what drives the runtime.
+   *
+   * <p>Not lower because the shared budget test needs the first statement to fit and still leave a
+   * remainder that {@code remainingSecondsCeil} does not round away. At 2s the fixture's own query
+   * time was enough to spend the whole budget on the first statement.
+   */
+  private static final Duration BUDGET = Duration.ofSeconds(5);
+
+  static class DhisConfig {
+    @Bean
+    public PostgresTestConfigOverride postgresTestConfigOverride() {
+      PostgresTestConfigOverride override = new PostgresTestConfigOverride();
+      override.put("tracker.export.timeout", String.valueOf(BUDGET.toSeconds()));
+      return override;
+    }
+  }
+
+  @Autowired private TestSetup testSetup;
+
+  @Autowired private IdentifiableObjectManager manager;
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  private User importUser;
+
+  @BeforeAll
+  void setUp() throws IOException {
+    testSetup.importMetadata();
+
+    importUser = userService.getUser("tTgjgobT1oS");
+    injectSecurityContextUser(importUser);
+
+    testSetup.importTrackerData();
+
+    manager.flush();
+    manager.clear();
+  }
+
+  @BeforeEach
+  void setUpUser() {
+    switchContextToUser(importUser);
+  }
+
+  @AfterEach
+  void tearDownProxy() {
+    SlowQueryDataSourceProxy.reset();
+  }
+
+  /**
+   * Outer projection of the tracked entity id query ({@code JdbcTrackedEntityStore}). Matching on
+   * this rather than on a table name keeps the sleep off the framework's own setup, auth and
+   * metadata queries, which would otherwise hold every pooled connection in a sleep.
+   */
+  private static final String ID_QUERY = "select te.trackedentityid, te.uid";
+
+  /**
+   * Projection unique to {@code TrackedEntityStore}, run by the aggregate branches on {@code
+   * TrackedEntityAggregate}'s thread pool rather than on the request thread.
+   */
+  private static final String AGGREGATE_QUERY = "te.uid as te_uid";
+
+  @Test
+  void shouldReturnGatewayTimeoutAndCancelTheQueryWhenTheBudgetIsExceeded() {
+    // sleep well past the budget so the deadline must fire on the id query
+    SlowQueryDataSourceProxy.sleepBefore(ID_QUERY, BUDGET.multipliedBy(3));
+
+    HttpStatus status = getTrackedEntities("/tracker/trackedEntities?program={program}");
+
+    assertEquals(HttpStatus.GATEWAY_TIMEOUT, status);
+    assertTrue(
+        SlowQueryDataSourceProxy.matches() > 0,
+        "no statement was slowed down, so this test would pass without any timeout being enforced");
+    // A silently failed Statement.cancel() is a documented pgjdbc mode, so asserting only on the
+    // HTTP status would pass while leaving an orphaned backend still running the query.
+    assertEquals(
+        0,
+        countBackendsRunningSleep(),
+        "a PostgreSQL backend is still running the cancelled query");
+  }
+
+  @Test
+  void shouldShareOneBudgetAcrossSequentialStatementsOfOneRequest() {
+    // Either statement fits the budget alone, the two together cannot. They also run on different
+    // threads, so this covers the deadline reaching the aggregate's pool.
+    Duration overHalfTheBudget = BUDGET.dividedBy(2).plusSeconds(1);
+    SlowQueryDataSourceProxy.sleepBefore(ID_QUERY, overHalfTheBudget);
+    SlowQueryDataSourceProxy.sleepBefore(AGGREGATE_QUERY, overHalfTheBudget);
+
+    long startNanos = System.nanoTime();
+    HttpStatus status = getTrackedEntities("/tracker/trackedEntities?program={program}&fields=*");
+    Duration elapsed = Duration.ofNanos(System.nanoTime() - startNanos);
+
+    assertEquals(HttpStatus.GATEWAY_TIMEOUT, status);
+    assertTrue(
+        SlowQueryDataSourceProxy.matches() > 1,
+        "only one statement was slowed down, so this does not exercise a shared budget");
+    assertTrue(
+        elapsed.compareTo(BUDGET.plus(overHalfTheBudget)) < 0,
+        "request took "
+            + elapsed
+            + ", so each statement got its own timeout instead of sharing the budget of "
+            + BUDGET);
+  }
+
+  /**
+   * The export paths reading through Hibernate rather than {@code JdbcTemplate}, which are bounded
+   * by the {@code jakarta.persistence.query.timeout} hint instead of by the deadline aware
+   * template.
+   *
+   * <p>Each case is the SQL the sleep is injected into and the request that runs it:
+   *
+   * <ul>
+   *   <li>relationships, the list query
+   *   <li>relationships with {@code totalPages}, the count query. It returns a single result rather
+   *       than a list, and an unbounded one surfaces as a bare {@code PersistenceException} that
+   *       the advice turns into 409 rather than 504
+   *   <li>tracked entity change logs, a sub path of an export controller, so the interceptor
+   *       already arms a deadline for it
+   * </ul>
+   */
+  private static Stream<Arguments> hibernateExportPaths() {
+    return Stream.of(
+        arguments("from relationship", "/tracker/relationships?trackedEntity={te}"),
+        arguments("count(", "/tracker/relationships?trackedEntity={te}&totalPages=true"),
+        arguments("from trackedentitychangelog", "/tracker/trackedEntities/{te}/changeLogs"));
+  }
+
+  @MethodSource("hibernateExportPaths")
+  @ParameterizedTest
+  void shouldReturnGatewayTimeoutWhenAHibernateExportQueryExceedsTheBudget(
+      String sqlPattern, String url) {
+    SlowQueryDataSourceProxy.sleepBefore(sqlPattern, BUDGET.multipliedBy(3));
+
+    HttpStatus status;
+    try {
+      status = GET(url, "QS6w44flWAf").status();
+    } finally {
+      SlowQueryDataSourceProxy.disarm();
+    }
+
+    assertEquals(HttpStatus.GATEWAY_TIMEOUT, status);
+    assertTrue(
+        SlowQueryDataSourceProxy.matches() > 0,
+        "no statement was slowed down, so this would pass without any timeout being enforced");
+  }
+
+  /**
+   * Issues the request and disarms the proxy the moment it returns, so no sleep can bleed into the
+   * assertions or the per-test teardown.
+   */
+  private HttpStatus getTrackedEntities(String url) {
+    try {
+      return GET(url, "BFcipDERJnf").status();
+    } finally {
+      SlowQueryDataSourceProxy.disarm();
+    }
+  }
+
+  /** Number of PostgreSQL backends still executing the injected sleep. */
+  private int countBackendsRunningSleep() {
+    Integer count =
+        jdbcTemplate.queryForObject(
+            """
+            select count(*) from pg_stat_activity
+            where state = 'active'
+              and query like '%pg_sleep%'
+              and pid <> pg_backend_pid()""",
+            Integer.class);
+    return count == null ? 0 : count;
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportTimeoutTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportTimeoutTest.java
@@ -217,6 +217,51 @@ class ExportTimeoutTest extends PostgresControllerIntegrationTestBase {
   }
 
   /**
+   * A Hibernate query reached with under a second of budget left must still be bounded.
+   *
+   * <p>Hibernate takes its timeout in whole seconds, so a sub second remainder has to round up to 1
+   * rather than down to 0, which JDBC reads as no timeout at all. Slowing the tracked entity lookup
+   * that {@code RelationshipOperationParamsMapper} runs first leaves exactly that remainder for the
+   * relationship query behind it.
+   *
+   * <p>Asserting on elapsed time rather than only on the 504: an unbounded relationship query still
+   * ends in a 504, since the budget is already spent by the time it returns, but it runs its sleep
+   * out in full first. That is the failure this guards, so the status alone would not catch it.
+   */
+  @Test
+  void shouldBoundAHibernateQueryReachedWithLessThanASecondOfBudgetLeft() {
+    Duration justUnderTheBudget = BUDGET.minusMillis(400);
+    SlowQueryDataSourceProxy.sleepBefore("from trackedentity", justUnderTheBudget);
+    SlowQueryDataSourceProxy.sleepBefore("from relationship", BUDGET.multipliedBy(3));
+
+    long startNanos = System.nanoTime();
+    HttpStatus status;
+    try {
+      status = GET("/tracker/relationships?trackedEntity={te}", "QS6w44flWAf").status();
+    } finally {
+      SlowQueryDataSourceProxy.disarm();
+    }
+    Duration elapsed = Duration.ofNanos(System.nanoTime() - startNanos);
+
+    assertEquals(HttpStatus.GATEWAY_TIMEOUT, status);
+    assertTrue(
+        SlowQueryDataSourceProxy.matches() > 1,
+        "only one statement was slowed down, so the relationship query did not run with a sub"
+            + " second remainder");
+    assertTrue(
+        elapsed.compareTo(BUDGET.multipliedBy(2)) < 0,
+        "request took "
+            + elapsed
+            + ", so the relationship query ran unbounded rather than being cancelled with the "
+            + "remainder of the budget of "
+            + BUDGET);
+    assertEquals(
+        0,
+        countBackendsRunningSleep(),
+        "a PostgreSQL backend is still running the cancelled query");
+  }
+
+  /**
    * Issues the request and disarms the proxy the moment it returns, so no sleep can bleed into the
    * assertions or the per-test teardown.
    */

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportTimeoutTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportTimeoutTest.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.http.HttpMethod;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.test.config.PostgresTestConfigOverride;
 import org.hisp.dhis.test.config.SlowQueryDataSourceProxy;
@@ -51,6 +52,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -131,12 +133,23 @@ class ExportTimeoutTest extends PostgresControllerIntegrationTestBase {
    */
   private static final String AGGREGATE_QUERY = "te.uid as te_uid";
 
-  @Test
-  void shouldReturnGatewayTimeoutAndCancelTheQueryWhenTheBudgetIsExceeded() {
+  /**
+   * HEAD as well as GET: Spring dispatches it to the same {@code @GetMapping} handler, so it runs
+   * the whole export and only drops the body on the way out. Unbounded, it would be a cheap request
+   * that costs a full export and that nothing cancels.
+   */
+  @EnumSource(names = {"GET", "HEAD"})
+  @ParameterizedTest
+  void shouldReturnGatewayTimeoutAndCancelTheQueryWhenTheBudgetIsExceeded(HttpMethod method) {
     // sleep well past the budget so the deadline must fire on the id query
     SlowQueryDataSourceProxy.sleepBefore(ID_QUERY, BUDGET.multipliedBy(3));
 
-    HttpStatus status = getTrackedEntities("/tracker/trackedEntities?program={program}");
+    HttpStatus status;
+    try {
+      status = perform(method, "/api/tracker/trackedEntities?program=BFcipDERJnf").status();
+    } finally {
+      SlowQueryDataSourceProxy.disarm();
+    }
 
     assertEquals(HttpStatus.GATEWAY_TIMEOUT, status);
     assertTrue(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/JdbcEnrollmentStore.java
@@ -74,6 +74,7 @@ import org.hisp.dhis.tracker.export.Geometries;
 import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.OrderJdbcClause;
 import org.hisp.dhis.tracker.export.UserInfoSnapshots;
+import org.hisp.dhis.tracker.export.timeout.TrackerExportTimeoutConfig;
 import org.hisp.dhis.tracker.model.Enrollment;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
@@ -81,6 +82,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.sharing.Sharing;
 import org.hisp.dhis.util.DateUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -102,6 +104,7 @@ class JdbcEnrollmentStore {
           "lastUpdated",
           "lastUpdatedAtClient");
 
+  @Qualifier(TrackerExportTimeoutConfig.TRACKER_EXPORT_JDBC_TEMPLATE)
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
   public List<Enrollment> getEnrollments(EnrollmentQueryParams enrollmentParams) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
@@ -163,7 +163,7 @@ public abstract class HibernateEventChangeLogStore<T, S extends SoftDeletableEnt
       query.setParameter("filterValue", filter.getValue().getFilter());
     }
 
-    List<Object[]> results = resultList(query, "event change log query");
+    List<Object[]> results = resultList(query);
     List<EventChangeLog> eventChangeLogs =
         results.stream()
             .map(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/event/HibernateEventChangeLogStore.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.tracker.export.event;
 
 import static java.util.Map.entry;
 import static org.hisp.dhis.query.JpaQueryUtils.generateHqlQueryForSharingCheck;
+import static org.hisp.dhis.tracker.export.timeout.DeadlineQueries.resultList;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
@@ -162,7 +163,7 @@ public abstract class HibernateEventChangeLogStore<T, S extends SoftDeletableEnt
       query.setParameter("filterValue", filter.getValue().getFilter());
     }
 
-    List<Object[]> results = query.getResultList();
+    List<Object[]> results = resultList(query, "event change log query");
     List<EventChangeLog> eventChangeLogs =
         results.stream()
             .map(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -29,6 +29,10 @@
  */
 package org.hisp.dhis.tracker.export.relationship;
 
+import static org.hisp.dhis.tracker.export.timeout.DeadlineQueries.resultList;
+import static org.hisp.dhis.tracker.export.timeout.DeadlineQueries.singleResult;
+import static org.hisp.dhis.tracker.export.timeout.DeadlineQueries.withDeadline;
+
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -103,9 +107,10 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
       hql += "and te.deleted = false";
     }
     List<TrackedEntity> trackedEntities =
-        getQuery(hql, TrackedEntity.class)
-            .setParameter("trackedEntity", trackedEntity.getValue())
-            .getResultList();
+        resultList(
+            getQuery(hql, TrackedEntity.class)
+                .setParameter("trackedEntity", trackedEntity.getValue()),
+            "relationship query");
     return trackedEntities.stream().findFirst();
   }
 
@@ -120,9 +125,9 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
       hql += "and e.deleted = false";
     }
     List<Enrollment> enrollments =
-        getQuery(hql, Enrollment.class)
-            .setParameter("enrollment", enrollment.getValue())
-            .getResultList();
+        resultList(
+            getQuery(hql, Enrollment.class).setParameter("enrollment", enrollment.getValue()),
+            "relationship query");
     return enrollments.stream().findFirst();
   }
 
@@ -137,7 +142,9 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
       hql += "and e.deleted = false";
     }
     List<TrackerEvent> events =
-        getQuery(hql, TrackerEvent.class).setParameter("event", event.getValue()).getResultList();
+        resultList(
+            getQuery(hql, TrackerEvent.class).setParameter("event", event.getValue()),
+            "relationship query");
     return events.stream().findFirst();
   }
 
@@ -152,7 +159,9 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
       hql += "and e.deleted = false";
     }
     List<SingleEvent> events =
-        getQuery(hql, SingleEvent.class).setParameter("event", event.getValue()).getResultList();
+        resultList(
+            getQuery(hql, SingleEvent.class).setParameter("event", event.getValue()),
+            "relationship query");
     return events.stream().findFirst();
   }
 
@@ -180,7 +189,9 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
         or (r.invertedKey in (:keys) and r.relationshipType.bidirectional = true))""";
     List<String> relationshipKeysAsString =
         relationshipKeys.stream().map(RelationshipKey::asString).toList();
-    return getQuery(hql, Relationship.class).setParameter("keys", relationshipKeysAsString).list();
+    return resultList(
+        getQuery(hql, Relationship.class).setParameter("keys", relationshipKeysAsString),
+        "relationship query");
   }
 
   public List<RelationshipItem> getRelationshipItemsByTrackedEntity(
@@ -198,9 +209,10 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
     if (!includeDeleted) {
       hql += "and r.deleted = false";
     }
-    return getQuery(hql, RelationshipItem.class)
-        .setParameter("trackedEntity", trackedEntity.getValue())
-        .list();
+    return resultList(
+        getQuery(hql, RelationshipItem.class)
+            .setParameter("trackedEntity", trackedEntity.getValue()),
+        "relationship query");
   }
 
   public List<RelationshipItem> getRelationshipItemsByEnrollment(
@@ -218,9 +230,9 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
     if (!includeDeleted) {
       hql += "and r.deleted = false";
     }
-    return getQuery(hql, RelationshipItem.class)
-        .setParameter("enrollment", enrollment.getValue())
-        .list();
+    return resultList(
+        getQuery(hql, RelationshipItem.class).setParameter("enrollment", enrollment.getValue()),
+        "relationship query");
   }
 
   public List<RelationshipItem> getRelationshipItemsByEvent(UID event, boolean includeDeleted) {
@@ -239,14 +251,17 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
     if (!includeDeleted) {
       hql += "and r.deleted = false";
     }
-    return getQuery(hql, RelationshipItem.class).setParameter("event", event.getValue()).list();
+    return resultList(
+        getQuery(hql, RelationshipItem.class).setParameter("event", event.getValue()),
+        "relationship query");
   }
 
   private List<Relationship> relationshipsList(
       RelationshipQueryParams queryParams, PageParams pageParams) {
     CriteriaQuery<Relationship> criteriaQuery = criteriaQuery(queryParams);
 
-    TypedQuery<Relationship> query = entityManager.createQuery(criteriaQuery);
+    TypedQuery<Relationship> query =
+        withDeadline(entityManager.createQuery(criteriaQuery), "relationship query");
 
     if (pageParams != null) {
       query.setFirstResult(pageParams.getOffset());
@@ -255,7 +270,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
               + 1); // get extra relationship to determine if there is a nextPage
     }
 
-    return query.getResultList();
+    return resultList(query, "relationship query");
   }
 
   private long countRelationships(RelationshipQueryParams queryParams) {
@@ -286,7 +301,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
 
       criteriaQuery.where(predicates.toArray(Predicate[]::new));
     }
-    return entityManager.createQuery(criteriaQuery).getSingleResult().longValue();
+    return singleResult(entityManager.createQuery(criteriaQuery), "relationship query");
   }
 
   private CriteriaQuery<Relationship> criteriaQuery(RelationshipQueryParams queryParams) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -109,8 +109,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
     List<TrackedEntity> trackedEntities =
         resultList(
             getQuery(hql, TrackedEntity.class)
-                .setParameter("trackedEntity", trackedEntity.getValue()),
-            "relationship query");
+                .setParameter("trackedEntity", trackedEntity.getValue()));
     return trackedEntities.stream().findFirst();
   }
 
@@ -126,8 +125,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
     }
     List<Enrollment> enrollments =
         resultList(
-            getQuery(hql, Enrollment.class).setParameter("enrollment", enrollment.getValue()),
-            "relationship query");
+            getQuery(hql, Enrollment.class).setParameter("enrollment", enrollment.getValue()));
     return enrollments.stream().findFirst();
   }
 
@@ -142,9 +140,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
       hql += "and e.deleted = false";
     }
     List<TrackerEvent> events =
-        resultList(
-            getQuery(hql, TrackerEvent.class).setParameter("event", event.getValue()),
-            "relationship query");
+        resultList(getQuery(hql, TrackerEvent.class).setParameter("event", event.getValue()));
     return events.stream().findFirst();
   }
 
@@ -159,9 +155,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
       hql += "and e.deleted = false";
     }
     List<SingleEvent> events =
-        resultList(
-            getQuery(hql, SingleEvent.class).setParameter("event", event.getValue()),
-            "relationship query");
+        resultList(getQuery(hql, SingleEvent.class).setParameter("event", event.getValue()));
     return events.stream().findFirst();
   }
 
@@ -190,8 +184,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
     List<String> relationshipKeysAsString =
         relationshipKeys.stream().map(RelationshipKey::asString).toList();
     return resultList(
-        getQuery(hql, Relationship.class).setParameter("keys", relationshipKeysAsString),
-        "relationship query");
+        getQuery(hql, Relationship.class).setParameter("keys", relationshipKeysAsString));
   }
 
   public List<RelationshipItem> getRelationshipItemsByTrackedEntity(
@@ -211,8 +204,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
     }
     return resultList(
         getQuery(hql, RelationshipItem.class)
-            .setParameter("trackedEntity", trackedEntity.getValue()),
-        "relationship query");
+            .setParameter("trackedEntity", trackedEntity.getValue()));
   }
 
   public List<RelationshipItem> getRelationshipItemsByEnrollment(
@@ -231,8 +223,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
       hql += "and r.deleted = false";
     }
     return resultList(
-        getQuery(hql, RelationshipItem.class).setParameter("enrollment", enrollment.getValue()),
-        "relationship query");
+        getQuery(hql, RelationshipItem.class).setParameter("enrollment", enrollment.getValue()));
   }
 
   public List<RelationshipItem> getRelationshipItemsByEvent(UID event, boolean includeDeleted) {
@@ -252,16 +243,14 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
       hql += "and r.deleted = false";
     }
     return resultList(
-        getQuery(hql, RelationshipItem.class).setParameter("event", event.getValue()),
-        "relationship query");
+        getQuery(hql, RelationshipItem.class).setParameter("event", event.getValue()));
   }
 
   private List<Relationship> relationshipsList(
       RelationshipQueryParams queryParams, PageParams pageParams) {
     CriteriaQuery<Relationship> criteriaQuery = criteriaQuery(queryParams);
 
-    TypedQuery<Relationship> query =
-        withDeadline(entityManager.createQuery(criteriaQuery), "relationship query");
+    TypedQuery<Relationship> query = withDeadline(entityManager.createQuery(criteriaQuery));
 
     if (pageParams != null) {
       query.setFirstResult(pageParams.getOffset());
@@ -270,7 +259,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
               + 1); // get extra relationship to determine if there is a nextPage
     }
 
-    return resultList(query, "relationship query");
+    return resultList(query);
   }
 
   private long countRelationships(RelationshipQueryParams queryParams) {
@@ -301,7 +290,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
 
       criteriaQuery.where(predicates.toArray(Predicate[]::new));
     }
-    return singleResult(entityManager.createQuery(criteriaQuery), "relationship query");
+    return singleResult(entityManager.createQuery(criteriaQuery));
   }
 
   private CriteriaQuery<Relationship> criteriaQuery(RelationshipQueryParams queryParams) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/singleevent/JdbcSingleEventStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/singleevent/JdbcSingleEventStore.java
@@ -83,11 +83,13 @@ import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.OrderJdbcClause;
 import org.hisp.dhis.tracker.export.OrgUnitQueryBuilder;
 import org.hisp.dhis.tracker.export.UserInfoSnapshots;
+import org.hisp.dhis.tracker.export.timeout.TrackerExportTimeoutConfig;
 import org.hisp.dhis.tracker.model.SingleEvent;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -149,7 +151,16 @@ class JdbcSingleEventStore {
   private static final ObjectReader eventDataValueJsonReader =
       JsonBinaryType.MAPPER.readerFor(new TypeReference<Map<String, EventDataValue>>() {});
 
+  /** Export reads. Enforces the tracker export deadline. */
+  @Qualifier(TrackerExportTimeoutConfig.TRACKER_EXPORT_JDBC_TEMPLATE)
   private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  /**
+   * The sync timestamp write. Kept on the primary template: it is a write, called by the data sync
+   * job rather than by any export endpoint, so it must not be bounded by an export deadline.
+   */
+  @Qualifier("namedParameterJdbcTemplate")
+  private final NamedParameterJdbcTemplate writeJdbcTemplate;
 
   public List<SingleEvent> getEvents(SingleEventQueryParams queryParams) {
     return fetchEvents(queryParams, null);
@@ -373,7 +384,7 @@ class JdbcSingleEventStore {
             .addValue("lastSynchronized", new java.sql.Timestamp(lastSynchronized.getTime()))
             .addValue("uids", eventUids);
 
-    jdbcTemplate.update(sql, parameters);
+    writeJdbcTemplate.update(sql, parameters);
   }
 
   private EventDataValue parseEventDataValue(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/Deadline.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/Deadline.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.timeout;
+
+import java.time.Duration;
+import java.util.function.LongSupplier;
+
+/**
+ * An absolute point in time by which a tracker export request must be done. Absolute rather than a
+ * duration so that passing it along cannot extend it, and based on {@link System#nanoTime()} so an
+ * NTP step cannot move it.
+ */
+public record Deadline(long deadlineNanos, LongSupplier nanoTime) {
+
+  /** A deadline {@code budget} from now. */
+  public static Deadline in(Duration budget) {
+    return in(budget, System::nanoTime);
+  }
+
+  /** Visible for testing. */
+  public static Deadline in(Duration budget, LongSupplier nanoTime) {
+    return new Deadline(nanoTime.getAsLong() + budget.toNanos(), nanoTime);
+  }
+
+  /** Negative once the deadline has passed. */
+  public Duration remaining() {
+    return Duration.ofNanos(deadlineNanos - nanoTime.getAsLong());
+  }
+
+  public boolean isExpired() {
+    return remaining().toNanos() <= 0;
+  }
+
+  /**
+   * The remaining budget for {@link java.sql.Statement#setQueryTimeout(int)}, which takes whole
+   * seconds. Rounded up so a query is never cancelled before the deadline, which is why a response
+   * can take up to a second longer than the budget.
+   *
+   * <p>Floored at 1 because {@code setQueryTimeout(0)} means no timeout at all, so an all but spent
+   * budget would leave the query unbounded rather than tightly bounded.
+   */
+  public int remainingSecondsCeil() {
+    long millis = remaining().toMillis();
+    return (int) Math.max(1, (millis + 999) / 1000);
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/Deadline.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/Deadline.java
@@ -36,8 +36,11 @@ import java.util.function.LongSupplier;
  * An absolute point in time by which a tracker export request must be done. Absolute rather than a
  * duration so that passing it along cannot extend it, and based on {@link System#nanoTime()} so an
  * NTP step cannot move it.
+ *
+ * @param budget what the deadline was created with, kept only so an error can name the limit the
+ *     request ran into
  */
-public record Deadline(long deadlineNanos, LongSupplier nanoTime) {
+public record Deadline(Duration budget, long deadlineNanos, LongSupplier nanoTime) {
 
   /** A deadline {@code budget} from now. */
   public static Deadline in(Duration budget) {
@@ -46,7 +49,7 @@ public record Deadline(long deadlineNanos, LongSupplier nanoTime) {
 
   /** Visible for testing. */
   public static Deadline in(Duration budget, LongSupplier nanoTime) {
-    return new Deadline(nanoTime.getAsLong() + budget.toNanos(), nanoTime);
+    return new Deadline(budget, nanoTime.getAsLong() + budget.toNanos(), nanoTime);
   }
 
   /** Negative once the deadline has passed. */

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineAwareJdbcTemplate.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineAwareJdbcTemplate.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.timeout;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * A {@link JdbcTemplate} that bounds every statement it issues by the remaining budget of the
+ * tracker export request on the current thread. Only tracker export reads go through it, which is
+ * what keeps the timeout off every other product.
+ *
+ * <p>Spring's own {@code DataSourceUtils.applyTimeout} cannot be reused: it reads a thread-bound
+ * {@code ConnectionHolder} that the parallel branches of {@code TrackedEntityAggregate} never see,
+ * and its fallback is a fixed timeout rather than a shrinking budget.
+ */
+public class DeadlineAwareJdbcTemplate extends JdbcTemplate {
+
+  public DeadlineAwareJdbcTemplate(DataSource dataSource) {
+    super(dataSource);
+  }
+
+  @Override
+  protected void applyStatementSettings(Statement stmt) throws SQLException {
+    // super sets fetch size, max rows, and a query timeout of its own via DataSourceUtils: from a
+    // @Transactional(timeout=N) on this thread, or from setQueryTimeout on this bean. Neither
+    // applies today, but calling super first means that if one ever does, it cannot replace our
+    // shrinking budget with a fixed value.
+    super.applyStatementSettings(stmt);
+
+    Deadline deadline = DeadlineHolder.get();
+    if (deadline == null) {
+      return; // feature off, or a background job rather than a request
+    }
+
+    // fail fast rather than arming a 1s timeout per remaining statement only to fail anyway
+    DeadlineHolder.checkNotExpired("issuing a query");
+
+    stmt.setQueryTimeout(deadline.remainingSecondsCeil());
+  }
+
+  /**
+   * Turns a query cancelled by our own {@code setQueryTimeout} into a {@link
+   * DeadlineExceededException} so it reaches the client as 504 rather than a generic 500. pgjdbc
+   * cancels the statement, which PostgreSQL reports as SQLSTATE 57014 and Spring translates to
+   * {@link QueryTimeoutException}.
+   *
+   * <p>Only translated when this thread had a deadline, so a cancel from any other source keeps its
+   * usual translation.
+   */
+  @Override
+  protected DataAccessException translateException(String task, String sql, SQLException ex) {
+    DataAccessException translated = super.translateException(task, sql, ex);
+    if (translated instanceof QueryTimeoutException && DeadlineHolder.get() != null) {
+      return new DeadlineExceededException(
+          "Tracker export exceeded its time budget and the query was cancelled", ex);
+    }
+    return translated;
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineAwareJdbcTemplate.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineAwareJdbcTemplate.java
@@ -65,7 +65,7 @@ public class DeadlineAwareJdbcTemplate extends JdbcTemplate {
     }
 
     // fail fast rather than arming a 1s timeout per remaining statement only to fail anyway
-    DeadlineHolder.checkNotExpired("issuing a query");
+    DeadlineHolder.checkNotExpired();
 
     stmt.setQueryTimeout(deadline.remainingSecondsCeil());
   }
@@ -82,9 +82,9 @@ public class DeadlineAwareJdbcTemplate extends JdbcTemplate {
   @Override
   protected DataAccessException translateException(String task, String sql, SQLException ex) {
     DataAccessException translated = super.translateException(task, sql, ex);
-    if (translated instanceof QueryTimeoutException && DeadlineHolder.get() != null) {
-      return new DeadlineExceededException(
-          "Tracker export exceeded its time budget and the query was cancelled", ex);
+    Deadline deadline = DeadlineHolder.get();
+    if (translated instanceof QueryTimeoutException && deadline != null) {
+      return new DeadlineExceededException(deadline.budget(), ex);
     }
     return translated;
   }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineExceededException.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineExceededException.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.tracker.export.timeout;
 
+import java.time.Duration;
 import org.springframework.dao.DataAccessException;
 
 /**
@@ -37,14 +38,23 @@ import org.springframework.dao.DataAccessException;
  *
  * <p>Extends {@link DataAccessException} so it can be returned from {@code JdbcTemplate}'s
  * exception translation, which is where a query cancelled by the deadline surfaces.
+ *
+ * <p>The message names the budget and nothing else. The caller knows the request they sent, and
+ * what made it slow is usually something it does not name, such as ordering by a non-indexed
+ * attribute. Nothing is logged either: the access log already records the 504, and the request is
+ * an idempotent GET, so diagnosis is to reproduce it rather than to read anything captured here.
  */
 public class DeadlineExceededException extends DataAccessException {
 
-  public DeadlineExceededException(String message) {
-    super(message);
+  public DeadlineExceededException(Duration budget) {
+    super(message(budget));
   }
 
-  public DeadlineExceededException(String message, Throwable cause) {
-    super(message, cause);
+  public DeadlineExceededException(Duration budget, Throwable cause) {
+    super(message(budget), cause);
+  }
+
+  private static String message(Duration budget) {
+    return "Tracker export exceeded its time budget of %ss".formatted(budget.toSeconds());
   }
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineExceededException.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineExceededException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.timeout;
+
+import org.springframework.dao.DataAccessException;
+
+/**
+ * Thrown when a tracker export request has used up its {@code tracker.export.timeout} budget. Maps
+ * to HTTP 504 Gateway Timeout.
+ *
+ * <p>Extends {@link DataAccessException} so it can be returned from {@code JdbcTemplate}'s
+ * exception translation, which is where a query cancelled by the deadline surfaces.
+ */
+public class DeadlineExceededException extends DataAccessException {
+
+  public DeadlineExceededException(String message) {
+    super(message);
+  }
+
+  public DeadlineExceededException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineHolder.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineHolder.java
@@ -74,10 +74,10 @@ public final class DeadlineHolder {
   /**
    * @throws DeadlineExceededException if this thread's budget is used up
    */
-  public static void checkNotExpired(String what) {
+  public static void checkNotExpired() {
     Deadline deadline = DEADLINE.get();
     if (deadline != null && deadline.isExpired()) {
-      throw new DeadlineExceededException("Tracker export exceeded its time budget before " + what);
+      throw new DeadlineExceededException(deadline.budget());
     }
   }
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineHolder.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineHolder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.timeout;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * Holds the {@link Deadline} of the tracker export request being served on this thread.
+ *
+ * <p>A {@link ThreadLocal} because the enforcement point, {@code
+ * DeadlineAwareJdbcTemplate#applyStatementSettings}, has no parameter to read a deadline from.
+ *
+ * <p>Tomcat reuses worker threads, so {@link #clear()} must run for every request that called
+ * {@link #set}, whatever the outcome.
+ *
+ * <p>An unset deadline means unbounded, so a lost deadline degrades to today's behaviour rather
+ * than to wrongly cancelled queries. That is also why the background sync job, which shares the
+ * export read path but runs on no HTTP request, is unaffected.
+ */
+public final class DeadlineHolder {
+
+  private static final ThreadLocal<Deadline> DEADLINE = new ThreadLocal<>();
+
+  private DeadlineHolder() {
+    throw new UnsupportedOperationException("utility class");
+  }
+
+  /** Null if this thread's request is unbounded. */
+  @CheckForNull
+  public static Deadline get() {
+    return DEADLINE.get();
+  }
+
+  /** Pass null to leave the request unbounded. */
+  public static void set(@CheckForNull Deadline deadline) {
+    if (deadline == null) {
+      DEADLINE.remove();
+    } else {
+      DEADLINE.set(deadline);
+    }
+  }
+
+  public static void clear() {
+    DEADLINE.remove();
+  }
+
+  /**
+   * @throws DeadlineExceededException if this thread's budget is used up
+   */
+  public static void checkNotExpired(String what) {
+    Deadline deadline = DEADLINE.get();
+    if (deadline != null && deadline.isExpired()) {
+      throw new DeadlineExceededException("Tracker export exceeded its time budget before " + what);
+    }
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineQueries.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineQueries.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.timeout;
+
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
+import java.util.List;
+import java.util.function.Supplier;
+import org.hibernate.annotations.QueryHints;
+
+/**
+ * Bounds tracker export queries that go through Hibernate by the remaining budget of the request on
+ * the current thread.
+ *
+ * <p>The JDBC export stores get this for free from {@link DeadlineAwareJdbcTemplate}. Hibernate has
+ * no such interception point, so its export stores have to ask per query. A static helper rather
+ * than a base class or an interceptor on {@code HibernateGenericStore}, because that store is
+ * shared by every Hibernate store in DHIS2 and a deadline check there would not be tracker scoped.
+ */
+public final class DeadlineQueries {
+
+  private DeadlineQueries() {
+    throw new UnsupportedOperationException("utility class");
+  }
+
+  /**
+   * Runs {@code query} bounded by the budget left for this request, turning the timeout Hibernate
+   * reports into {@link DeadlineExceededException} so it reaches the client as 504. Without that
+   * translation the JPA {@code QueryTimeoutException} is a {@code PersistenceException}, which the
+   * advice maps to 409.
+   *
+   * @param what names the query in the error, for example {@code "relationship query"}
+   * @throws DeadlineExceededException if the budget is already used up, so we fail fast rather than
+   *     issue a query that cannot finish in time
+   */
+  public static <T> List<T> resultList(Query query, String what) {
+    return bounded(withDeadline(query, what)::getResultList, what);
+  }
+
+  /** {@link #resultList} for a query returning a single row, such as a count. */
+  public static <T> T singleResult(TypedQuery<T> query, String what) {
+    return bounded(withDeadline(query, what)::getSingleResult, what);
+  }
+
+  /**
+   * Arms {@code query} with the budget left for this request without running it. Prefer {@link
+   * #resultList} or {@link #singleResult}, which arm and run in one call. This is only for a query
+   * that needs more configuration after it is created, such as paging.
+   */
+  public static <Q extends Query> Q withDeadline(Q query, String what) {
+    Deadline deadline = DeadlineHolder.get();
+    if (deadline == null) {
+      return query;
+    }
+    DeadlineHolder.checkNotExpired("issuing " + what);
+    // this hint is in milliseconds
+    query.setHint(QueryHints.TIMEOUT_JAKARTA_JPA, (int) deadline.remaining().toMillis());
+    return query;
+  }
+
+  private static <T> T bounded(Supplier<T> execute, String what) {
+    try {
+      return execute.get();
+    } catch (jakarta.persistence.QueryTimeoutException | org.hibernate.QueryTimeoutException e) {
+      throw new DeadlineExceededException(
+          "Tracker export exceeded its time budget and the %s was cancelled".formatted(what), e);
+    }
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineQueries.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineQueries.java
@@ -56,17 +56,16 @@ public final class DeadlineQueries {
    * translation the JPA {@code QueryTimeoutException} is a {@code PersistenceException}, which the
    * advice maps to 409.
    *
-   * @param what names the query in the error, for example {@code "relationship query"}
    * @throws DeadlineExceededException if the budget is already used up, so we fail fast rather than
    *     issue a query that cannot finish in time
    */
-  public static <T> List<T> resultList(Query query, String what) {
-    return bounded(withDeadline(query, what)::getResultList, what);
+  public static <T> List<T> resultList(Query query) {
+    return bounded(withDeadline(query)::getResultList);
   }
 
   /** {@link #resultList} for a query returning a single row, such as a count. */
-  public static <T> T singleResult(TypedQuery<T> query, String what) {
-    return bounded(withDeadline(query, what)::getSingleResult, what);
+  public static <T> T singleResult(TypedQuery<T> query) {
+    return bounded(withDeadline(query)::getSingleResult);
   }
 
   /**
@@ -74,23 +73,27 @@ public final class DeadlineQueries {
    * #resultList} or {@link #singleResult}, which arm and run in one call. This is only for a query
    * that needs more configuration after it is created, such as paging.
    */
-  public static <Q extends Query> Q withDeadline(Q query, String what) {
+  public static <Q extends Query> Q withDeadline(Q query) {
     Deadline deadline = DeadlineHolder.get();
     if (deadline == null) {
       return query;
     }
-    DeadlineHolder.checkNotExpired("issuing " + what);
+    DeadlineHolder.checkNotExpired();
     // this hint is in milliseconds
     query.setHint(QueryHints.TIMEOUT_JAKARTA_JPA, (int) deadline.remaining().toMillis());
     return query;
   }
 
-  private static <T> T bounded(Supplier<T> execute, String what) {
+  private static <T> T bounded(Supplier<T> execute) {
     try {
       return execute.get();
     } catch (jakarta.persistence.QueryTimeoutException | org.hibernate.QueryTimeoutException e) {
-      throw new DeadlineExceededException(
-          "Tracker export exceeded its time budget and the %s was cancelled".formatted(what), e);
+      Deadline deadline = DeadlineHolder.get();
+      if (deadline == null) {
+        // a timeout from some other source, not ours to translate
+        throw e;
+      }
+      throw new DeadlineExceededException(deadline.budget(), e);
     }
   }
 }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineQueries.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/DeadlineQueries.java
@@ -33,7 +33,6 @@ import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 import java.util.List;
 import java.util.function.Supplier;
-import org.hibernate.annotations.QueryHints;
 
 /**
  * Bounds tracker export queries that go through Hibernate by the remaining budget of the request on
@@ -79,8 +78,11 @@ public final class DeadlineQueries {
       return query;
     }
     DeadlineHolder.checkNotExpired();
-    // this hint is in milliseconds
-    query.setHint(QueryHints.TIMEOUT_JAKARTA_JPA, (int) deadline.remaining().toMillis());
+    // Not the jakarta.persistence.query.timeout hint: it takes milliseconds and Hibernate converts
+    // them with Math.round, so a remainder below 500ms becomes 0, which means no timeout at all.
+    // setTimeout takes the seconds we computed. It needs the unwrap, which is honest about being
+    // Hibernate specific rather than relying on a hint another provider would silently ignore.
+    query.unwrap(org.hibernate.query.Query.class).setTimeout(deadline.remainingSecondsCeil());
     return query;
   }
 

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/TrackerExportTimeout.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/TrackerExportTimeout.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.timeout;
+
+import java.time.Duration;
+import javax.annotation.CheckForNull;
+
+/**
+ * The configured tracker export budget, resolved once at startup.
+ *
+ * @param budget how long an export request may spend querying, or null if the timeout is disabled
+ */
+public record TrackerExportTimeout(@CheckForNull Duration budget) {
+
+  /** Null if the timeout is disabled. */
+  @CheckForNull
+  public Deadline newDeadline() {
+    return budget == null ? null : Deadline.in(budget);
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/TrackerExportTimeoutConfig.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/timeout/TrackerExportTimeoutConfig.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.timeout;
+
+import java.time.Duration;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/**
+ * Wires the tracker export query timeout.
+ *
+ * <p>The template is a separate bean, not a setting on the shared {@code @Primary} or {@code
+ * readOnlyJdbcTemplate} beans, so the timeout cannot reach any other product.
+ */
+@Slf4j
+@Configuration
+public class TrackerExportTimeoutConfig {
+
+  /** Name of the bean the tracker export stores inject. */
+  public static final String TRACKER_EXPORT_JDBC_TEMPLATE = "trackerExportJdbcTemplate";
+
+  /**
+   * The only {@link JdbcTemplate} in DHIS2 that enforces the tracker export deadline. Exposed as a
+   * {@link NamedParameterJdbcTemplate} because that is what the export stores use; it delegates to
+   * the {@link DeadlineAwareJdbcTemplate} it wraps.
+   */
+  @Bean(TRACKER_EXPORT_JDBC_TEMPLATE)
+  public NamedParameterJdbcTemplate trackerExportJdbcTemplate(DataSource dataSource) {
+    JdbcTemplate jdbcTemplate = new DeadlineAwareJdbcTemplate(dataSource);
+    jdbcTemplate.setFetchSize(1000);
+    return new NamedParameterJdbcTemplate(jdbcTemplate);
+  }
+
+  /**
+   * The configured export budget, or null when {@code 0} turned the timeout off.
+   *
+   * @throws IllegalStateException if the value is not a whole number of seconds, or is negative.
+   *     Failing startup beats disabling the timeout on a typo, which would leave exports unbounded
+   *     for a deployment that asked for the opposite.
+   */
+  @Bean
+  public TrackerExportTimeout trackerExportTimeout(DhisConfigurationProvider config) {
+    String key = ConfigurationKey.TRACKER_EXPORT_TIMEOUT.getKey();
+    String value = config.getProperty(ConfigurationKey.TRACKER_EXPORT_TIMEOUT);
+
+    long seconds;
+    try {
+      seconds = Long.parseLong(value.trim());
+    } catch (NumberFormatException e) {
+      throw new IllegalStateException(
+          "Invalid %s='%s', expected a whole number of seconds".formatted(key, value), e);
+    }
+    if (seconds < 0) {
+      throw new IllegalStateException(
+          "Invalid %s='%s', expected a positive number of seconds or 0 to disable"
+              .formatted(key, value));
+    }
+
+    if (seconds == 0) {
+      log.warn("Tracker export timeout is disabled ({}=0), exports will run unbounded", key);
+      return new TrackerExportTimeout(null);
+    }
+    return new TrackerExportTimeout(Duration.ofSeconds(seconds));
+  }
+}

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityChangeLogStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityChangeLogStore.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.tracker.export.trackedentity;
 
 import static java.util.Map.entry;
+import static org.hisp.dhis.tracker.export.timeout.DeadlineQueries.resultList;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
@@ -178,7 +179,7 @@ public class HibernateTrackedEntityChangeLogStore {
       query.setParameter("filterValue", filter.getValue().getFilter());
     }
 
-    List<Object[]> results = query.getResultList();
+    List<Object[]> results = resultList(query, "tracked entity change log query");
     List<TrackedEntityChangeLog> trackedEntityChangeLogs =
         results.stream()
             .map(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityChangeLogStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityChangeLogStore.java
@@ -179,7 +179,7 @@ public class HibernateTrackedEntityChangeLogStore {
       query.setParameter("filterValue", filter.getValue().getFilter());
     }
 
-    List<Object[]> results = resultList(query, "tracked entity change log query");
+    List<Object[]> results = resultList(query);
     List<TrackedEntityChangeLog> trackedEntityChangeLogs =
         results.stream()
             .map(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/JdbcTrackedEntityStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/JdbcTrackedEntityStore.java
@@ -55,8 +55,10 @@ import org.hisp.dhis.tracker.Page;
 import org.hisp.dhis.tracker.PageParams;
 import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.OrderJdbcClause;
+import org.hisp.dhis.tracker.export.timeout.TrackerExportTimeoutConfig;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.util.DateUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.SqlParameterValue;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -102,7 +104,16 @@ class JdbcTrackedEntityStore {
 
   private final SystemSettingsProvider settingsProvider;
 
+  /** Export reads. Enforces the tracker export deadline. */
+  @Qualifier(TrackerExportTimeoutConfig.TRACKER_EXPORT_JDBC_TEMPLATE)
   private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+  /**
+   * The sync timestamp write. Kept on the primary template: it is a write, called by the data sync
+   * job rather than by any export endpoint, so it must not be bounded by an export deadline.
+   */
+  @Qualifier("namedParameterJdbcTemplate")
+  private final NamedParameterJdbcTemplate writeJdbcTemplate;
 
   public List<TrackedEntityIdentifiers> getTrackedEntityIds(TrackedEntityQueryParams params) {
     // A te which is not enrolled can only be accessed by a user that is able to enroll it into a
@@ -180,7 +191,7 @@ class JdbcTrackedEntityStore {
             .addValue("lastSynchronized", new java.sql.Timestamp(lastSynchronized.getTime()))
             .addValue("uids", trackedEntities.stream().map(UID::toString).toList());
 
-    namedParameterJdbcTemplate.update(sql, parameters);
+    writeJdbcTemplate.update(sql, parameters);
   }
 
   public Long getTrackedEntityCount(TrackedEntityQueryParams params) {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityAggregate.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityAggregate.java
@@ -160,19 +160,21 @@ public class TrackedEntityAggregate {
       Deadline deadline) {
     return condition
         ? supplyAsync(withRequestContext(mdc, deadline, supplier), executor)
-        : supplyAsync(ArrayListMultimap::create, executor);
+        : supplyAsync(withRequestContext(mdc, deadline, ArrayListMultimap::create), executor);
   }
 
   /**
-   * Sets the calling request's MDC context and export deadline on the pooled thread. Both are
-   * restored afterwards, which in practice means cleared: the pool is cached and its threads
-   * outlive the request, so a deadline left behind would bound whatever runs there next.
+   * Sets the calling request's MDC context and export deadline on the pooled thread, clearing the
+   * deadline when the task is done.
+   *
+   * <p>Cleared, not restored to what the thread held before: the pool is private to this class and
+   * every task sets its own deadline, so restoring would only hand the next request the expired
+   * deadline of the previous one and fail it with a 504 it never earned.
    */
-  private static <T> Supplier<T> withRequestContext(
+  static <T> Supplier<T> withRequestContext(
       Map<String, String> mdc, Deadline deadline, Supplier<T> supplier) {
     return () -> {
       Map<String, String> previousMdc = MDC.getCopyOfContextMap();
-      Deadline previousDeadline = DeadlineHolder.get();
       if (mdc != null) {
         MDC.setContextMap(mdc);
       }
@@ -180,7 +182,7 @@ public class TrackedEntityAggregate {
       try {
         return supplier.get();
       } finally {
-        DeadlineHolder.set(previousDeadline);
+        DeadlineHolder.clear();
         if (previousMdc != null) {
           MDC.setContextMap(previousMdc);
         } else {

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityAggregate.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityAggregate.java
@@ -46,6 +46,8 @@ import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.tracker.export.timeout.Deadline;
+import org.hisp.dhis.tracker.export.timeout.DeadlineHolder;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityFields;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityIdentifiers;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityQueryParams;
@@ -88,27 +90,39 @@ public class TrackedEntityAggregate {
             : null;
 
     List<Long> ids = identifiers.stream().map(TrackedEntityIdentifiers::id).toList();
+
+    // do not start four parallel fetches if the id query already spent the budget
+    DeadlineHolder.checkNotExpired("fetching tracked entities");
+
     Map<String, String> mdc = MDC.getCopyOfContextMap();
+    // carried onto each pooled thread like MDC already is. All four close over this one deadline,
+    // so they share the remaining budget rather than each getting a fresh one.
+    Deadline deadline = DeadlineHolder.get();
     final CompletableFuture<Multimap<String, Enrollment>> enrollmentsAsync =
         conditionalAsyncFetch(
             fields.isIncludesEnrollments(),
             () -> enrollmentAggregate.findByTrackedEntityIds(identifiers, ctx),
             getPool(),
-            mdc);
+            mdc,
+            deadline);
     final CompletableFuture<Multimap<String, TrackedEntityProgramOwner>> programOwnersAsync =
         conditionalAsyncFetch(
             fields.isIncludesProgramOwners(),
             () -> trackedEntityStore.getProgramOwners(ids),
             getPool(),
-            mdc);
+            mdc,
+            deadline);
     final CompletableFuture<Map<String, TrackedEntity>> trackedEntitiesAsync =
-        supplyAsync(withMdc(mdc, () -> trackedEntityStore.getTrackedEntities(ids)), getPool());
+        supplyAsync(
+            withRequestContext(mdc, deadline, () -> trackedEntityStore.getTrackedEntities(ids)),
+            getPool());
     final CompletableFuture<Multimap<String, TrackedEntityAttributeValue>> attributesAsync =
         conditionalAsyncFetch(
             fields.isIncludesAttributes(),
             () -> trackedEntityStore.getAttributes(ids, programId),
             getPool(),
-            mdc);
+            mdc,
+            deadline);
 
     try {
       allOf(trackedEntitiesAsync, attributesAsync, enrollmentsAsync, programOwnersAsync).join();
@@ -142,24 +156,33 @@ public class TrackedEntityAggregate {
       boolean condition,
       Supplier<Multimap<String, T>> supplier,
       Executor executor,
-      Map<String, String> mdc) {
+      Map<String, String> mdc,
+      Deadline deadline) {
     return condition
-        ? supplyAsync(withMdc(mdc, supplier), executor)
+        ? supplyAsync(withRequestContext(mdc, deadline, supplier), executor)
         : supplyAsync(ArrayListMultimap::create, executor);
   }
 
-  /** Wraps a supplier so that the given MDC context is set on the async thread. */
-  private static <T> Supplier<T> withMdc(Map<String, String> mdc, Supplier<T> supplier) {
+  /**
+   * Sets the calling request's MDC context and export deadline on the pooled thread. Both are
+   * restored afterwards, which in practice means cleared: the pool is cached and its threads
+   * outlive the request, so a deadline left behind would bound whatever runs there next.
+   */
+  private static <T> Supplier<T> withRequestContext(
+      Map<String, String> mdc, Deadline deadline, Supplier<T> supplier) {
     return () -> {
-      Map<String, String> previous = MDC.getCopyOfContextMap();
+      Map<String, String> previousMdc = MDC.getCopyOfContextMap();
+      Deadline previousDeadline = DeadlineHolder.get();
       if (mdc != null) {
         MDC.setContextMap(mdc);
       }
+      DeadlineHolder.set(deadline);
       try {
         return supplier.get();
       } finally {
-        if (previous != null) {
-          MDC.setContextMap(previous);
+        DeadlineHolder.set(previousDeadline);
+        if (previousMdc != null) {
+          MDC.setContextMap(previousMdc);
         } else {
           MDC.clear();
         }

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityAggregate.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityAggregate.java
@@ -92,7 +92,7 @@ public class TrackedEntityAggregate {
     List<Long> ids = identifiers.stream().map(TrackedEntityIdentifiers::id).toList();
 
     // do not start four parallel fetches if the id query already spent the budget
-    DeadlineHolder.checkNotExpired("fetching tracked entities");
+    DeadlineHolder.checkNotExpired();
 
     Map<String, String> mdc = MDC.getCopyOfContextMap();
     // carried onto each pooled thread like MDC already is. All four close over this one deadline,

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityStore.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.CheckForNull;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.attribute.AttributeValues;
 import org.hisp.dhis.common.ValueType;
@@ -46,11 +47,11 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.export.Geometries;
 import org.hisp.dhis.tracker.export.UserInfoSnapshots;
+import org.hisp.dhis.tracker.export.timeout.TrackerExportTimeoutConfig;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.model.TrackedEntityProgramOwner;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -61,6 +62,7 @@ import org.springframework.stereotype.Repository;
  * @author Ameen Mohamed
  */
 @Repository
+@RequiredArgsConstructor
 class TrackedEntityStore {
   // language=SQL
   private static final String GET_TE_SQL =
@@ -121,11 +123,8 @@ class TrackedEntityStore {
       join trackedentity te on teop.trackedentityid = te.trackedentityid
       where teop.trackedentityid in (:ids)""";
 
+  @Qualifier(TrackerExportTimeoutConfig.TRACKER_EXPORT_JDBC_TEMPLATE)
   private final NamedParameterJdbcTemplate jdbcTemplate;
-
-  TrackedEntityStore(@Qualifier("readOnlyJdbcTemplate") JdbcTemplate jdbcTemplate) {
-    this.jdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
-  }
 
   Map<String, TrackedEntity> getTrackedEntities(List<Long> ids) {
     Map<String, TrackedEntity> trackedEntities = new LinkedHashMap<>();

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackerevent/JdbcTrackerEventStore.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackerevent/JdbcTrackerEventStore.java
@@ -84,6 +84,7 @@ import org.hisp.dhis.tracker.export.Geometries;
 import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.OrderJdbcClause;
 import org.hisp.dhis.tracker.export.UserInfoSnapshots;
+import org.hisp.dhis.tracker.export.timeout.TrackerExportTimeoutConfig;
 import org.hisp.dhis.tracker.model.Enrollment;
 import org.hisp.dhis.tracker.model.TrackedEntity;
 import org.hisp.dhis.tracker.model.TrackerEvent;
@@ -91,6 +92,7 @@ import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -160,6 +162,7 @@ class JdbcTrackerEventStore {
   private static final ObjectReader eventDataValueJsonReader =
       JsonBinaryType.MAPPER.readerFor(new TypeReference<Map<String, EventDataValue>>() {});
 
+  @Qualifier(TrackerExportTimeoutConfig.TRACKER_EXPORT_JDBC_TEMPLATE)
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
   public List<TrackerEvent> getEvents(TrackerEventQueryParams queryParams) {

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/export/timeout/DeadlineTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/export/timeout/DeadlineTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class DeadlineTest {
+
+  /** Test clock so the assertions do not depend on how long the test itself takes. */
+  private long nanos = TimeUnit.SECONDS.toNanos(1_000);
+
+  private Deadline deadlineIn(Duration budget) {
+    return Deadline.in(budget, () -> nanos);
+  }
+
+  private void elapse(Duration elapsed) {
+    nanos += elapsed.toNanos();
+  }
+
+  @Test
+  void shouldReportTheFullBudgetAsRemainingBeforeAnyTimePasses() {
+    Deadline deadline = deadlineIn(Duration.ofSeconds(10));
+
+    assertEquals(Duration.ofSeconds(10), deadline.remaining());
+    assertFalse(deadline.isExpired());
+  }
+
+  @Test
+  void shouldShrinkTheRemainingBudgetAsTimePasses() {
+    Deadline deadline = deadlineIn(Duration.ofSeconds(10));
+
+    elapse(Duration.ofSeconds(4));
+
+    assertEquals(Duration.ofSeconds(6), deadline.remaining());
+    assertFalse(deadline.isExpired());
+  }
+
+  @Test
+  void shouldBeExpiredExactlyAtTheDeadline() {
+    Deadline deadline = deadlineIn(Duration.ofSeconds(10));
+
+    elapse(Duration.ofSeconds(10));
+
+    assertEquals(Duration.ZERO, deadline.remaining());
+    assertTrue(deadline.isExpired(), "a budget of exactly zero is used up");
+  }
+
+  @Test
+  void shouldBeExpiredPastTheDeadlineAndReportNegativeRemaining() {
+    Deadline deadline = deadlineIn(Duration.ofSeconds(10));
+
+    elapse(Duration.ofSeconds(11));
+
+    assertEquals(Duration.ofSeconds(-1), deadline.remaining());
+    assertTrue(deadline.isExpired());
+  }
+
+  @Test
+  void shouldRoundTheRemainingSecondsUpSoAQueryIsNeverGivenLessTimeThanItHas() {
+    Deadline deadline = deadlineIn(Duration.ofMillis(2_400));
+
+    assertEquals(3, deadline.remainingSecondsCeil());
+  }
+
+  @Test
+  void shouldNotRoundUpAWholeNumberOfSeconds() {
+    Deadline deadline = deadlineIn(Duration.ofSeconds(3));
+
+    assertEquals(3, deadline.remainingSecondsCeil());
+  }
+
+  @Test
+  void shouldFloorTheRemainingSecondsAtOneForASubSecondBudget() {
+    Deadline deadline = deadlineIn(Duration.ofMillis(200));
+
+    assertEquals(1, deadline.remainingSecondsCeil());
+  }
+
+  @Test
+  void shouldNeverReturnZeroOrNegativeSecondsForAnExpiredBudget() {
+    Deadline deadline = deadlineIn(Duration.ofSeconds(10));
+
+    elapse(Duration.ofSeconds(15));
+
+    assertTrue(deadline.isExpired());
+    assertEquals(
+        1,
+        deadline.remainingSecondsCeil(),
+        "0 would disable the timeout and a negative value would be rejected by the driver");
+  }
+
+  @Test
+  void shouldNotBeAffectedByTheClockMovingBackwards() {
+    // nanoTime is monotonic, so this only documents that the deadline is absolute: it is computed
+    // once and never recomputed from a duration.
+    Deadline deadline = deadlineIn(Duration.ofSeconds(10));
+    long deadlineNanos = deadline.deadlineNanos();
+
+    elapse(Duration.ofSeconds(5));
+
+    assertEquals(deadlineNanos, deadline.deadlineNanos());
+    assertEquals(Duration.ofSeconds(5), deadline.remaining());
+  }
+}

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/WithRequestContextTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/WithRequestContextTest.java
@@ -117,7 +117,7 @@ class WithRequestContextTest {
   }
 
   @Test
-  void shouldClearTheDeadlineEvenWhenTheTaskFails() throws Exception {
+  void shouldClearTheDeadlineEvenWhenTheTaskFails() {
     // a branch whose query times out throws, and its budget is spent by then, so the exception
     // path is exactly where an expired deadline would be left behind
     assertThrows(

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/WithRequestContextTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/WithRequestContextTest.java
@@ -98,7 +98,7 @@ class WithRequestContextTest {
   /** Reads the deadline the way a query does, throwing if the thread holds an expired one. */
   private static Supplier<Void> readDeadline() {
     return () -> {
-      DeadlineHolder.checkNotExpired("fetching tracked entities");
+      DeadlineHolder.checkNotExpired();
       return null;
     };
   }

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/WithRequestContextTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/WithRequestContextTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.trackedentity.aggregates;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.hisp.dhis.tracker.export.timeout.Deadline;
+import org.hisp.dhis.tracker.export.timeout.DeadlineHolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link TrackedEntityAggregate#withRequestContext}, which carries a request's deadline onto
+ * the pooled threads its branches run on.
+ *
+ * <p>The deadline must not outlive the task that set it. The pool is cached, so its threads are
+ * reused across requests, and a deadline left behind is read by whatever lands there next.
+ */
+class WithRequestContextTest {
+
+  /** One thread, so every task after the first runs on a reused thread, as the cached pool does. */
+  private final ExecutorService pool = Executors.newSingleThreadExecutor();
+
+  @AfterEach
+  void tearDown() {
+    pool.shutdownNow();
+    DeadlineHolder.clear();
+  }
+
+  /** Runs a task on the pool the way the aggregate does, and waits for it. */
+  private <T> T runOnPool(Supplier<T> task) throws Exception {
+    return pool.submit(task::get).get(10, TimeUnit.SECONDS);
+  }
+
+  /** Runs {@code task} on the pool wrapped in the deadline, as one aggregate branch does. */
+  private <T> T runWithRequestContext(Deadline deadline, Supplier<T> task) throws Exception {
+    return runOnPool(TrackedEntityAggregate.withRequestContext(Map.of(), deadline, task));
+  }
+
+  /** Runs {@code task} on the pool unwrapped, as anything else sharing the pool would. */
+  private <T> T runWithoutRequestContext(Supplier<T> task) throws Exception {
+    return runOnPool(task);
+  }
+
+  /** A budget that is already used up, as an export's is once it has timed out. */
+  private static Deadline spent() {
+    return Deadline.in(Duration.ZERO);
+  }
+
+  /**
+   * Puts {@code deadline} on the pooled thread and leaves it there, so the thread is in the state a
+   * reused one is in. Without this there is nothing for a later task to inherit and a wrapper that
+   * restores instead of clearing looks correct.
+   */
+  private void threadAlreadyHolds(Deadline deadline) throws Exception {
+    runWithoutRequestContext(
+        () -> {
+          DeadlineHolder.set(deadline);
+          return null;
+        });
+  }
+
+  /** Reads the deadline the way a query does, throwing if the thread holds an expired one. */
+  private static Supplier<Void> readDeadline() {
+    return () -> {
+      DeadlineHolder.checkNotExpired("fetching tracked entities");
+      return null;
+    };
+  }
+
+  @Test
+  void shouldNotLetAnExpiredDeadlineReachTheNextTaskOnTheSameThread() throws Exception {
+    threadAlreadyHolds(spent());
+
+    runWithRequestContext(Deadline.in(Duration.ofSeconds(10)), () -> null);
+
+    // work that sets no deadline of its own, such as the data sync job or the SMS listener, must
+    // stay unbounded rather than fail on a budget that was never its own
+    assertDoesNotThrow(
+        () -> runWithoutRequestContext(readDeadline()),
+        "an unbounded task inherited the expired deadline left by an earlier export");
+  }
+
+  @Test
+  void shouldClearTheDeadlineEvenWhenTheTaskFails() throws Exception {
+    // a branch whose query times out throws, and its budget is spent by then, so the exception
+    // path is exactly where an expired deadline would be left behind
+    assertThrows(
+        Exception.class,
+        () ->
+            runWithRequestContext(
+                spent(),
+                () -> {
+                  throw new IllegalStateException("query cancelled");
+                }));
+
+    assertDoesNotThrow(
+        () -> runWithoutRequestContext(readDeadline()),
+        "a failed task left its deadline behind, so the next task on this thread inherits it");
+  }
+
+  @Test
+  void shouldGiveEachTaskItsOwnDeadlineRatherThanTheOneLeftByThePrevious() throws Exception {
+    threadAlreadyHolds(spent());
+    Deadline mine = Deadline.in(Duration.ofSeconds(30));
+
+    Deadline seen = runWithRequestContext(mine, DeadlineHolder::get);
+
+    assertSame(mine, seen, "the task saw a deadline other than the one it was given");
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -85,6 +85,7 @@ import org.hisp.dhis.system.util.HttpUtils;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.deduplication.PotentialDuplicateConflictException;
 import org.hisp.dhis.tracker.deduplication.PotentialDuplicateForbiddenException;
+import org.hisp.dhis.tracker.export.timeout.DeadlineExceededException;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.controller.exception.MetadataImportConflictException;
 import org.hisp.dhis.webapi.controller.exception.MetadataSyncException;
@@ -280,6 +281,12 @@ public class CrudControllerAdvice {
       }
     }
     return false;
+  }
+
+  @ExceptionHandler(DeadlineExceededException.class)
+  @ResponseBody
+  public WebMessage deadlineExceededExceptionHandler(DeadlineExceededException ex) {
+    return createWebMessage(ex.getMessage(), Status.ERROR, HttpStatus.GATEWAY_TIMEOUT);
   }
 
   @ExceptionHandler(IllegalQueryException.class)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/interceptor/TrackerExportDeadlineInterceptor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/interceptor/TrackerExportDeadlineInterceptor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.mvc.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.tracker.export.timeout.Deadline;
+import org.hisp.dhis.tracker.export.timeout.DeadlineHolder;
+import org.hisp.dhis.tracker.export.timeout.TrackerExportTimeout;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * Gives every tracker export request a {@link Deadline} so its queries are bounded by {@code
+ * tracker.export.timeout}.
+ *
+ * <p>Scoped by {@link #PATH_PATTERNS} and GET so no other product ever gets a deadline. Both are
+ * needed: the paths exclude {@code /api/tracker/ownership} and the import job endpoints, GET
+ * excludes the note POSTs which live in {@code TrackerImportController} under the same prefixes.
+ *
+ * <p>Cleared in {@link #afterCompletion} whatever the outcome, since Tomcat reuses worker threads.
+ */
+@Component
+@RequiredArgsConstructor
+public class TrackerExportDeadlineInterceptor implements HandlerInterceptor {
+
+  /** The six export controllers' request mappings. */
+  public static final List<String> PATH_PATTERNS =
+      List.of(
+          "/api/tracker/trackedEntities/**",
+          "/api/tracker/enrollments/**",
+          "/api/tracker/events/**",
+          "/api/tracker/trackerEvents/**",
+          "/api/tracker/singleEvents/**",
+          "/api/tracker/relationships/**");
+
+  private final TrackerExportTimeout timeout;
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    if (!HttpMethod.GET.matches(request.getMethod())) {
+      return true;
+    }
+
+    // null when the timeout is disabled, which leaves the request unbounded
+    DeadlineHolder.set(timeout.newDeadline());
+    return true;
+  }
+
+  @Override
+  public void afterCompletion(
+      HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+    DeadlineHolder.clear();
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/interceptor/TrackerExportDeadlineInterceptor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/interceptor/TrackerExportDeadlineInterceptor.java
@@ -44,9 +44,14 @@ import org.springframework.web.servlet.HandlerInterceptor;
  * Gives every tracker export request a {@link Deadline} so its queries are bounded by {@code
  * tracker.export.timeout}.
  *
- * <p>Scoped by {@link #PATH_PATTERNS} and GET so no other product ever gets a deadline. Both are
- * needed: the paths exclude {@code /api/tracker/ownership} and the import job endpoints, GET
- * excludes the note POSTs which live in {@code TrackerImportController} under the same prefixes.
+ * <p>Scoped by {@link #PATH_PATTERNS} and to reads so no other product ever gets a deadline. Both
+ * are needed: the paths exclude {@code /api/tracker/ownership} and the import job endpoints, the
+ * methods exclude the note POSTs which live in {@code TrackerImportController} under the same
+ * prefixes.
+ *
+ * <p>HEAD as well as GET. Spring dispatches HEAD to the same {@code @GetMapping} handlers, so it
+ * runs the whole export and only drops the body on the way out, which costs exactly as much as the
+ * GET.
  *
  * <p>Cleared in {@link #afterCompletion} whatever the outcome, since Tomcat reuses worker threads.
  */
@@ -69,7 +74,8 @@ public class TrackerExportDeadlineInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
-    if (!HttpMethod.GET.matches(request.getMethod())) {
+    if (!HttpMethod.GET.matches(request.getMethod())
+        && !HttpMethod.HEAD.matches(request.getMethod())) {
       return true;
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
@@ -51,6 +51,7 @@ import org.hisp.dhis.webapi.mvc.UrlParamsMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.interceptor.AuthorityInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.HandlerMethodInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.SystemSettingsInterceptor;
+import org.hisp.dhis.webapi.mvc.interceptor.TrackerExportDeadlineInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.TrailingSlashInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.UserContextInterceptor;
 import org.hisp.dhis.webapi.mvc.messageconverter.FilteredPageHttpMessageConverter;
@@ -121,6 +122,8 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration {
   @Autowired private SystemSettingsInterceptor settingsInterceptor;
 
   @Autowired private StaticCacheInterceptor staticCacheInterceptor;
+
+  @Autowired private TrackerExportDeadlineInterceptor trackerExportDeadlineInterceptor;
 
   @Autowired private NodeService nodeService;
 
@@ -258,6 +261,10 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration {
     registry
         .addInterceptor(staticCacheInterceptor)
         .addPathPatterns("/dhis-web-*/**", "/icons/**", "/images/**", "/favicon.ico");
+    // Scoped to the tracker export endpoints so no other product's requests get a deadline.
+    registry
+        .addInterceptor(trackerExportDeadlineInterceptor)
+        .addPathPatterns(TrackerExportDeadlineInterceptor.PATH_PATTERNS);
   }
 
   @Override


### PR DESCRIPTION
## Problem

Tracker export endpoints have no upper bound on processing time. Once nobody is waiting for the response, the server keeps going, holding Tomcat workers, PostgreSQL backends and pool connections for a result that will be discarded.

## Fix

A per-request deadline from which each SQL statement derives its **remaining** budget.

`tracker.export.timeout` in `dhis.conf`, in seconds. Default `0`, which disables it, so nothing changes on upgrade and deployments opt in once they know what value suits them.

Set it below any timeout in front of DHIS2. If the proxy times out first it returns its own 504 while the query is never cancelled.

Enforced by overriding `JdbcTemplate.applyStatementSettings` on a tracker-only template: fail fast if the budget is gone, else arm `setQueryTimeout` with the remainder. pgjdbc cancels the statement, which surfaces as SQLSTATE `57014`. The export paths going through Hibernate, relationships and the change logs, get the `jakarta.persistence.query.timeout` hint from the same deadline via `DeadlineQueries` instead.

Either way the client gets a 504:

```console
$ curl -i -u admin:district \
  "http://localhost:8080/api/tracker/trackedEntities?orgUnitMode=ACCESSIBLE&program=ur1Edk5Oe2n&fields=*&pageSize=5000&order=zDhUuAYrxNC:asc"
HTTP/1.1 504
Content-Type: application/json

{
  "httpStatus": "Gateway Timeout",
  "httpStatusCode": 504,
  "status": "ERROR",
  "message": "Tracker export exceeded its time budget of 2s"
}
```

`@Transactional(timeout=N)` cannot be reused: exports are `@IndirectTransactional`, and its `ConnectionHolder` is thread-bound so the parallel branches in `TrackedEntityAggregate` would not see it.

## Not affecting other products

Two independent boundaries keep the deadline off everything else: only the new `trackerExportJdbcTemplate` reads it, never the shared `@Primary` or `readOnlyJdbcTemplate` beans that import and analytics use, and it is only set on the six export path patterns **and** only for GET. Both halves of that are needed, since GET is what excludes `POST /api/tracker/{enrollments,events}/{uid}/note`, which lives in `TrackerImportController` under the same prefixes.

`{entity}` below is one of `trackedEntities`, `enrollments`, `events`, `trackerEvents`, `singleEvents`, `relationships`.

| endpoint | deadline |
|---|---|
| `/api/tracker/{entity}` and `/{uid}`, including the csv, zip and gzip variants | yes |
| `/api/tracker/{entity}/{uid}/changeLogs` | yes |
| `/api/tracker/{entity}/{uid}/**/{file,image}` | on its DB lookup, not on the S3 fetch |
| `/api/tracker/jobs/{uid}` and `/report` | no, import side job polling |
| `/api/tracker/ownership`, `/api/potentialDuplicates` | no, not export and no GET on ownership |
| the two sync-timestamp writes in the export stores | no, called by the data sync job, so they stay on the primary template |

## One datasource for all export reads

`TrackedEntityStore` was the only export store on `readOnlyJdbcTemplate`, so on deployments with read replicas its aggregate queries move to the primary with the other four.

That lone qualifier looks accidental: [06fa4ac576](https://github.com/dhis2/dhis2-core/commit/06fa4ac5762b88a761e16ca4e3a95f87749fc8d4) (DHIS2-7336, 2019) added it to the tracked entity and enrollment stores but not the event store in the same commit, with no reason given. Replica routing has not held up either, [33e2ef2437](https://github.com/dhis2/dhis2-core/commit/33e2ef24377627814d2ee973ef0b64da45f13ff8) was reverted two weeks later by [1902d40a52](https://github.com/dhis2/dhis2-core/commit/1902d40a52863efa3c57fc0bdda16fc508710002), and Hibernate has no routing at all, so relationships always read the primary. Primary for everything avoids one request reading from two databases with no read your writes guarantee.

## Tests

`ExportTimeoutTest` drives the real export API over real Postgres: 504 on timeout, no surviving backend in `pg_stat_activity` (a silently failed `Statement.cancel()` is a documented pgjdbc mode, so asserting only on the Java exception would pass while leaving an orphan), one budget shared across a request's statements, and the Hibernate relationship path.

`SlowQueryDataSourceProxy` makes real export SQL slow without putting `pg_sleep` near production code.

## Out of scope

Client-disconnect detection (the Servlet API gives no proactive notification, only an `IOException` on the next write, after the queries have run, see [spring-framework#33763](https://github.com/spring-projects/spring-framework/issues/33763)) and cancellation during serialization (once bytes are on the wire a 504 is impossible).

The shared metadata reads an export makes along the way, such as `getAllUserReadableTrackedEntityAttributes`. These are cached Hibernate lookups in `dhis-service-core`, not tracker stores, so bounding them means either touching stores other products share or a server-side `statement_timeout`, which is the next step and catches them with no per-store work.

## Follow-ups

* S3 timeouts. The file and image endpoints are bounded on their DB lookup but not on the file fetch that follows.
* Capture and UX. A 504 currently tells the user their request ran out of time but not what to do about it. Clients could turn it into actionable feedback, such as suggesting a narrower `fields`, a smaller `pageSize` or a tighter filter.
