### PR TITLE
fix: clean up program indicator dimensions on PI deletion

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AnalyticalObjectService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AnalyticalObjectService.java
@@ -63,6 +63,8 @@ public interface AnalyticalObjectService<T extends AnalyticalObject> {
 
   List<T> getAnalyticalObjects(ProgramIndicator programIndicator);
 
+  List<T> getAnalyticalObjectsByDataDimension(ProgramIndicator programIndicator);
+
   List<T> getAnalyticalObjects(Period period);
 
   List<T> getAnalyticalObjects(OrganisationUnit organisationUnit);

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AnalyticalObjectStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AnalyticalObjectStore.java
@@ -63,6 +63,8 @@ public interface AnalyticalObjectStore<T extends AnalyticalObject>
 
   List<T> getAnalyticalObjects(ProgramIndicator programIndicator);
 
+  List<T> getAnalyticalObjectsByDataDimension(ProgramIndicator programIndicator);
+
   List<T> getByDataElementDimensionsWithAnyOf(List<DataElement> dataElements);
 
   List<T> getAnalyticalObjects(Period period);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/GenericAnalyticalObjectDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/GenericAnalyticalObjectDeletionHandler.java
@@ -95,6 +95,28 @@ public abstract class GenericAnalyticalObjectDeletionHandler<
         AnalyticalObject::removeDataDimensionItem);
   }
 
+  /**
+   * Removes the given {@link ProgramIndicator} from the {@code programIndicatorDimensions} of any
+   * analytical object referencing it, e.g. as a disaggregation in a tracker/event line list.
+   * Unlike {@link #deleteProgramIndicator(ProgramIndicator)}, this only touches {@code
+   * programIndicatorDimensions} and must only be wired up for analytical object types that
+   * actually persist that collection (currently event visualizations, event reports and event
+   * charts), since it is not mapped on all {@link BaseAnalyticalObject} subtypes.
+   */
+  protected final void deleteProgramIndicatorDimension(ProgramIndicator programIndicator) {
+    List<T> analyticalObjects = service.getAnalyticalObjectsByDataDimension(programIndicator);
+
+    for (T analyticalObject : analyticalObjects) {
+      analyticalObject
+          .getProgramIndicatorDimensions()
+          .removeIf(
+              dimension ->
+                  dimension != null && programIndicator.equals(dimension.getProgramIndicator()));
+
+      service.update(analyticalObject);
+    }
+  }
+
   protected final void deleteOrganisationUnit(OrganisationUnit organisationUnit) {
     removeItem(
         service.getAnalyticalObjects(organisationUnit),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/GenericAnalyticalObjectDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/GenericAnalyticalObjectDeletionHandler.java
@@ -95,14 +95,6 @@ public abstract class GenericAnalyticalObjectDeletionHandler<
         AnalyticalObject::removeDataDimensionItem);
   }
 
-  /**
-   * Removes the given {@link ProgramIndicator} from the {@code programIndicatorDimensions} of any
-   * analytical object referencing it, e.g. as a disaggregation in a tracker/event line list.
-   * Unlike {@link #deleteProgramIndicator(ProgramIndicator)}, this only touches {@code
-   * programIndicatorDimensions} and must only be wired up for analytical object types that
-   * actually persist that collection (currently event visualizations, event reports and event
-   * charts), since it is not mapped on all {@link BaseAnalyticalObject} subtypes.
-   */
   protected final void deleteProgramIndicatorDimension(ProgramIndicator programIndicator) {
     List<T> analyticalObjects = service.getAnalyticalObjectsByDataDimension(programIndicator);
 
@@ -112,8 +104,6 @@ public abstract class GenericAnalyticalObjectDeletionHandler<
           .removeIf(
               dimension ->
                   dimension != null && programIndicator.equals(dimension.getProgramIndicator()));
-
-      service.update(analyticalObject);
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/GenericAnalyticalObjectService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/GenericAnalyticalObjectService.java
@@ -101,6 +101,12 @@ public abstract class GenericAnalyticalObjectService<T extends AnalyticalObject>
 
   @Override
   @Transactional(readOnly = true)
+  public List<T> getAnalyticalObjectsByDataDimension(ProgramIndicator programIndicator) {
+    return getAnalyticalObjectStore().getAnalyticalObjectsByDataDimension(programIndicator);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
   public List<T> getAnalyticalObjects(Period period) {
     return getAnalyticalObjectStore().getAnalyticalObjects(period);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateAnalyticalObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateAnalyticalObjectStore.java
@@ -136,6 +136,15 @@ public class HibernateAnalyticalObjectStore<T extends BaseAnalyticalObject>
   }
 
   @Override
+  public List<T> getAnalyticalObjectsByDataDimension(ProgramIndicator programIndicator) {
+    String hql =
+        "select distinct c from "
+            + clazz.getName()
+            + " c join c.programIndicatorDimensions d where d.programIndicator = :programIndicator";
+    return getQuery(hql).setParameter("programIndicator", programIndicator).list();
+  }
+
+  @Override
   public List<T> getByDataElementDimensionsWithAnyOf(List<DataElement> dataElements) {
     return getQuery(
             "select distinct c from "

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventchart/EventChartDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventchart/EventChartDeletionHandler.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.system.deletion.DeletionVeto;
 import org.springframework.stereotype.Component;
@@ -61,6 +62,7 @@ public class EventChartDeletionHandler
     whenDeleting(DataElement.class, this::deleteDataElementSpecial);
     whenDeleting(ProgramStage.class, this::deleteProgramStage);
     whenDeleting(Program.class, this::deleteProgram);
+    whenDeleting(ProgramIndicator.class, this::deleteProgramIndicatorDimension);
   }
 
   private void deleteDataElementSpecial(DataElement dataElement) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventreport/EventReportDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventreport/EventReportDeletionHandler.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.system.deletion.DeletionVeto;
 import org.springframework.stereotype.Component;
@@ -61,6 +62,7 @@ public class EventReportDeletionHandler
     whenDeleting(DataElement.class, this::deleteDataElementSpecial);
     whenDeleting(ProgramStage.class, this::deleteProgramStage);
     whenDeleting(Program.class, this::deleteProgram);
+    whenDeleting(ProgramIndicator.class, this::deleteProgramIndicatorDimension);
   }
 
   private void deleteDataElementSpecial(DataElement dataElement) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationDeletionHandler.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.system.deletion.DeletionVeto;
 import org.springframework.stereotype.Component;
@@ -63,6 +64,7 @@ public class EventVisualizationDeletionHandler
     whenDeleting(DataElement.class, this::deleteDataElementSpecial);
     whenDeleting(ProgramStage.class, this::deleteProgramStage);
     whenDeleting(Program.class, this::deleteProgram);
+    whenDeleting(ProgramIndicator.class, this::deleteProgramIndicatorDimension);
   }
 
   private void deleteDataElementSpecial(DataElement dataElement) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/eventvisualization/EventVisualizationDeletionHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/eventvisualization/EventVisualizationDeletionHandlerTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/eventvisualization/EventVisualizationDeletionHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/eventvisualization/EventVisualizationDeletionHandlerTest.java
@@ -12,7 +12,7 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * 3. Neither the name of the copyright holder nor the names of its contributors
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
  * may be used to endorse or promote products derived from this software without
  * specific prior written permission.
  *
@@ -44,12 +44,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Regression test for DHIS2-21936: deleting a {@link ProgramIndicator} that is used as a
- * disaggregation (a {@link TrackedEntityProgramIndicatorDimension}) in a line list previously
- * failed with a foreign key constraint violation on {@code trackedentityprogramindicatordimension}
- * instead of cleanly removing the dangling reference.
- */
 @Transactional
 class EventVisualizationDeletionHandlerTest extends PostgresIntegrationTestBase {
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/eventvisualization/EventVisualizationDeletionHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/eventvisualization/EventVisualizationDeletionHandlerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.eventvisualization;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dbms.DbmsManager;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramIndicator;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Regression test for DHIS2-21936: deleting a {@link ProgramIndicator} that is used as a
+ * disaggregation (a {@link TrackedEntityProgramIndicatorDimension}) in a line list previously
+ * failed with a foreign key constraint violation on {@code trackedentityprogramindicatordimension}
+ * instead of cleanly removing the dangling reference.
+ */
+@Transactional
+class EventVisualizationDeletionHandlerTest extends PostgresIntegrationTestBase {
+
+  @Autowired private IdentifiableObjectManager manager;
+  @Autowired private EventVisualizationStore eventVisualizationStore;
+  @Autowired private ProgramService programService;
+  @Autowired private DbmsManager dbmsManager;
+
+  @Test
+  @DisplayName(
+      "deleting a Program Indicator used as a line list program indicator dimension succeeds and removes the dangling dimension")
+  void testDeleteProgramIndicatorUsedInProgramIndicatorDimension() {
+    Program program = createProgram('A');
+    programService.addProgram(program);
+
+    ProgramIndicator programIndicator =
+        createProgramIndicator('A', program, "V{enrollment_count}", "true");
+    manager.save(programIndicator);
+
+    EventVisualization eventVisualization = createEventVisualization('A', program);
+    eventVisualization
+        .getProgramIndicatorDimensions()
+        .add(new TrackedEntityProgramIndicatorDimension(programIndicator, null, null));
+    eventVisualizationStore.save(eventVisualization);
+    dbmsManager.clearSession();
+
+    manager.delete(manager.get(ProgramIndicator.class, programIndicator.getUid()));
+    dbmsManager.flushSession();
+
+    assertNull(manager.get(ProgramIndicator.class, programIndicator.getUid()));
+
+    EventVisualization reloaded = eventVisualizationStore.getByUid(eventVisualization.getUid());
+    assertTrue(reloaded.getProgramIndicatorDimensions().isEmpty());
+  }
+}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-21936
### Issue and fix
- Deleting a Program Indicator used as a disaggregation dimension in a line list (event visualization, event report or event chart) failed with a raw foreign key violation on `trackedentityprogramindicatordimension`
- Since none of those deletion handlers removed the dangling reference before the delete. Add a dedicated cleanup path and wire it into all three handlers.

### Test
- Added test
- Manually tested on local following test step in jira 
<img width="1423" height="1137" alt="Screenshot 2026-09-01 at 1 47 34 AM" src="https://github.com/user-attachments/assets/aa34a7a0-8552-4a95-8f3c-747d335db452" />

