### PR TITLE
fix(DHIS2-22034): datavalue audit trigger uses dedicated sequence instead of hibernate_sequence

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_23__fix_datavalueaudit_sequence.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.44/V2_44_23__fix_datavalueaudit_sequence.sql
@@ -1,0 +1,50 @@
+-- DHIS2-22034: the datavalue audit trigger introduced in V2_43_17 hardcodes
+-- nextval('hibernate_sequence') for datavalueauditid, instead of the dedicated
+-- datavalueaudit_sequence that DataValueChangelog.hbm.xml declares as the id generator.
+-- As a result datavalueaudit_sequence has been dead since 2.43, while hibernate_sequence
+-- takes on extra unrelated churn.
+
+-- Reseed the dedicated sequence past any ids already inserted via hibernate_sequence since
+-- V2_43_17, so switching the trigger back to it below cannot collide with an existing PK value.
+select setval('datavalueaudit_sequence', coalesce((select max(datavalueauditid) from datavalueaudit), 1));
+
+CREATE OR REPLACE FUNCTION log_datavalue_audit()
+    RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' OR
+       (TG_OP = 'UPDATE' AND (
+           OLD.value IS DISTINCT FROM NEW.value OR OLD.deleted IS DISTINCT FROM NEW.deleted
+       ))
+    THEN
+        INSERT INTO datavalueaudit (
+            datavalueauditid,
+            created,
+            modifiedby,
+            dataelementid,
+            periodid,
+            organisationunitid,
+            categoryoptioncomboid,
+            attributeoptioncomboid,
+            value,
+            audittype
+        )
+        VALUES (
+           nextval('datavalueaudit_sequence'),
+           now(),
+           left(NEW.storedby, 100),
+           NEW.dataelementid,
+           NEW.periodid,
+           NEW.sourceid,
+           NEW.categoryoptioncomboid,
+           NEW.attributeoptioncomboid,
+           NEW.value,
+           CASE
+               WHEN TG_OP = 'INSERT' THEN 'CREATE'
+               WHEN NEW.deleted AND (OLD.deleted IS NULL OR NOT OLD.deleted) THEN 'DELETE'
+               ELSE 'UPDATE'
+           END
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueChangelogStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueChangelogStoreTest.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -60,10 +61,15 @@ class DataValueChangelogStoreTest extends PostgresIntegrationTestBase {
   @Autowired private IdentifiableObjectManager manager;
   @Autowired private CategoryService categoryService;
   @Autowired private PeriodService periodService;
+  @Autowired private JdbcTemplate jdbcTemplate;
 
   private CategoryOptionCombo coc1;
   private CategoryOptionCombo coc2;
   private CategoryOptionCombo coc3;
+
+  private DataElement dataElementA;
+  private Period periodA;
+  private OrganisationUnit orgUnitA;
 
   @BeforeEach
   void setUp() {
@@ -79,13 +85,12 @@ class DataValueChangelogStoreTest extends PostgresIntegrationTestBase {
     coc3.setCategoryCombo(categoryService.getDefaultCategoryCombo());
     categoryService.addCategoryOptionCombo(coc3);
 
-    DataElement dataElementA = createDataElement('A');
+    dataElementA = createDataElement('A');
     DataElement dataElementB = createDataElement('B');
     DataElement dataElementC = createDataElement('C');
     manager.save(List.of(dataElementA, dataElementB, dataElementC));
 
-    Period periodA =
-        createPeriod(new MonthlyPeriodType(), getDate(2017, 1, 1), getDate(2017, 1, 31));
+    periodA = createPeriod(new MonthlyPeriodType(), getDate(2017, 1, 1), getDate(2017, 1, 31));
     Period periodB =
         createPeriod(new MonthlyPeriodType(), getDate(2018, 1, 1), getDate(2017, 1, 31));
     Period periodC =
@@ -94,7 +99,7 @@ class DataValueChangelogStoreTest extends PostgresIntegrationTestBase {
     periodService.addPeriod(periodB);
     periodService.addPeriod(periodC);
 
-    OrganisationUnit orgUnitA = createOrganisationUnit('A');
+    orgUnitA = createOrganisationUnit('A');
     OrganisationUnit orgUnitB = createOrganisationUnit('B');
     OrganisationUnit orgUnitC = createOrganisationUnit('C');
     manager.save(List.of(orgUnitA, orgUnitB, orgUnitC));
@@ -148,6 +153,32 @@ class DataValueChangelogStoreTest extends PostgresIntegrationTestBase {
     assertTrue(dvaCoc1After.isEmpty(), "There should be 0 audits referencing Cat Opt Combo 1");
     assertTrue(dvaCoc2After.isEmpty(), "There should be 0 audits referencing Cat Opt Combo 2");
     assertEquals(2, dvaCoc3After.size(), "There should be 2 audits referencing Cat Opt Combo 3");
+  }
+
+  @Test
+  @DisplayName("New datavalueaudit rows get their id from datavalueaudit_sequence")
+  void testAuditRowIdComesFromDedicatedSequence() {
+    long hibernateSeqBefore = getSequenceValue("hibernate_sequence");
+    long dedicatedSeqBefore = getSequenceValue("datavalueaudit_sequence");
+
+    // a combination not already inserted in setUp(), so the trigger fires a fresh CREATE audit
+    addDataValues(createDataValue(dataElementA, periodA, orgUnitA, coc2, coc2, "99"));
+
+    long hibernateSeqAfter = getSequenceValue("hibernate_sequence");
+    long dedicatedSeqAfter = getSequenceValue("datavalueaudit_sequence");
+
+    assertEquals(
+        dedicatedSeqBefore + 1,
+        dedicatedSeqAfter,
+        "datavalueaudit_sequence should advance by exactly 1 for the new audit row");
+    assertEquals(
+        hibernateSeqBefore,
+        hibernateSeqAfter,
+        "hibernate_sequence must not be consumed by the datavalue audit trigger");
+  }
+
+  private long getSequenceValue(String sequenceName) {
+    return jdbcTemplate.queryForObject("select last_value from " + sequenceName, Long.class);
   }
 
   private void addDataValues(DataValue... values) {


### PR DESCRIPTION
## Summary
- `log_datavalue_audit()` (introduced in `V2_43_17__data_entry_import_adjustments.sql`) hardcodes `nextval('hibernate_sequence')` for `datavalueauditid`, instead of the dedicated `datavalueaudit_sequence` that `DataValueChangelog.hbm.xml` already declares as the id generator.
- As a result, `datavalueaudit_sequence` has been dead since 2.43, while `hibernate_sequence` absorbs unrelated churn from every new data value audit row.
- `V2_44_23__fix_datavalueaudit_sequence.sql` reseeds `datavalueaudit_sequence` past any ids already issued via `hibernate_sequence` since the bug was introduced (avoiding PK collisions on upgrade), then repoints the trigger's `nextval()` call at the correct sequence.

Closes DHIS2-22034.

## Test plan
- [x] Added `DataValueChangelogStoreTest#testAuditRowIdComesFromDedicatedSequence`, asserting `datavalueaudit_sequence` advances by 1 and `hibernate_sequence` is untouched when a new audit row is written.
- [x] Confirmed the new test fails against the unfixed trigger (`expected: <2> but was: <1>`) to rule out a vacuous test.
- [x] Confirmed `DataValueChangelogStoreTest` passes in full with the fix applied (`Tests run: 2, Failures: 0, Errors: 0`).

🤖 AI Assisted