### PR TITLE
fix: skip enrollment-notes preheat query for WITHOUT_REGISTRATION synthetic enrollments

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/EnrollmentMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/EnrollmentMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/EnrollmentMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/EnrollmentMapper.java
@@ -65,6 +65,32 @@ public interface EnrollmentMapper extends PreheatMapper<Enrollment> {
   @Mapping(target = "status")
   Enrollment map(Enrollment enrollment);
 
+  /**
+   * Same as {@link #map(Enrollment)} but without {@code notes}, which is a lazy collection. Mapping
+   * it would force a query to load it. Use this for enrollments that are only ever read for their
+   * identifiers (e.g. the synthetic enrollment preheated for WITHOUT_REGISTRATION programs), never
+   * converted or persisted.
+   */
+  @Named("mapWithoutNotes")
+  @BeanMapping(ignoreByDefault = true)
+  @Mapping(target = "id")
+  @Mapping(target = "uid")
+  @Mapping(target = "code")
+  @Mapping(target = "user")
+  @Mapping(target = "completedBy")
+  @Mapping(target = "completedDate")
+  @Mapping(target = "program", qualifiedByName = "program")
+  @Mapping(target = "trackedEntity")
+  @Mapping(target = "organisationUnit")
+  @Mapping(target = "created")
+  @Mapping(target = "occurredDate")
+  @Mapping(target = "enrollmentDate")
+  @Mapping(target = "deleted")
+  @Mapping(target = "createdByUserInfo")
+  @Mapping(target = "lastUpdatedByUserInfo")
+  @Mapping(target = "status")
+  Enrollment mapWithoutNotes(Enrollment enrollment);
+
   @Named("program")
   @BeanMapping(ignoreByDefault = true)
   @Mapping(target = "id")

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentSupplier.java
@@ -61,10 +61,13 @@ public class EnrollmentSupplier extends AbstractPreheatSupplier {
       programsWithoutRegistration = programStore.getByType(ProgramType.WITHOUT_REGISTRATION);
     }
     if (!programsWithoutRegistration.isEmpty()) {
+      // This enrollment is only ever used as an FK reference for events (it is never converted
+      // or persisted), so its notes are never read: map without them to avoid an unnecessary
+      // lazy-load query per WITHOUT_REGISTRATION program on every import.
       List<Enrollment> enrollments =
-          DetachUtils.detach(
-              EnrollmentMapper.INSTANCE,
-              enrollmentStore.getByPrograms(programsWithoutRegistration));
+          enrollmentStore.getByPrograms(programsWithoutRegistration).stream()
+              .map(EnrollmentMapper.INSTANCE::mapWithoutNotes)
+              .collect(Collectors.toList());
 
       enrollments.forEach(
           e -> {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentSupplierTest.java
@@ -31,6 +31,9 @@ import static org.hisp.dhis.program.ProgramType.WITHOUT_REGISTRATION;
 import static org.hisp.dhis.program.ProgramType.WITH_REGISTRATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
@@ -147,6 +150,24 @@ class EnrollmentSupplierTest extends DhisConvenienceTest {
     assertEnrollmentInPreheat(
         enrollmentWithoutRegistration,
         preheat.getEnrollmentsWithoutRegistration(programWithoutRegistration.getUid()));
+  }
+
+  @Test
+  void verifySupplierDoesNotAccessNotesOfEnrollmentWithoutRegistration() {
+    // On a real (Hibernate-backed) Enrollment, calling getNotes() on an entity that hasn't
+    // had its notes collection initialized yet triggers a lazy-load query. This enrollment is
+    // only ever used by the importer as an FK reference for events, never converted or
+    // persisted, so its notes must never be read during preheat.
+    Enrollment spiedEnrollmentWithoutRegistration = spy(enrollmentWithoutRegistration);
+    when(enrollmentStore.getByPrograms(Lists.newArrayList(programWithoutRegistration)))
+        .thenReturn(List.of(spiedEnrollmentWithoutRegistration));
+    preheat.put(
+        TrackerIdSchemeParam.UID,
+        Lists.newArrayList(programWithRegistration, programWithoutRegistration));
+
+    this.supplier.preheatAdd(params, preheat);
+
+    verify(spiedEnrollmentWithoutRegistration, never()).getNotes();
   }
 
   private void assertEnrollmentInPreheat(Enrollment expected, Enrollment actual) {


### PR DESCRIPTION
## Summary

- `EnrollmentSupplier` preheats a synthetic `Enrollment` for every `WITHOUT_REGISTRATION` program an import touches. It used the shared preheat `EnrollmentMapper`, whose `@Mapping(target = "notes")` forces Hibernate to lazy-load `enrollment_notes`/`note` for every such enrollment — even though this synthetic entity is only ever used as an FK reference for events (`event.setEnrollment(...)`) and is never converted or persisted, so its notes are never read. On a single-event import this fires one dead query per `WITHOUT_REGISTRATION` program, every time.
- Added `EnrollmentMapper.mapWithoutNotes(Enrollment)` — same mapping as `map()` minus `notes` — and switched `EnrollmentSupplier` to use it.
- `EnrollmentStrategy` (which preheats *real* enrollments referenced by UID in a tracker payload) keeps using the notes-inclusive `map()`: `AbstractTrackerPersister` calls `entityManager.merge(...)` on update, and `Enrollment.notes` is `cascade="all-delete-orphan"`, so skipping the eager load there would silently delete every existing note on every enrollment update. The fix is scoped to `EnrollmentSupplier` only.
- Confirmed the same `@Mapping(target = "notes")` exists on master too, so this is not a 2.41-only regression, just a 2.41-only fix for now (consistent with prior single-event preheat fixes on this branch).

Found via a Glowroot trace on a production single-event import, live-validated: smoke-tested a built `dhis.war` against the target instance and confirmed the query disappears from the trace.

## Test plan

- [x] New unit test `EnrollmentSupplierTest.verifySupplierDoesNotAccessNotesOfEnrollmentWithoutRegistration` spies on a real `Enrollment` and asserts `getNotes()` is never called during preheat; confirmed it fails against pre-fix code (Mockito pointed at `EnrollmentMapperImpl.map()`), passes post-fix.
- [x] Full `preheat`/`converter`/`bundle` package regression sweep in `dhis-service-tracker`: 129 tests, 0 failures.
- [x] Built `dhis.war` from this branch merged into a downstream integration branch and smoke-tested against a production-like single-event import; confirmed the `enrollment_notes JOIN note` query no longer appears in the trace.
