### PR TITLE
fix: only generate links when fields expand to href [DHIS2-21856] (2.41)

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -73,6 +73,8 @@ import org.hisp.dhis.webapi.json.domain.JsonUser;
 import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.MediaType;
 
 /**
@@ -99,6 +101,28 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest {
 
     assertTrue(userById.exists());
     assertEquals(id, userById.getId());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {":all", "*", ":simple", "href", "id,href", "id,name,href"})
+  @DisplayName("Single object GET returns href when requested directly or via an expanding preset")
+  void testGetObjectWithHref(String fields) {
+    String id = run(SomeUserId::new);
+    JsonUser user =
+        GET("/users/{id}?fields={fields}", id, fields).content(HttpStatus.OK).as(JsonUser.class);
+    String href = user.getString("href").string();
+    assertNotNull(href);
+    assertTrue(href.endsWith("/users/" + id));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {":owner", ":identifiable", ":nameable", ":persisted", "id,name"})
+  @DisplayName("Single object GET omits href for presets that do not expand to it")
+  void testGetObjectWithoutHref(String fields) {
+    String id = run(SomeUserId::new);
+    JsonUser user =
+        GET("/users/{id}?fields={fields}", id, fields).content(HttpStatus.OK).as(JsonUser.class);
+    assertFalse(user.has("href"));
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -614,8 +614,14 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
 
   private boolean fieldsContains(String match, List<String> fields) {
     for (String field : fields) {
-      // for now assume href/access if * or preset is requested
-      if (field.contains(match) || field.equals("*") || field.startsWith(":")) {
+      // only presets that expand to the href property need link generation;
+      // href is transient (not owner/persisted) and not part of the fixed
+      // identifiable/nameable presets, but it is a simple property, so it is
+      // included by *, :all and :simple
+      if (field.contains(match)
+          || field.equals("*")
+          || field.equals(":all")
+          || field.equals(":simple")) {
         return true;
       }
     }


### PR DESCRIPTION
## Problem

`AbstractFullReadOnlyController#fieldsContains` treated any field preset (`field.startsWith(":")`) as needing `href`. That forced `LinkService.generateLinks(..., deep=true)` and hydrated huge lazy collections (e.g. a user role with ~241k members).

## Fix

Only `*`, `:all`, `:simple`, or an explicit `href` field (including nested `users[href]`) trigger link generation. Same approach as 2.42 #24500, not the master/2.43 PropertyTransformer prune stack.

## Verification

Parameterized tests in `AbstractCrudControllerTest`: href present for `:all`, `*`, `:simple`, `href`, `id,href`, `id,name,href`; absent for `:owner`, `:identifiable`, `:nameable`, `:persisted`, `id,name`. 11/11 pass on H2.

AI Assisted
