### PR TITLE
fix: Collection validation in scheme [DHIS2-22026]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -130,7 +130,6 @@ import org.hisp.dhis.visualization.LegendDefinitions;
 public abstract class BaseAnalyticalObject extends BaseNameableObject implements AnalyticalObject {
 
   private static final List<String> STATIC_DIMS = List.of(LONGITUDE_DIM_ID, LATITUDE_DIM_ID);
-  private static final int TEN_YEARS_OF_DAILY_PERIODS = 10 * 365;
 
   /** Line and axis labels. */
   protected String domainAxisLabel;
@@ -1410,7 +1409,6 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
   @JsonProperty
   @JacksonXmlElementWrapper(localName = "rawPeriods", namespace = DxfNamespaces.DXF_2_0)
   @JacksonXmlProperty(localName = "rawPeriods", namespace = DxfNamespaces.DXF_2_0)
-  @PropertyRange(max = TEN_YEARS_OF_DAILY_PERIODS)
   public List<String> getRawPeriods() {
     return rawPeriods;
   }

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/HibernatePropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/HibernatePropertyIntrospector.java
@@ -188,7 +188,6 @@ public class HibernatePropertyIntrospector implements PropertyIntrospector {
       property.setUnique(column.isUnique());
       property.setRequired(!column.isNullable());
       property.setMin(0d);
-      property.setMax((double) column.getLength());
       property.setLength(column.getLength());
 
       if (type instanceof TextType) {

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/HibernatePropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/HibernatePropertyIntrospector.java
@@ -188,6 +188,7 @@ public class HibernatePropertyIntrospector implements PropertyIntrospector {
       property.setUnique(column.isUnique());
       property.setRequired(!column.isNullable());
       property.setMin(0d);
+      property.setMax((double) column.getLength());
       property.setLength(column.getLength());
 
       if (type instanceof TextType) {

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/HibernatePropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/HibernatePropertyIntrospector.java
@@ -190,9 +190,13 @@ public class HibernatePropertyIntrospector implements PropertyIntrospector {
       property.setRequired(!column.isNullable());
       property.setMin(0d);
 
+      boolean isCollectionOrCustomType =
+          type instanceof CustomType
+              || (property.getGetterMethod() != null
+                  && Collection.class.isAssignableFrom(property.getGetterMethod().getReturnType()));
+
       // Skip max length for collections.
-      if (!(type instanceof CustomType)
-          || !Collection.class.isAssignableFrom(property.getGetterMethod().getReturnType())) {
+      if (!isCollectionOrCustomType) {
         property.setMax((double) column.getLength());
       }
 

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/HibernatePropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/HibernatePropertyIntrospector.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.schema.introspection;
 
 import jakarta.persistence.EntityManagerFactory;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -188,7 +189,13 @@ public class HibernatePropertyIntrospector implements PropertyIntrospector {
       property.setUnique(column.isUnique());
       property.setRequired(!column.isNullable());
       property.setMin(0d);
-      property.setMax((double) column.getLength());
+
+      // Skip max length for collections.
+      if (!(type instanceof CustomType)
+          || !Collection.class.isAssignableFrom(property.getGetterMethod().getReturnType())) {
+        property.setMax((double) column.getLength());
+      }
+
       property.setLength(column.getLength());
 
       if (type instanceof TextType) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -29,17 +29,25 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.http.HttpAssertions.assertStatus;
+import static org.hisp.dhis.http.HttpStatus.CREATED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.dashboard.DashboardItem;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.http.HttpStatus;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
@@ -122,6 +130,49 @@ class DashboardControllerTest extends PostgresControllerIntegrationTestBase {
             .findFirst();
     assertTrue(dashboardItem.isPresent());
     assertEquals("gyYXi0rXAIc", dashboardItem.get().getVisualization().getUid());
+  }
+
+  @Test
+  void testPostContainingOver255Favorites() {
+    // Given
+    Set<String> randomUids = new HashSet<>();
+    int favoritesTotal = 300;
+
+    for (int i = 0; i < favoritesTotal; i++) {
+      randomUids.add("'" + RandomStringUtils.randomAlphanumeric(11) + "'");
+    }
+
+    String body =
+        """
+            {
+              'name': 'some name',
+              'restrictFilters': false,
+              'allowedFilters': [],
+              'favorites': [
+                _favorites
+              ],
+              'displayName': 'Antenatal Care',
+              'access': {
+                'manage': true,
+                'write': true,
+                'read': true,
+                'update': true,
+                'delete': true
+              }
+            }
+          """
+            .replaceFirst(
+                "_favorites",
+                randomUids.stream().toList().stream().collect(Collectors.joining(",")));
+
+    // When
+    String uid = assertStatus(CREATED, POST("/dashboards/", body));
+
+    // Then
+    JsonObject response = GET("/dashboards/" + uid + "?fields=favorites").content();
+
+    JsonList<JsonObject> favorites = response.getList("favorites", JsonObject.class);
+    assertEquals(favoritesTotal, favorites.size());
   }
 
   @Test


### PR DESCRIPTION
There is a validation that triggers for Collection types, enforcing the max size of 255 elements.
This limitation is a mistake and shouldn't be there unless a `max/min` size is defined programmatically at the `entity` level.

The PR removes this enforcement for Collection types. For types where a default `max` size still needs some enforcement (by default), the flow still applies it as expected, so no breaking changes in this sense.

Also, with this change, the `max` limit on Periods is no longer required. Hence, they were removed.