### PR TITLE
fix: qualify subexpression period offset join keys for ClickHouse

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
@@ -123,7 +123,7 @@ import org.hisp.dhis.subexpression.SubexpressionDimensionItem;
  *             union all select -1, '202310', '202309'
  *             union all select 0, '202309', '202309'
  *             union all select 0, '202310', '202310')
- *              as shift on dataperiod = monthly
+ *              as shift on shift.dataperiod = ax.monthly
  *       where monthly in ('202308', '202309', '202310')
  *       and dx in ('A2VfEfPflHV') // (greatly improves performance)
  *       group by uidlevel2, monthly, ou) as ax

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/SubexpressionPeriodOffsetUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/SubexpressionPeriodOffsetUtils.java
@@ -88,7 +88,7 @@ public class SubexpressionPeriodOffsetUtils {
    *             union all select -1, '202310', '202309'
    *             union all select 0, '202309', '202309'
    *             union all select 0, '202310', '202310')
-   *       as shift on "dataperiod" = "monthly"
+   *       as shift on shift."dataperiod" = ax."monthly"
    * </pre>
    *
    * @param params parameters with reporting periods
@@ -131,8 +131,8 @@ public class SubexpressionPeriodOffsetUtils {
         format(
             ") as %s on %s = %s",
             SHIFT,
-            sqlBuilder.quote(DATAPERIOD),
-            sqlBuilder.quote(params.getPeriodType().toLowerCase())));
+            sqlBuilder.quote(SHIFT, DATAPERIOD),
+            sqlBuilder.quoteAx(params.getPeriodType().toLowerCase())));
 
     return sb.toString();
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGeneratorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGeneratorTest.java
@@ -227,7 +227,7 @@ class JdbcSubexpressionQueryGeneratorTest {
             select -1 as "delta", '202305' as "reportperiod", '202304' as "dataperiod" \
             union all select 0, '202305', '202305'\
             ) as shift on \
-            "dataperiod" = "monthly"\
+            shift."dataperiod" = ax."monthly"\
             where ax."monthly" in ('202304', '202305') \
             and ( ax."pe" in ('202305') ) \
             and ( ax."ou" in ('ouabcdefghA') ) \

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/SubexpressionPeriodOffsetUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/SubexpressionPeriodOffsetUtilsTest.java
@@ -100,7 +100,7 @@ class SubexpressionPeriodOffsetUtilsTest {
             + " union all select 0, '202310', '202310'"
             + " union all select 1, '202309', '202310'"
             + " union all select 1, '202310', '202311'"
-            + ") as shift on \"dataperiod\" = \"monthly\"";
+            + ") as shift on shift.\"dataperiod\" = ax.\"monthly\"";
     assertEquals(expected, result);
   }
 
@@ -117,7 +117,7 @@ class SubexpressionPeriodOffsetUtilsTest {
             + " union all select 0, '202310', '202310'"
             + " union all select 1, '202309', '202310'"
             + " union all select 1, '202310', '202311'"
-            + ") as shift on `dataperiod` = `monthly`";
+            + ") as shift on shift.`dataperiod` = ax.`monthly`";
     assertEquals(expected, result);
   }
 


### PR DESCRIPTION
## Summary

This PR fixes a Clickhouse-only SQL syntax error when subexpressions are used along with period offset. The fix is about qualifying the period in the `ON` clause.


```diff
  select shift."reportperiod" as yearly,        -- declares an alias named "yearly"
         avg(case when ax."dx"='h0xKKjijTdI' and shift."delta" = -1 then ... end) as "h0xKKjijTdI_minus_1",
         avg(case when ax."dx"='h0xKKjijTdI' and shift."delta" =  0 then ... end) as "h0xKKjijTdI"
  from analytics as ax
  join (select -1 as "delta", '2021' as "reportperiod", '2020' as "dataperiod"
        union all select 0, '2021', '2021') as shift
-   on "dataperiod" = "yearly"
+   on shift."dataperiod" = ax."yearly"
  where ax."yearly" in ('2020', '2021')


Postgres and Doris are unaffected.
