### PR TITLE
fix: add correct dcr endpoint to auth bypass list [DHIS2-22056][2.42] (#22519)

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
@@ -47,6 +47,7 @@ import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
+import jakarta.servlet.http.HttpSession;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
@@ -77,6 +78,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.jackson2.SecurityJackson2Modules;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
@@ -98,6 +100,7 @@ import org.springframework.security.oauth2.server.authorization.settings.Authori
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
@@ -443,6 +446,40 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
             > Instant.now().plus(30, ChronoUnit.SECONDS).getEpochSecond());
     assertNotNull(claims.get("jti"));
     assertNotNull(claims.get("iat"));
+  }
+
+  @Test
+  @DisplayName("Unauthenticated enroll request is saved and resumed after form login")
+  void testEnrollEndpointIsResumedAfterLogin() throws Exception {
+    // Given an unauthenticated call to the enroll endpoint, like the Android Capture app does
+    MvcResult result =
+        mvc.perform(
+                get("/api/auth/enrollDevice?redirectUri=dhis2oauth://oauth&state=abc")
+                    .accept(MediaType.TEXT_HTML))
+            // Then the user is sent to the login page
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+    String location = result.getResponse().getHeader(HttpHeaders.LOCATION);
+    assertNotNull(location);
+    assertTrue(location.contains("login"), location);
+
+    // And the request is saved in a session so it can be resumed after login. Without this the
+    // login app has no saved request and sends the user to the dashboard instead of the device.
+    HttpSession session = result.getRequest().getSession(false);
+    assertNotNull(session, "enroll request must create a session holding the saved request");
+
+    // When the user logs in on that session
+    mvc.perform(
+            post("/api/auth/login")
+                .session((MockHttpSession) session)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"admin\",\"password\":\"district\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.loginStatus").value("SUCCESS"))
+        // Then the login response points back to the enroll endpoint, not the dashboard
+        .andExpect(
+            jsonPath("$.redirectUrl")
+                .value("/api/auth/enrollDevice?redirectUri=dhis2oauth://oauth&state=abc"));
   }
 
   private String doClientRegistrationRequest(String iat, KeyPair keyPair) throws Exception {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
@@ -494,6 +494,8 @@ class DcrWithJwksTest extends ControllerWithJwtTokenAuthTestBase {
                 keyPair
                     .jwkSet())); // Inline JWKS , note jwks_uri is also set but should be ignored,
     // validation will fail if not set, only jwks is used
+    // NOTE: Scope is defined here BUT this is only because we use client_credentials grant
+    // when using /authorize first in the real world, you define scope in there.
   }
 
   private String createClientAndIat() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java
@@ -156,6 +156,10 @@ class JwtBearerTokenTest extends ControllerWithJwtTokenAuthTestBase {
         GET("/me", JwtTokenHeader("NOT_A_JWT_TOKEN")));
   }
 
+  /**
+   * This error happens when using ephemeral signing keys, so for example when you restart the
+   * server, the access tokens issued before the restart will no longer be valid.
+   */
   @Test
   void testExpiredToken() {
     setupTestingProvider(CLIENT_ID_1, TEST_PROVIDER_ONE_NAME, TEST_PROVIDER_ONE_URI);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -158,7 +158,7 @@ public class DhisWebApiWebSecurityConfig {
     private static final Pattern p2 = Pattern.compile("^/apps/.+", Pattern.CASE_INSENSITIVE);
     private static final Pattern p3 = Pattern.compile("^/dhis-web-.+", Pattern.CASE_INSENSITIVE);
     private static final Pattern p4 =
-        Pattern.compile("^/api/deviceClients/.+", Pattern.CASE_INSENSITIVE);
+        Pattern.compile("^/api/auth/enrollDevice", Pattern.CASE_INSENSITIVE);
     private static final Pattern p5 =
         Pattern.compile("^/oauth2/authorize", Pattern.CASE_INSENSITIVE);
     private final List<Pattern> includePatterns = new ArrayList<>(List.of(p1, p2, p3, p4, p5));


### PR DESCRIPTION
Backport of #22519 to 2.42, plus a regression test.

## Problem
`GET /api/auth/enrollDevice` (Android Capture app device enrollment via OAuth2 DCR) is not in `CustomRequestMatcher`, so the unauthenticated request is never saved in the request cache and no session is created before the login redirect. After login, `POST /api/auth/login` returns `redirectUrl: "/"` and the user lands on the dashboard instead of being redirected back to the app with the IAT. Retrying works because the session is by then authenticated. 2.43 and master are fine.

## Fix
Replace the stale `^/api/deviceClients/.+` pattern with `^/api/auth/enrollDevice`, as on master. The `SystemSettings` hunk of the original PR was already on 2.42.

## Test
`DcrWithJwksTest.testEnrollEndpointIsResumedAfterLogin`: unauthenticated `enrollDevice` must redirect to login and create a session with the saved request; a `POST /api/auth/login` on that session must return `redirectUrl` pointing back at `enrollDevice`. Fails on the old matcher at the session assertion. Same test is being added to 2.43 and master.

## Verified
- curl on patched 2.42.7-SNAPSHOT: `enrollDevice` 302 now carries `Set-Cookie: JSESSIONID`, login returns `redirectUrl: "/api/auth/enrollDevice?..."`, following it yields `302 dhis2oauth://oauth?iat=...`.
- Android Capture app in a fresh emulator against the patched server: login returns straight to the app.
- `DcrWithJwksTest`, `JwtBearerTokenTest` green.

Jira: [DHIS2-22056](https://dhis2.atlassian.net/browse/DHIS2-22056)

AI Assisted


[DHIS2-22056]: https://dhis2.atlassian.net/browse/DHIS2-22056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ