### PR TITLE
fix: Expand sync log info [DHIS2-21606][2.42]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilter.java
@@ -249,25 +249,22 @@ class PersistablesFilter {
 
   private <T extends TrackerDto> Predicate<T> parentConditions(
       List<Function<T, TrackerDto>> parents) {
-    final Predicate<TrackerDto> parentCondition =
-        parent -> isMarked(parent) || this.preheat.exists(parent);
-
     return parents.stream()
         .map(
             p ->
                 (Predicate<T>)
                     t ->
-                        parentCondition.test(
+                        isPersistableParent(
                             p.apply(t))) // children of invalid parents can only be persisted under
         // certain conditions
         .reduce(Predicate::and)
         .orElse(t -> true); // predicate always returning true for entities without parents
   }
 
-  /**
-   * Add error for valid child entity with invalid parent as a reason. If a child is invalid that is
-   * enough information for a user to know why it could not be persisted.
-   */
+  private boolean isPersistableParent(TrackerDto parent) {
+    return isMarked(parent) || this.preheat.exists(parent);
+  }
+
   private <T extends TrackerDto> void addErrorsForChildren(
       List<Function<T, TrackerDto>> parents, T entity) {
     if (isNotValid(entity)) {
@@ -277,7 +274,7 @@ class PersistablesFilter {
     List<Error> errors =
         parents.stream()
             .map(p -> p.apply(entity))
-            .filter(this::isNotValid) // remove valid parents
+            .filter(p -> !isPersistableParent(p))
             .map(p -> error(ValidationCode.E5000, entity, p))
             .toList();
     this.result.errors.addAll(errors);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilterTest.java
@@ -223,6 +223,31 @@ class PersistablesFilterTest {
   }
 
   @Test
+  void testCreateAndUpdateValidEventOfValidEnrollmentWithInvalidTrackedEntityCannotBeCreated() {
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .isNotValid()
+            .enrollment("t1zaUjKgT3p")
+            .event("Qck4PQ7TMun")
+            .build();
+
+    PersistablesFilter.Result persistable =
+        filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
+
+    assertAll(
+        () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+        () -> assertIsEmpty(persistable.get(Enrollment.class)),
+        () -> assertIsEmpty(persistable.get(Event.class)),
+        () ->
+            assertHasError(
+                persistable, ENROLLMENT, "t1zaUjKgT3p", E5000, "trackedEntity `xK7H53f4Hc2`"),
+        () ->
+            assertHasError(
+                persistable, EVENT, "Qck4PQ7TMun", E5000, "because enrollment `t1zaUjKgT3p`"));
+  }
+
+  @Test
   void testCreateAndUpdateInvalidEventOfValidEnrollmentCannotBePersisted() {
     Setup setup =
         new Setup.Builder()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/SingleEventDataSynchronizationService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/SingleEventDataSynchronizationService.java
@@ -34,7 +34,9 @@ import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM;
 import static org.hisp.dhis.tracker.imports.TrackerImportStrategy.CREATE_AND_UPDATE;
 import static org.hisp.dhis.tracker.imports.TrackerImportStrategy.DELETE;
 import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.alreadyDeletedOrSucceededUids;
+import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.blockingFailedItems;
 import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.blockingFailedUids;
+import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.failedItems;
 import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.failedUids;
 import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.formatFailedUids;
 import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.sendTrackerRequest;
@@ -426,17 +428,16 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
             .filter(event -> syncedEventUids.contains(event.getEvent()))
             .toList();
 
-    Set<UID> failedEventUids = blockingFailedUids(report, TrackerType.EVENT);
     Set<UID> failedRelationshipUids = blockingFailedUids(report, TrackerType.RELATIONSHIP);
 
     log.info(
         "Single Event delete sync: events={}/{} synced{}, relationships={}/{} synced{}",
         syncedEvents.size(),
         deletedEventDtos.size(),
-        formatFailedUids(failedEventUids),
+        formatFailedUids(blockingFailedItems(report, TrackerType.EVENT)),
         syncedRelationshipUids.size(),
         deletedRelationships.size(),
-        formatFailedUids(failedRelationshipUids));
+        formatFailedUids(blockingFailedItems(report, TrackerType.RELATIONSHIP)));
 
     return new DeleteSyncResult(syncedEventUids, failedRelationshipUids);
   }
@@ -461,15 +462,15 @@ public class SingleEventDataSynchronizationService extends TrackerDataSynchroniz
         events.stream().filter(event -> syncedEventUids.contains(event.getEvent())).toList();
 
     Set<UID> relationshipUids = getAllRelationshipUids(events);
-    Set<UID> failedRelationshipUids = failedUids(report, TrackerType.RELATIONSHIP);
 
     log.info(
-        "Single Event create/update sync: events={}/{} synced, relationships={}/{} synced{}",
+        "Single Event create/update sync: events={}/{} synced{}, relationships={}/{} synced{}",
         syncedEvents.size(),
         events.size(),
+        formatFailedUids(failedItems(report, TrackerType.EVENT)),
         successfullyProcessedUids(report, TrackerType.RELATIONSHIP).size(),
         relationshipUids.size(),
-        formatFailedUids(failedRelationshipUids));
+        formatFailedUids(failedItems(report, TrackerType.RELATIONSHIP)));
 
     return syncedEventUids;
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerDataSynchronizationService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerDataSynchronizationService.java
@@ -34,7 +34,9 @@ import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM;
 import static org.hisp.dhis.tracker.imports.TrackerImportStrategy.CREATE_AND_UPDATE;
 import static org.hisp.dhis.tracker.imports.TrackerImportStrategy.DELETE;
 import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.alreadyDeletedOrSucceededUids;
+import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.blockingFailedItems;
 import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.blockingFailedUids;
+import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.failedItems;
 import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.failedUids;
 import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.formatFailedUids;
 import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.sendTrackerRequest;
@@ -560,7 +562,6 @@ public class TrackerDataSynchronizationService extends TrackerDataSynchronizatio
             .filter(te -> syncedTeUids.contains(te.getTrackedEntity()))
             .toList();
 
-    Set<UID> failedTeUids = blockingFailedUids(report, TrackerType.TRACKED_ENTITY);
     Set<UID> failedEnrollmentUids = blockingFailedUids(report, TrackerType.ENROLLMENT);
     Set<UID> failedEventUids = blockingFailedUids(report, TrackerType.EVENT);
     Set<UID> failedRelationshipUids = blockingFailedUids(report, TrackerType.RELATIONSHIP);
@@ -574,16 +575,16 @@ public class TrackerDataSynchronizationService extends TrackerDataSynchronizatio
             + " events={}/{} synced{}, relationships={}/{} synced{}",
         syncedTes.size(),
         deletedTrackedEntities.size(),
-        formatFailedUids(failedTeUids),
+        formatFailedUids(blockingFailedItems(report, TrackerType.TRACKED_ENTITY)),
         syncedEnrollmentUids.size(),
         deletedEnrollments.size(),
-        formatFailedUids(failedEnrollmentUids),
+        formatFailedUids(blockingFailedItems(report, TrackerType.ENROLLMENT)),
         syncedEventUids.size(),
         deletedEvents.size(),
-        formatFailedUids(failedEventUids),
+        formatFailedUids(blockingFailedItems(report, TrackerType.EVENT)),
         syncedRelationshipUids.size(),
         deletedRelationships.size(),
-        formatFailedUids(failedRelationshipUids));
+        formatFailedUids(blockingFailedItems(report, TrackerType.RELATIONSHIP)));
 
     return new DeleteSyncResult(syncedTeUids, blockingFailedChildUids);
   }
@@ -618,24 +619,22 @@ public class TrackerDataSynchronizationService extends TrackerDataSynchronizatio
         trackedEntities.stream().flatMap(te -> te.getEnrollments().stream()).toList();
     List<Event> events = enrollments.stream().flatMap(e -> e.getEvents().stream()).toList();
     Set<UID> relationshipUids = getAllRelationshipUids(trackedEntities);
-    Set<UID> failedEnrollmentUids = failedUids(report, TrackerType.ENROLLMENT);
-    Set<UID> failedEventUids = failedUids(report, TrackerType.EVENT);
-    Set<UID> failedRelationshipUids = failedUids(report, TrackerType.RELATIONSHIP);
 
     log.info(
-        "Tracker create/update sync: TEs={}/{} synced, enrollments={}/{} synced{},"
+        "Tracker create/update sync: TEs={}/{} synced{}, enrollments={}/{} synced{},"
             + " events={}/{} synced{}, relationships={}/{} synced{}",
         syncedTes.size(),
         trackedEntities.size(),
+        formatFailedUids(failedItems(report, TrackerType.TRACKED_ENTITY)),
         successfullyProcessedUids(report, TrackerType.ENROLLMENT).size(),
         enrollments.size(),
-        formatFailedUids(failedEnrollmentUids),
+        formatFailedUids(failedItems(report, TrackerType.ENROLLMENT)),
         successfullyProcessedUids(report, TrackerType.EVENT).size(),
         events.size(),
-        formatFailedUids(failedEventUids),
+        formatFailedUids(failedItems(report, TrackerType.EVENT)),
         successfullyProcessedUids(report, TrackerType.RELATIONSHIP).size(),
         relationshipUids.size(),
-        formatFailedUids(failedRelationshipUids));
+        formatFailedUids(failedItems(report, TrackerType.RELATIONSHIP)));
 
     return syncedTeUids;
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerSyncReportUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerSyncReportUtils.java
@@ -37,7 +37,12 @@ import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1114;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E4017;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -111,8 +116,105 @@ final class TrackerSyncReportUtils {
     };
   }
 
-  static String formatFailedUids(Set<UID> failedUids) {
-    return failedUids.isEmpty() ? "" : format(" (failed: %s)", failedUids);
+  record FailedItem(UID uid, String errorCode) {}
+
+  private static final int MAX_UIDS_PER_REASON = 5;
+
+  /** Formats failures grouped by error code, so a large batch of failures stays readable */
+  static String formatFailedUids(List<FailedItem> failed) {
+    if (failed.isEmpty()) {
+      return "";
+    }
+
+    Map<String, List<UID>> uidsByErrorCode =
+        failed.stream()
+            .collect(
+                Collectors.groupingBy(
+                    FailedItem::errorCode,
+                    LinkedHashMap::new,
+                    Collectors.collectingAndThen(
+                        Collectors.mapping(
+                            FailedItem::uid, Collectors.toCollection(LinkedHashSet::new)),
+                        ArrayList::new)));
+
+    String reasons =
+        uidsByErrorCode.entrySet().stream()
+            .sorted(
+                Comparator.<Map.Entry<String, List<UID>>>comparingInt(e -> e.getValue().size())
+                    .reversed())
+            .map(e -> formatReasonGroup(e.getKey(), e.getValue()))
+            .collect(Collectors.joining(", "));
+
+    return format(" (failed: %s)", reasons);
+  }
+
+  private static String formatReasonGroup(String errorCode, List<UID> uids) {
+    List<UID> shown =
+        uids.size() > MAX_UIDS_PER_REASON ? uids.subList(0, MAX_UIDS_PER_REASON) : uids;
+    String uidList = shown.stream().map(UID::getValue).collect(Collectors.joining(", "));
+    String more =
+        uids.size() > MAX_UIDS_PER_REASON
+            ? format(", +%d more", uids.size() - MAX_UIDS_PER_REASON)
+            : "";
+    return format("%s x%d [%s%s]", errorCode, uids.size(), uidList, more);
+  }
+
+  /** Like {@link #failedUids}, but keeps the error code behind each failure for logging. */
+  static List<FailedItem> failedItems(ImportReport report, TrackerType type) {
+    List<FailedItem> failed = new ArrayList<>();
+
+    if (report.getValidationReport() != null) {
+      report.getValidationReport().getErrors().stream()
+          .filter(e -> type.name().equals(e.getTrackerType()))
+          .forEach(e -> failed.add(new FailedItem(e.getUid(), e.getErrorCode())));
+    }
+
+    if (report.getPersistenceReport() != null) {
+      TrackerTypeReport typeReport = report.getPersistenceReport().getTypeReportMap().get(type);
+      if (typeReport != null) {
+        typeReport
+            .getEntityReport()
+            .forEach(
+                entity ->
+                    entity
+                        .getErrorReports()
+                        .forEach(
+                            e -> failed.add(new FailedItem(entity.getUid(), e.getErrorCode()))));
+      }
+    }
+
+    return failed;
+  }
+
+  /**
+   * Like {@link #blockingFailedUids}, but keeps the error code behind each failure for logging.
+   * Only meaningful against a DELETE report.
+   */
+  static List<FailedItem> blockingFailedItems(ImportReport report, TrackerType type) {
+    List<FailedItem> blocking = new ArrayList<>();
+
+    if (report.getValidationReport() != null) {
+      report.getValidationReport().getErrors().stream()
+          .filter(e -> type.name().equals(e.getTrackerType()))
+          .filter(e -> !ALREADY_DELETED_CODES.contains(e.getErrorCode()))
+          .forEach(e -> blocking.add(new FailedItem(e.getUid(), e.getErrorCode())));
+    }
+
+    if (report.getPersistenceReport() != null) {
+      TrackerTypeReport typeReport = report.getPersistenceReport().getTypeReportMap().get(type);
+      if (typeReport != null) {
+        typeReport
+            .getEntityReport()
+            .forEach(
+                entity ->
+                    entity.getErrorReports().stream()
+                        .filter(e -> !ALREADY_DELETED_CODES.contains(e.getErrorCode()))
+                        .forEach(
+                            e -> blocking.add(new FailedItem(entity.getUid(), e.getErrorCode()))));
+      }
+    }
+
+    return blocking;
   }
 
   static Set<UID> successfullyProcessedUids(ImportReport report, TrackerType type) {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerSyncReportUtilsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/sync/TrackerSyncReportUtilsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2004-2025, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.sync;
+
+import static org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.formatFailedUids;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.webapi.controller.tracker.sync.TrackerSyncReportUtils.FailedItem;
+import org.junit.jupiter.api.Test;
+
+class TrackerSyncReportUtilsTest {
+
+  @Test
+  void shouldReturnEmptyStringWhenNoFailures() {
+    assertEquals("", formatFailedUids(List.of()));
+  }
+
+  @Test
+  void shouldListAllUidsWhenFailuresAreAtOrBelowTheCap() {
+    List<FailedItem> failed = List.of(item("Uid00000001", "E1032"), item("Uid00000002", "E1032"));
+
+    assertEquals(" (failed: E1032 x2 [Uid00000001, Uid00000002])", formatFailedUids(failed));
+  }
+
+  @Test
+  void shouldCapUidsPerReasonAndReportHowManyMoreThereAre() {
+    List<FailedItem> failed =
+        List.of(
+            item("Uid00000001", "E1032"),
+            item("Uid00000002", "E1032"),
+            item("Uid00000003", "E1032"),
+            item("Uid00000004", "E1032"),
+            item("Uid00000005", "E1032"),
+            item("Uid00000006", "E1032"),
+            item("Uid00000007", "E1032"));
+
+    assertEquals(
+        " (failed: E1032 x7 [Uid00000001, Uid00000002, Uid00000003, Uid00000004, Uid00000005,"
+            + " +2 more])",
+        formatFailedUids(failed));
+  }
+
+  @Test
+  void shouldGroupByErrorCodeAndOrderReasonsByDescendingFailureCount() {
+    List<FailedItem> failed =
+        List.of(
+            item("Uid00000001", "E1082"),
+            item("Uid00000002", "E1032"),
+            item("Uid00000003", "E1032"),
+            item("Uid00000004", "E1032"));
+
+    assertEquals(
+        " (failed: E1032 x3 [Uid00000002, Uid00000003, Uid00000004], E1082 x1 [Uid00000001])",
+        formatFailedUids(failed));
+  }
+
+  @Test
+  void shouldCountAFailedEntityOnceEvenWhenItHasMultipleErrorsUnderTheSameCode() {
+    List<FailedItem> failed = List.of(item("Uid00000001", "E5000"), item("Uid00000001", "E5000"));
+
+    assertEquals(" (failed: E5000 x1 [Uid00000001])", formatFailedUids(failed));
+  }
+
+  private static FailedItem item(String uid, String errorCode) {
+    return new FailedItem(UID.of(uid), errorCode);
+  }
+}


### PR DESCRIPTION
I'm adding more information to the sync log job.
We were already logging how many entities were synchronized and how many were attempted. 
In case of failure, we also showed the UIDs of the failed entities. However, this was missing for single events, which is now fixed. 
I'm now adding the error code to each failed UID, and in order to make it more human readable, I'm grouping the failed entity UIDs by error code.

Additionally, events that can't be persisted because of a conflict in the parent, will be logged with an `E5000`, as we already did for enrollments.
