### PR TITLE
fix: Handle ProgramRuleAction without a ProgramRule when importing [DHIS2-13920]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -329,6 +329,7 @@ public enum ErrorCode {
   E4055("User needs to have at least one user role associated with it"),
   E4050(
       "One of DataElement, TrackedEntityAttribute or ProgramRuleVariable is required for program rule `{0}`"),
+  E4093("ProgramRuleAction `{0}` must reference a program rule"),
 
   /* ProgramRuleVariable validation */
   E4051("A program rule variable with name `{0}` and program uid `{1}` already exists"),
@@ -343,11 +344,6 @@ public enum ErrorCode {
   E4090("ProgramRuleVariable `{0}` is missing a source type"),
   E4091("ProgramRuleVariable `{0}` with source type `{1}` requires a program stage"),
   E4092("ProgramRuleVariable `{0}` with source type `{1}` requires a value type"),
-  E4093("ProgramRuleAction `{0}` must reference a program rule"),
-  E4094("ProgramRule `{0}` referenced by program rule action `{1}` does not exist"),
-  E4095("ProgramRule `{0}` must reference a program"),
-  E4096("Program `{0}` referenced by program rule `{1}` does not exist"),
-  E4097("ProgramRuleAction `{0}` has no validator for action type `{1}`"),
 
   /* Metadata Validation (continued) */
   E4060("Object could not be deleted: {0}"),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -343,6 +343,11 @@ public enum ErrorCode {
   E4090("ProgramRuleVariable `{0}` is missing a source type"),
   E4091("ProgramRuleVariable `{0}` with source type `{1}` requires a program stage"),
   E4092("ProgramRuleVariable `{0}` with source type `{1}` requires a value type"),
+  E4093("ProgramRuleAction `{0}` must reference a program rule"),
+  E4094("ProgramRule `{0}` referenced by program rule action `{1}` does not exist"),
+  E4095("ProgramRule `{0}` must reference a program"),
+  E4096("Program `{0}` referenced by program rule `{1}` does not exist"),
+  E4097("ProgramRuleAction `{0}` has no validator for action type `{1}`"),
 
   /* Metadata Validation (continued) */
   E4060("Object could not be deleted: {0}"),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/programrule/action/validation/ProgramRuleActionValidationContextLoader.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/programrule/action/validation/ProgramRuleActionValidationContextLoader.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.programrule.action.validation;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
@@ -64,11 +65,36 @@ public class ProgramRuleActionValidationContextLoader {
     this.objectManager = manager;
   }
 
+  /**
+   * Resolves the {@link ProgramRule} the given action belongs to.
+   *
+   * @return the rule from the bundle, or {@code null} if the action has no rule reference or the
+   *     referenced rule is not part of the bundle
+   */
+  @CheckForNull
+  public ProgramRule resolveProgramRule(
+      @Nonnull Preheat preheat,
+      @Nonnull PreheatIdentifier preheatIdentifier,
+      @Nonnull ProgramRuleAction ruleAction) {
+    return preheat.get(preheatIdentifier, ProgramRule.class, ruleAction.getProgramRule());
+  }
+
+  /**
+   * Resolves the {@link Program} of the given rule, falling back to the database and seeding the
+   * bundle with what it finds there.
+   *
+   * @return the program, or {@code null} if the rule has no program reference or the referenced
+   *     program exists neither in the bundle nor in the database
+   */
+  @CheckForNull
   @Transactional(readOnly = true)
-  public ProgramRuleActionValidationContext load(
-      Preheat preheat, PreheatIdentifier preheatIdentifier, ProgramRuleAction ruleAction) {
-    ProgramRule rule =
-        preheat.get(preheatIdentifier, ProgramRule.class, ruleAction.getProgramRule());
+  public Program resolveProgram(
+      @Nonnull Preheat preheat,
+      @Nonnull PreheatIdentifier preheatIdentifier,
+      @Nonnull ProgramRule rule) {
+    if (rule.getProgram() == null) {
+      return null;
+    }
 
     Program program = preheat.get(preheatIdentifier, Program.class, rule.getProgram());
 
@@ -77,6 +103,22 @@ public class ProgramRuleActionValidationContextLoader {
       preheat.put(preheatIdentifier, program);
     }
 
+    return program;
+  }
+
+  /**
+   * Builds the context a {@link ProgramRuleActionValidator} validates against. The {@code rule} and
+   * {@code program} must already have been resolved via {@link #resolveProgramRule} and {@link
+   * #resolveProgram}; unresolved references are a validation error for the caller to report, not
+   * something this method can express.
+   */
+  @Transactional(readOnly = true)
+  public ProgramRuleActionValidationContext load(
+      @Nonnull Preheat preheat,
+      @Nonnull PreheatIdentifier preheatIdentifier,
+      @Nonnull ProgramRuleAction ruleAction,
+      @Nonnull ProgramRule rule,
+      @Nonnull Program program) {
     List<ProgramStage> stages =
         preheat.getAll(preheatIdentifier, new ArrayList<>(program.getProgramStages()));
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/programrule/action/validation/ProgramRuleActionValidationContextLoader.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/programrule/action/validation/ProgramRuleActionValidationContextLoader.java
@@ -31,7 +31,6 @@ package org.hisp.dhis.programrule.action.validation;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
@@ -65,36 +64,11 @@ public class ProgramRuleActionValidationContextLoader {
     this.objectManager = manager;
   }
 
-  /**
-   * Resolves the {@link ProgramRule} the given action belongs to.
-   *
-   * @return the rule from the bundle, or {@code null} if the action has no rule reference or the
-   *     referenced rule is not part of the bundle
-   */
-  @CheckForNull
-  public ProgramRule resolveProgramRule(
-      @Nonnull Preheat preheat,
-      @Nonnull PreheatIdentifier preheatIdentifier,
-      @Nonnull ProgramRuleAction ruleAction) {
-    return preheat.get(preheatIdentifier, ProgramRule.class, ruleAction.getProgramRule());
-  }
-
-  /**
-   * Resolves the {@link Program} of the given rule, falling back to the database and seeding the
-   * bundle with what it finds there.
-   *
-   * @return the program, or {@code null} if the rule has no program reference or the referenced
-   *     program exists neither in the bundle nor in the database
-   */
-  @CheckForNull
   @Transactional(readOnly = true)
-  public Program resolveProgram(
-      @Nonnull Preheat preheat,
-      @Nonnull PreheatIdentifier preheatIdentifier,
-      @Nonnull ProgramRule rule) {
-    if (rule.getProgram() == null) {
-      return null;
-    }
+  public ProgramRuleActionValidationContext load(
+      Preheat preheat, PreheatIdentifier preheatIdentifier, ProgramRuleAction ruleAction) {
+    ProgramRule rule =
+        preheat.get(preheatIdentifier, ProgramRule.class, ruleAction.getProgramRule());
 
     Program program = preheat.get(preheatIdentifier, Program.class, rule.getProgram());
 
@@ -103,22 +77,6 @@ public class ProgramRuleActionValidationContextLoader {
       preheat.put(preheatIdentifier, program);
     }
 
-    return program;
-  }
-
-  /**
-   * Builds the context a {@link ProgramRuleActionValidator} validates against. The {@code rule} and
-   * {@code program} must already have been resolved via {@link #resolveProgramRule} and {@link
-   * #resolveProgram}; unresolved references are a validation error for the caller to report, not
-   * something this method can express.
-   */
-  @Transactional(readOnly = true)
-  public ProgramRuleActionValidationContext load(
-      @Nonnull Preheat preheat,
-      @Nonnull PreheatIdentifier preheatIdentifier,
-      @Nonnull ProgramRuleAction ruleAction,
-      @Nonnull ProgramRule rule,
-      @Nonnull Program program) {
     List<ProgramStage> stages =
         preheat.getAll(preheatIdentifier, new ArrayList<>(program.getProgramStages()));
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleActionObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleActionObjectBundleHook.java
@@ -36,11 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.preheat.Preheat;
-import org.hisp.dhis.preheat.PreheatIdentifier;
-import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
-import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleAction;
 import org.hisp.dhis.programrule.ProgramRuleActionType;
 import org.hisp.dhis.programrule.ProgramRuleActionValidationResult;
@@ -71,7 +67,12 @@ public class ProgramRuleActionObjectBundleHook extends AbstractObjectBundleHook<
   @Override
   public void validate(
       ProgramRuleAction programRuleAction, ObjectBundle bundle, Consumer<ErrorReport> addReports) {
-    validateProgramRuleAction(programRuleAction, bundle, addReports);
+    ProgramRuleActionValidationResult validationResult =
+        validateProgramRuleAction(programRuleAction, bundle);
+
+    if (!validationResult.isValid()) {
+      addReports.accept(validationResult.getErrorReport());
+    }
   }
 
   @Override
@@ -85,76 +86,28 @@ public class ProgramRuleActionObjectBundleHook extends AbstractObjectBundleHook<
     getNotificationTemplate(object, bundle);
   }
 
-  /**
-   * Validates a single action, reporting any unresolved reference as an {@link ErrorReport} against
-   * the action itself. Every reference the validation context is built from is resolved here first,
-   * so that a payload with an incomplete reference is reported as a conflict on the offending
-   * object rather than aborting the whole import with an exception.
-   */
-  private void validateProgramRuleAction(
-      ProgramRuleAction ruleAction, ObjectBundle bundle, Consumer<ErrorReport> addReports) {
-    Preheat preheat = bundle.getPreheat();
-    PreheatIdentifier preheatIdentifier = bundle.getPreheatIdentifier();
+  private ProgramRuleActionValidationResult validateProgramRuleAction(
+      ProgramRuleAction ruleAction, ObjectBundle bundle) {
+    ProgramRuleActionValidationResult validationResult;
 
-    ProgramRule ruleReference = ruleAction.getProgramRule();
-
-    if (ruleReference == null) {
-      addReports.accept(
-          new ErrorReport(ProgramRuleAction.class, ErrorCode.E4093, ruleAction.getUid()));
-      return;
+    if (ruleAction.getProgramRule() == null) {
+      // there is no rule to build a validation context from, so report it against the action
+      return ProgramRuleActionValidationResult.builder()
+          .valid(false)
+          .errorReport(
+              new ErrorReport(ProgramRuleAction.class, ErrorCode.E4093, ruleAction.getUid()))
+          .build();
     }
 
-    ProgramRule rule = contextLoader.resolveProgramRule(preheat, preheatIdentifier, ruleAction);
-
-    if (rule == null) {
-      addReports.accept(
-          new ErrorReport(
-              ProgramRuleAction.class,
-              ErrorCode.E4094,
-              preheatIdentifier.getIdentifier(ruleReference),
-              ruleAction.getUid()));
-      return;
-    }
-
-    if (rule.getProgram() == null) {
-      addReports.accept(new ErrorReport(ProgramRuleAction.class, ErrorCode.E4095, rule.getUid()));
-      return;
-    }
-
-    Program program = contextLoader.resolveProgram(preheat, preheatIdentifier, rule);
-
-    if (program == null) {
-      addReports.accept(
-          new ErrorReport(
-              ProgramRuleAction.class,
-              ErrorCode.E4096,
-              preheatIdentifier.getIdentifier(rule.getProgram()),
-              rule.getUid()));
-      return;
-    }
+    ProgramRuleActionValidationContext validationContext =
+        contextLoader.load(bundle.getPreheat(), bundle.getPreheatIdentifier(), ruleAction);
 
     ProgramRuleActionValidator validator =
         programRuleActionValidatorMap.get(ruleAction.getProgramRuleActionType());
 
-    if (validator == null) {
-      addReports.accept(
-          new ErrorReport(
-              ProgramRuleAction.class,
-              ErrorCode.E4097,
-              ruleAction.getUid(),
-              ruleAction.getProgramRuleActionType()));
-      return;
-    }
+    validationResult = validator.validate(ruleAction, validationContext);
 
-    ProgramRuleActionValidationContext validationContext =
-        contextLoader.load(preheat, preheatIdentifier, ruleAction, rule, program);
-
-    ProgramRuleActionValidationResult validationResult =
-        validator.validate(ruleAction, validationContext);
-
-    if (!validationResult.isValid()) {
-      addReports.accept(validationResult.getErrorReport());
-    }
+    return validationResult;
   }
 
   private void getNotificationTemplate(ProgramRuleAction object, ObjectBundle bundle) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleActionObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleActionObjectBundleHook.java
@@ -90,8 +90,8 @@ public class ProgramRuleActionObjectBundleHook extends AbstractObjectBundleHook<
       ProgramRuleAction ruleAction, ObjectBundle bundle) {
     ProgramRuleActionValidationResult validationResult;
 
+    // report error if no programRule
     if (ruleAction.getProgramRule() == null) {
-      // there is no rule to build a validation context from, so report it against the action
       return ProgramRuleActionValidationResult.builder()
           .valid(false)
           .errorReport(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleActionObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleActionObjectBundleHook.java
@@ -34,8 +34,13 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
+import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleAction;
 import org.hisp.dhis.programrule.ProgramRuleActionType;
 import org.hisp.dhis.programrule.ProgramRuleActionValidationResult;
@@ -66,12 +71,7 @@ public class ProgramRuleActionObjectBundleHook extends AbstractObjectBundleHook<
   @Override
   public void validate(
       ProgramRuleAction programRuleAction, ObjectBundle bundle, Consumer<ErrorReport> addReports) {
-    ProgramRuleActionValidationResult validationResult =
-        validateProgramRuleAction(programRuleAction, bundle);
-
-    if (!validationResult.isValid()) {
-      addReports.accept(validationResult.getErrorReport());
-    }
+    validateProgramRuleAction(programRuleAction, bundle, addReports);
   }
 
   @Override
@@ -85,19 +85,76 @@ public class ProgramRuleActionObjectBundleHook extends AbstractObjectBundleHook<
     getNotificationTemplate(object, bundle);
   }
 
-  private ProgramRuleActionValidationResult validateProgramRuleAction(
-      ProgramRuleAction ruleAction, ObjectBundle bundle) {
-    ProgramRuleActionValidationResult validationResult;
+  /**
+   * Validates a single action, reporting any unresolved reference as an {@link ErrorReport} against
+   * the action itself. Every reference the validation context is built from is resolved here first,
+   * so that a payload with an incomplete reference is reported as a conflict on the offending
+   * object rather than aborting the whole import with an exception.
+   */
+  private void validateProgramRuleAction(
+      ProgramRuleAction ruleAction, ObjectBundle bundle, Consumer<ErrorReport> addReports) {
+    Preheat preheat = bundle.getPreheat();
+    PreheatIdentifier preheatIdentifier = bundle.getPreheatIdentifier();
 
-    ProgramRuleActionValidationContext validationContext =
-        contextLoader.load(bundle.getPreheat(), bundle.getPreheatIdentifier(), ruleAction);
+    ProgramRule ruleReference = ruleAction.getProgramRule();
+
+    if (ruleReference == null) {
+      addReports.accept(
+          new ErrorReport(ProgramRuleAction.class, ErrorCode.E4093, ruleAction.getUid()));
+      return;
+    }
+
+    ProgramRule rule = contextLoader.resolveProgramRule(preheat, preheatIdentifier, ruleAction);
+
+    if (rule == null) {
+      addReports.accept(
+          new ErrorReport(
+              ProgramRuleAction.class,
+              ErrorCode.E4094,
+              preheatIdentifier.getIdentifier(ruleReference),
+              ruleAction.getUid()));
+      return;
+    }
+
+    if (rule.getProgram() == null) {
+      addReports.accept(new ErrorReport(ProgramRuleAction.class, ErrorCode.E4095, rule.getUid()));
+      return;
+    }
+
+    Program program = contextLoader.resolveProgram(preheat, preheatIdentifier, rule);
+
+    if (program == null) {
+      addReports.accept(
+          new ErrorReport(
+              ProgramRuleAction.class,
+              ErrorCode.E4096,
+              preheatIdentifier.getIdentifier(rule.getProgram()),
+              rule.getUid()));
+      return;
+    }
 
     ProgramRuleActionValidator validator =
         programRuleActionValidatorMap.get(ruleAction.getProgramRuleActionType());
 
-    validationResult = validator.validate(ruleAction, validationContext);
+    if (validator == null) {
+      addReports.accept(
+          new ErrorReport(
+              ProgramRuleAction.class,
+              ErrorCode.E4097,
+              ruleAction.getUid(),
+              ruleAction.getProgramRuleActionType()));
+      return;
+    }
 
-    return validationResult;
+    ProgramRuleActionValidationContext validationContext =
+        contextLoader.load(preheat, preheatIdentifier, ruleAction, rule, program);
+
+    ProgramRuleActionValidationResult validationResult =
+        validator.validate(ruleAction, validationContext);
+
+    if (!validationResult.isValid()) {
+      addReports.accept(validationResult.getErrorReport());
+    }
   }
 
   private void getNotificationTemplate(ProgramRuleAction object, ObjectBundle bundle) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
@@ -115,10 +115,8 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
   @DisplayName(
       "A program rule action with no programRule reference is reported against that object (atomicMode=ALL)")
   void testProgramRuleActionWithoutProgramRuleReference_atomicAll() {
-    // programRules[0].programRuleActions lists the action, but programRuleActions[0] carries no
-    // "programRule" property. This used to abort the whole import with a NullPointerException.
     JsonImportSummary summary =
-        POST("/metadata", Path.of(PROGRAM_RULE_ACTION_WITHOUT_RULE))
+        POST("/metadata?atomicMode=ALL", Path.of(PROGRAM_RULE_ACTION_WITHOUT_RULE))
             .content(HttpStatus.CONFLICT)
             .get("response")
             .as(JsonImportSummary.class);
@@ -145,13 +143,12 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
     assertEquals("WARNING", summary.getStatus());
     assertProgramRuleActionErrorIsVisible(summary);
 
-    // atomicMode=NONE, so only the offending action is skipped
+    // atomicMode=NONE, so only the invalid object is ignored
     assertStatus(HttpStatus.OK, GET("/programs/ProgramUid1"));
     assertStatus(HttpStatus.OK, GET("/programRules/PrgRuleUid1"));
     assertStatus(HttpStatus.NOT_FOUND, GET("/programRuleActions/PrgRuleAct1"));
 
-    // the rule is imported action-less: the skipped action is absent from its collection rather
-    // than left as a dangling reference
+    // the rule is imported without the action, rather than left as a dangling reference
     assertTrue(
         GET("/programRules/PrgRuleUid1?fields=programRuleActions[id]")
             .content()
@@ -160,8 +157,8 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
   }
 
   /**
-   * Asserts the failure is attributed to the offending {@link ProgramRuleAction} itself -- its
-   * class, bundle index and UID -- and not reported as a bare message on the import as a whole.
+   * Asserts the failure is attributed to the offending {@link ProgramRuleAction} itself in an
+   * import report.
    */
   private void assertProgramRuleActionErrorIsVisible(JsonImportSummary summary) {
     JsonTypeReport typeReport = summary.getTypeReport(ProgramRuleAction.class);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
@@ -29,6 +29,7 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.http.HttpAssertions.assertStatus;
 import static org.hisp.dhis.http.HttpClientAdapter.Body;
 import static org.hisp.dhis.http.HttpClientAdapter.ContentType;
 import static org.hisp.dhis.test.utils.Assertions.assertStartsWith;
@@ -38,9 +39,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.programrule.ProgramRuleAction;
 import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
+import org.hisp.dhis.test.webapi.json.domain.JsonErrorReport;
 import org.hisp.dhis.test.webapi.json.domain.JsonImportSummary;
+import org.hisp.dhis.test.webapi.json.domain.JsonObjectReport;
 import org.hisp.dhis.test.webapi.json.domain.JsonTypeReport;
 import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
 import org.hisp.dhis.user.User;
@@ -51,6 +56,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 class MetadataImportExportControllerIntegrationTest extends PostgresControllerIntegrationTestBase {
+
+  private static final String PROGRAM_RULE_ACTION_WITHOUT_RULE =
+      "metadata/program_rule_action_without_program_rule_reference.json";
 
   @Test
   void testAggregateDataExchangeSuccess() {
@@ -101,6 +109,67 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
                 Body("<metadata></metadata>"),
                 ContentType("application/xml")));
     assertStartsWith("Initiated METADATA_IMPORT", msg.getMessage());
+  }
+
+  @Test
+  @DisplayName(
+      "A program rule action with no programRule reference is reported against that object (atomicMode=ALL)")
+  void testProgramRuleActionWithoutProgramRuleReference_atomicAll() {
+    // programRules[0].programRuleActions lists the action, but programRuleActions[0] carries no
+    // "programRule" property. This used to abort the whole import with a NullPointerException.
+    JsonImportSummary summary =
+        POST("/metadata", Path.of(PROGRAM_RULE_ACTION_WITHOUT_RULE))
+            .content(HttpStatus.CONFLICT)
+            .get("response")
+            .as(JsonImportSummary.class);
+
+    assertEquals("ERROR", summary.getStatus());
+    assertProgramRuleActionErrorIsVisible(summary);
+
+    // atomicMode=ALL, so nothing at all is persisted
+    assertStatus(HttpStatus.NOT_FOUND, GET("/programs/aUbnwuv5D2z"));
+    assertStatus(HttpStatus.NOT_FOUND, GET("/programRules/YKxrqRMonw2"));
+    assertStatus(HttpStatus.NOT_FOUND, GET("/programRuleActions/HMAVLnd1bZ8"));
+  }
+
+  @Test
+  @DisplayName(
+      "A program rule action with no programRule reference is reported against that object (atomicMode=NONE)")
+  void testProgramRuleActionWithoutProgramRuleReference_atomicNone() {
+    JsonImportSummary summary =
+        POST("/metadata?atomicMode=NONE", Path.of(PROGRAM_RULE_ACTION_WITHOUT_RULE))
+            .content(HttpStatus.CONFLICT)
+            .get("response")
+            .as(JsonImportSummary.class);
+
+    assertEquals("WARNING", summary.getStatus());
+    assertProgramRuleActionErrorIsVisible(summary);
+
+    // atomicMode=NONE, so only the offending action is skipped
+    assertStatus(HttpStatus.OK, GET("/programs/aUbnwuv5D2z"));
+    assertStatus(HttpStatus.OK, GET("/programRules/YKxrqRMonw2"));
+    assertStatus(HttpStatus.NOT_FOUND, GET("/programRuleActions/HMAVLnd1bZ8"));
+  }
+
+  /**
+   * Asserts the failure is attributed to the offending {@link ProgramRuleAction} itself -- its
+   * class, bundle index and UID -- and not reported as a bare message on the import as a whole.
+   */
+  private void assertProgramRuleActionErrorIsVisible(JsonImportSummary summary) {
+    JsonTypeReport typeReport = summary.getTypeReport(ProgramRuleAction.class);
+    assertEquals(1, typeReport.getObjectReports().size());
+
+    JsonObjectReport objectReport = typeReport.getObjectReports().get(0);
+    assertEquals(ProgramRuleAction.class, objectReport.getKlass());
+    assertEquals("HMAVLnd1bZ8", objectReport.getUid());
+    assertEquals(0, objectReport.getIndex());
+
+    assertEquals(1, objectReport.getErrorReports().size());
+    JsonErrorReport errorReport = objectReport.getErrorReports().get(0);
+    assertEquals(ErrorCode.E4093, errorReport.getErrorCode());
+    assertEquals(ProgramRuleAction.class, errorReport.getMainKlass());
+    assertEquals(
+        "ProgramRuleAction `HMAVLnd1bZ8` must reference a program rule", errorReport.getMessage());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
@@ -127,9 +127,9 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
     assertProgramRuleActionErrorIsVisible(summary);
 
     // atomicMode=ALL, so nothing at all is persisted
-    assertStatus(HttpStatus.NOT_FOUND, GET("/programs/aUbnwuv5D2z"));
-    assertStatus(HttpStatus.NOT_FOUND, GET("/programRules/YKxrqRMonw2"));
-    assertStatus(HttpStatus.NOT_FOUND, GET("/programRuleActions/HMAVLnd1bZ8"));
+    assertStatus(HttpStatus.NOT_FOUND, GET("/programs/ProgramUid1"));
+    assertStatus(HttpStatus.NOT_FOUND, GET("/programRules/PrgRuleUid1"));
+    assertStatus(HttpStatus.NOT_FOUND, GET("/programRuleActions/PrgRuleAct1"));
   }
 
   @Test
@@ -146,9 +146,9 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
     assertProgramRuleActionErrorIsVisible(summary);
 
     // atomicMode=NONE, so only the offending action is skipped
-    assertStatus(HttpStatus.OK, GET("/programs/aUbnwuv5D2z"));
-    assertStatus(HttpStatus.OK, GET("/programRules/YKxrqRMonw2"));
-    assertStatus(HttpStatus.NOT_FOUND, GET("/programRuleActions/HMAVLnd1bZ8"));
+    assertStatus(HttpStatus.OK, GET("/programs/ProgramUid1"));
+    assertStatus(HttpStatus.OK, GET("/programRules/PrgRuleUid1"));
+    assertStatus(HttpStatus.NOT_FOUND, GET("/programRuleActions/PrgRuleAct1"));
   }
 
   /**
@@ -161,7 +161,7 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
 
     JsonObjectReport objectReport = typeReport.getObjectReports().get(0);
     assertEquals(ProgramRuleAction.class, objectReport.getKlass());
-    assertEquals("HMAVLnd1bZ8", objectReport.getUid());
+    assertEquals("PrgRuleAct1", objectReport.getUid());
     assertEquals(0, objectReport.getIndex());
 
     assertEquals(1, objectReport.getErrorReports().size());
@@ -169,7 +169,7 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
     assertEquals(ErrorCode.E4093, errorReport.getErrorCode());
     assertEquals(ProgramRuleAction.class, errorReport.getMainKlass());
     assertEquals(
-        "ProgramRuleAction `HMAVLnd1bZ8` must reference a program rule", errorReport.getMessage());
+        "ProgramRuleAction `PrgRuleAct1` must reference a program rule", errorReport.getMessage());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerIntegrationTest.java
@@ -149,6 +149,14 @@ class MetadataImportExportControllerIntegrationTest extends PostgresControllerIn
     assertStatus(HttpStatus.OK, GET("/programs/ProgramUid1"));
     assertStatus(HttpStatus.OK, GET("/programRules/PrgRuleUid1"));
     assertStatus(HttpStatus.NOT_FOUND, GET("/programRuleActions/PrgRuleAct1"));
+
+    // the rule is imported action-less: the skipped action is absent from its collection rather
+    // than left as a dangling reference
+    assertTrue(
+        GET("/programRules/PrgRuleUid1?fields=programRuleActions[id]")
+            .content()
+            .getArray("programRuleActions")
+            .isEmpty());
   }
 
   /**

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/program_rule_action_without_program_rule_reference.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/program_rule_action_without_program_rule_reference.json
@@ -1,0 +1,183 @@
+{
+  "categoryOptions": [
+    {
+      "code": "default",
+      "name": "default",
+      "id": "xYerKDKCefk",
+      "shortName": "default",
+      "sharing": { "userGroups": {}, "external": false, "public": "rwrw----", "users": {} },
+      "organisationUnits": []
+    }
+  ],
+  "categories": [
+    {
+      "code": "default",
+      "name": "default",
+      "id": "GLevLNI9wkl",
+      "shortName": "default",
+      "dataDimensionType": "DISAGGREGATION",
+      "dataDimension": false,
+      "sharing": { "userGroups": {}, "external": false, "public": "rw------", "users": {} },
+      "categoryOptions": [{ "id": "xYerKDKCefk" }]
+    }
+  ],
+  "categoryCombos": [
+    {
+      "code": "default",
+      "name": "default",
+      "id": "bjDvmb4bfuf",
+      "dataDimensionType": "DISAGGREGATION",
+      "skipTotal": false,
+      "sharing": { "userGroups": {}, "external": false, "public": "rw------", "users": {} },
+      "categories": [{ "id": "GLevLNI9wkl" }]
+    }
+  ],
+  "categoryOptionCombos": [
+    {
+      "code": "default",
+      "name": "default",
+      "id": "HllvX50cXC0",
+      "ignoreApproval": false,
+      "categoryCombo": { "id": "bjDvmb4bfuf" },
+      "categoryOptions": [{ "id": "xYerKDKCefk" }]
+    }
+  ],
+  "dataElements": [
+    {
+      "id": "IWLWOXyHwFb",
+      "name": "zzTest input number 1",
+      "shortName": "zzTest input number 1",
+      "aggregationType": "SUM",
+      "domainType": "TRACKER",
+      "valueType": "NUMBER",
+      "zeroIsSignificant": false,
+      "categoryCombo": { "id": "bjDvmb4bfuf" },
+      "sharing": { "userGroups": {}, "external": false, "public": "rw------", "users": {} }
+    },
+    {
+      "id": "EZfu1R3vdSe",
+      "name": "zzTest input number 2",
+      "shortName": "zzTest input number 2",
+      "aggregationType": "SUM",
+      "domainType": "TRACKER",
+      "valueType": "NUMBER",
+      "zeroIsSignificant": false,
+      "categoryCombo": { "id": "bjDvmb4bfuf" },
+      "sharing": { "userGroups": {}, "external": false, "public": "rw------", "users": {} }
+    }
+  ],
+  "programs": [
+    {
+      "id": "aUbnwuv5D2z",
+      "name": "zzTest program with number variable comparator issue",
+      "shortName": "zzTest program with number var comparator issue",
+      "programType": "WITHOUT_REGISTRATION",
+      "accessLevel": "OPEN",
+      "version": 0,
+      "completeEventsExpiryDays": 0,
+      "expiryDays": 0,
+      "openDaysAfterCoEndDate": 0,
+      "maxTeiCountToReturn": 0,
+      "minAttributesRequiredToSearch": 1,
+      "ignoreOverdueEvents": false,
+      "skipOffline": false,
+      "displayFrontPageList": false,
+      "onlyEnrollOnce": false,
+      "selectIncidentDatesInFuture": false,
+      "selectEnrollmentDatesInFuture": false,
+      "displayIncidentDate": true,
+      "useFirstStageDuringRegistration": false,
+      "categoryCombo": { "id": "bjDvmb4bfuf" },
+      "sharing": { "userGroups": {}, "external": false, "public": "rwrw----", "users": {} },
+      "programStages": [{ "id": "nN0GtXmGhvi" }]
+    }
+  ],
+  "programStages": [
+    {
+      "id": "nN0GtXmGhvi",
+      "name": "zzTest program with number variable comparator issue",
+      "allowGenerateNextVisit": false,
+      "preGenerateUID": false,
+      "openAfterEnrollment": false,
+      "repeatable": false,
+      "remindCompleted": false,
+      "displayGenerateEventBox": true,
+      "generatedByEnrollmentDate": false,
+      "validationStrategy": "ON_UPDATE_AND_INSERT",
+      "autoGenerateEvent": true,
+      "hideDueDate": false,
+      "blockEntryForm": false,
+      "enableUserAssignment": false,
+      "minDaysFromStart": 0,
+      "program": { "id": "aUbnwuv5D2z" },
+      "sharing": { "userGroups": {}, "external": false, "public": "rwrw----", "users": {} },
+      "programStageDataElements": [{ "id": "An1CL5heDpm" }, { "id": "KfsxuuU9UM4" }]
+    }
+  ],
+  "programStageDataElements": [
+    {
+      "id": "An1CL5heDpm",
+      "displayInReports": false,
+      "skipSynchronization": false,
+      "renderOptionsAsRadio": false,
+      "compulsory": false,
+      "skipAnalytics": false,
+      "allowProvidedElsewhere": false,
+      "sortOrder": 1,
+      "allowFutureDate": false,
+      "programStage": { "id": "nN0GtXmGhvi" },
+      "dataElement": { "id": "IWLWOXyHwFb" }
+    },
+    {
+      "id": "KfsxuuU9UM4",
+      "displayInReports": false,
+      "skipSynchronization": false,
+      "renderOptionsAsRadio": false,
+      "compulsory": false,
+      "skipAnalytics": false,
+      "allowProvidedElsewhere": false,
+      "sortOrder": 2,
+      "allowFutureDate": false,
+      "programStage": { "id": "nN0GtXmGhvi" },
+      "dataElement": { "id": "EZfu1R3vdSe" }
+    }
+  ],
+  "programRuleVariables": [
+    {
+      "id": "VkhzN9gHAUJ",
+      "name": "zzTest number var 1",
+      "programRuleVariableSourceType": "DATAELEMENT_CURRENT_EVENT",
+      "useCodeForOptionSet": false,
+      "valueType": "NUMBER",
+      "program": { "id": "aUbnwuv5D2z" },
+      "dataElement": { "id": "IWLWOXyHwFb" }
+    },
+    {
+      "id": "Hv83fT0LeEV",
+      "name": "zzTest number var 2",
+      "programRuleVariableSourceType": "DATAELEMENT_CURRENT_EVENT",
+      "useCodeForOptionSet": false,
+      "valueType": "NUMBER",
+      "program": { "id": "aUbnwuv5D2z" },
+      "dataElement": { "id": "EZfu1R3vdSe" }
+    }
+  ],
+  "programRules": [
+    {
+      "id": "YKxrqRMonw2",
+      "name": "zzTest rule - error if var 1 is larger than var 2",
+      "condition": "#{zzTest number var 1} > #{zzTest number var 2}",
+      "program": { "id": "aUbnwuv5D2z" },
+      "programRuleActions": [{ "id": "HMAVLnd1bZ8" }]
+    }
+  ],
+  "programRuleActions": [
+    {
+      "id": "HMAVLnd1bZ8",
+      "programRuleActionType": "SHOWERROR",
+      "evaluationTime": "ALWAYS",
+      "content": "input 1 is greater than input 2",
+      "evaluationEnvironments": ["ANDROID", "WEB"]
+    }
+  ]
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/program_rule_action_without_program_rule_reference.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/program_rule_action_without_program_rule_reference.json
@@ -1,183 +1,26 @@
 {
-  "categoryOptions": [
-    {
-      "code": "default",
-      "name": "default",
-      "id": "xYerKDKCefk",
-      "shortName": "default",
-      "sharing": { "userGroups": {}, "external": false, "public": "rwrw----", "users": {} },
-      "organisationUnits": []
-    }
-  ],
-  "categories": [
-    {
-      "code": "default",
-      "name": "default",
-      "id": "GLevLNI9wkl",
-      "shortName": "default",
-      "dataDimensionType": "DISAGGREGATION",
-      "dataDimension": false,
-      "sharing": { "userGroups": {}, "external": false, "public": "rw------", "users": {} },
-      "categoryOptions": [{ "id": "xYerKDKCefk" }]
-    }
-  ],
-  "categoryCombos": [
-    {
-      "code": "default",
-      "name": "default",
-      "id": "bjDvmb4bfuf",
-      "dataDimensionType": "DISAGGREGATION",
-      "skipTotal": false,
-      "sharing": { "userGroups": {}, "external": false, "public": "rw------", "users": {} },
-      "categories": [{ "id": "GLevLNI9wkl" }]
-    }
-  ],
-  "categoryOptionCombos": [
-    {
-      "code": "default",
-      "name": "default",
-      "id": "HllvX50cXC0",
-      "ignoreApproval": false,
-      "categoryCombo": { "id": "bjDvmb4bfuf" },
-      "categoryOptions": [{ "id": "xYerKDKCefk" }]
-    }
-  ],
-  "dataElements": [
-    {
-      "id": "IWLWOXyHwFb",
-      "name": "zzTest input number 1",
-      "shortName": "zzTest input number 1",
-      "aggregationType": "SUM",
-      "domainType": "TRACKER",
-      "valueType": "NUMBER",
-      "zeroIsSignificant": false,
-      "categoryCombo": { "id": "bjDvmb4bfuf" },
-      "sharing": { "userGroups": {}, "external": false, "public": "rw------", "users": {} }
-    },
-    {
-      "id": "EZfu1R3vdSe",
-      "name": "zzTest input number 2",
-      "shortName": "zzTest input number 2",
-      "aggregationType": "SUM",
-      "domainType": "TRACKER",
-      "valueType": "NUMBER",
-      "zeroIsSignificant": false,
-      "categoryCombo": { "id": "bjDvmb4bfuf" },
-      "sharing": { "userGroups": {}, "external": false, "public": "rw------", "users": {} }
-    }
-  ],
   "programs": [
     {
-      "id": "aUbnwuv5D2z",
-      "name": "zzTest program with number variable comparator issue",
-      "shortName": "zzTest program with number var comparator issue",
-      "programType": "WITHOUT_REGISTRATION",
-      "accessLevel": "OPEN",
-      "version": 0,
-      "completeEventsExpiryDays": 0,
-      "expiryDays": 0,
-      "openDaysAfterCoEndDate": 0,
-      "maxTeiCountToReturn": 0,
-      "minAttributesRequiredToSearch": 1,
-      "ignoreOverdueEvents": false,
-      "skipOffline": false,
-      "displayFrontPageList": false,
-      "onlyEnrollOnce": false,
-      "selectIncidentDatesInFuture": false,
-      "selectEnrollmentDatesInFuture": false,
-      "displayIncidentDate": true,
-      "useFirstStageDuringRegistration": false,
-      "categoryCombo": { "id": "bjDvmb4bfuf" },
-      "sharing": { "userGroups": {}, "external": false, "public": "rwrw----", "users": {} },
-      "programStages": [{ "id": "nN0GtXmGhvi" }]
-    }
-  ],
-  "programStages": [
-    {
-      "id": "nN0GtXmGhvi",
-      "name": "zzTest program with number variable comparator issue",
-      "allowGenerateNextVisit": false,
-      "preGenerateUID": false,
-      "openAfterEnrollment": false,
-      "repeatable": false,
-      "remindCompleted": false,
-      "displayGenerateEventBox": true,
-      "generatedByEnrollmentDate": false,
-      "validationStrategy": "ON_UPDATE_AND_INSERT",
-      "autoGenerateEvent": true,
-      "hideDueDate": false,
-      "blockEntryForm": false,
-      "enableUserAssignment": false,
-      "minDaysFromStart": 0,
-      "program": { "id": "aUbnwuv5D2z" },
-      "sharing": { "userGroups": {}, "external": false, "public": "rwrw----", "users": {} },
-      "programStageDataElements": [{ "id": "An1CL5heDpm" }, { "id": "KfsxuuU9UM4" }]
-    }
-  ],
-  "programStageDataElements": [
-    {
-      "id": "An1CL5heDpm",
-      "displayInReports": false,
-      "skipSynchronization": false,
-      "renderOptionsAsRadio": false,
-      "compulsory": false,
-      "skipAnalytics": false,
-      "allowProvidedElsewhere": false,
-      "sortOrder": 1,
-      "allowFutureDate": false,
-      "programStage": { "id": "nN0GtXmGhvi" },
-      "dataElement": { "id": "IWLWOXyHwFb" }
-    },
-    {
-      "id": "KfsxuuU9UM4",
-      "displayInReports": false,
-      "skipSynchronization": false,
-      "renderOptionsAsRadio": false,
-      "compulsory": false,
-      "skipAnalytics": false,
-      "allowProvidedElsewhere": false,
-      "sortOrder": 2,
-      "allowFutureDate": false,
-      "programStage": { "id": "nN0GtXmGhvi" },
-      "dataElement": { "id": "EZfu1R3vdSe" }
-    }
-  ],
-  "programRuleVariables": [
-    {
-      "id": "VkhzN9gHAUJ",
-      "name": "zzTest number var 1",
-      "programRuleVariableSourceType": "DATAELEMENT_CURRENT_EVENT",
-      "useCodeForOptionSet": false,
-      "valueType": "NUMBER",
-      "program": { "id": "aUbnwuv5D2z" },
-      "dataElement": { "id": "IWLWOXyHwFb" }
-    },
-    {
-      "id": "Hv83fT0LeEV",
-      "name": "zzTest number var 2",
-      "programRuleVariableSourceType": "DATAELEMENT_CURRENT_EVENT",
-      "useCodeForOptionSet": false,
-      "valueType": "NUMBER",
-      "program": { "id": "aUbnwuv5D2z" },
-      "dataElement": { "id": "EZfu1R3vdSe" }
+      "id": "ProgramUid1",
+      "name": "zzTest program",
+      "shortName": "zzTest program",
+      "programType": "WITHOUT_REGISTRATION"
     }
   ],
   "programRules": [
     {
-      "id": "YKxrqRMonw2",
-      "name": "zzTest rule - error if var 1 is larger than var 2",
-      "condition": "#{zzTest number var 1} > #{zzTest number var 2}",
-      "program": { "id": "aUbnwuv5D2z" },
-      "programRuleActions": [{ "id": "HMAVLnd1bZ8" }]
+      "id": "PrgRuleUid1",
+      "name": "zzTest rule",
+      "condition": "true",
+      "program": { "id": "ProgramUid1" },
+      "programRuleActions": [{ "id": "PrgRuleAct1" }]
     }
   ],
   "programRuleActions": [
     {
-      "id": "HMAVLnd1bZ8",
+      "id": "PrgRuleAct1",
       "programRuleActionType": "SHOWERROR",
-      "evaluationTime": "ALWAYS",
-      "content": "input 1 is greater than input 2",
-      "evaluationEnvironments": ["ANDROID", "WEB"]
+      "content": "input 1 is greater than input 2"
     }
   ]
 }


### PR DESCRIPTION
## Issue
Importing a `ProgramRuleAction` with no ref to a `ProgramRule` results in `NullPointerException` & the import finishes unexpectedly.
Import/Export app UI gets this response when importing async:
```json
[
    {
        "level": "ERROR",
        "category": "METADATA_IMPORT",
        "message": "Cannot invoke \"org.hisp.dhis.programrule.ProgramRule.getProgram()\" because \"rule\" is null",
        "completed": true,
        "uid": "iZ4eX8gGB0e",
        "id": "iZ4eX8gGB0e",
        "time": "2026-08-25T10:49:28.757"
    }
]
```

## Cause
Import payload has `ProgramRuleAction` with no ref to a `ProgramRule`. Causes a `NPE` and abruptly stops the import job.

## Fix
Check that a `ProgramRuleAction` has a `ProgramRule` before continuing the import flow.
Report an error if there is no `ProgramRule` attached, which allows the import job to continue.

## Testing
Added tests that check importing a payload with a `ProgramRuleAction` without a `ProgramRule` ref.
- `atomicMode=ALL` -> no objects imported and object report contains error detailing the missing ref issue
- `atomicMode=NONE` -> valid objects still imported and invalid `ProgramRuleAction` ignored with an error report