### PR TITLE
fix: make 2.43 datavalueaudit trigger migration ownership-safe and reseed the sequence

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_68__fix_datavalueaudit_sequence.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.43/V2_43_68__fix_datavalueaudit_sequence.sql
@@ -1,4 +1,27 @@
-CREATE OR REPLACE FUNCTION log_datavalue_audit()
+-- DHIS2-22034: the datavalue audit trigger introduced in V2_43_17 hardcodes
+-- nextval('hibernate_sequence') for datavalueauditid, instead of the dedicated
+-- datavalueaudit_sequence that DataValueChangelog.hbm.xml declares as the id generator.
+-- As a result datavalueaudit_sequence has been dead since V2_43_17, while hibernate_sequence
+-- takes on extra unrelated churn.
+
+-- Reseed the dedicated sequence past any ids already inserted via hibernate_sequence since
+-- V2_43_17, so switching the trigger back to it below cannot collide with an existing PK value.
+select setval('datavalueaudit_sequence', coalesce((select max(datavalueauditid) from datavalueaudit), 1));
+
+-- DHIS2-22059: log_datavalue_audit() was originally created by V2_43_17. CREATE OR REPLACE
+-- FUNCTION on a pre-existing function requires the connecting role to already own it (or be
+-- superuser) - on environments where migrations now run as a different role than the one
+-- that ran V2_43_17 (e.g. a database refreshed from a dump/snapshot without normalizing
+-- object ownership), replacing it in place fails with "must be owner of function
+-- log_datavalue_audit" and blocks this migration (and, since migrations run as a single
+-- grouped transaction, every migration after it) from ever applying.
+--
+-- Instead, define the corrected trigger logic under a new function name (which the current
+-- role always owns, since it's the one creating it) and repoint the trigger to it.
+-- Retargeting a trigger only requires ownership of the table it's defined on (datavalue),
+-- not of the function it calls, so this works regardless of who owns the old
+-- log_datavalue_audit() function.
+CREATE OR REPLACE FUNCTION log_datavalue_audit_v2()
     RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP = 'INSERT' OR
@@ -38,3 +61,22 @@ BEGIN
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_datavalue_audit ON datavalue;
+
+CREATE TRIGGER trg_datavalue_audit
+    AFTER INSERT OR UPDATE ON datavalue
+    FOR EACH ROW
+    EXECUTE FUNCTION log_datavalue_audit_v2();
+
+-- Best-effort cleanup of the now-unused function. Only succeeds when we happen to own
+-- it; when we don't (the exact scenario this migration exists to route around), skip
+-- rather than fail the migration.
+DO $$
+BEGIN
+    DROP FUNCTION IF EXISTS log_datavalue_audit();
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        NULL;
+END;
+$$;


### PR DESCRIPTION
## Summary

Follow-up to #25019 (master) for the 2.43 line, targeting `2.43` since PR #25010 (which added `V2_43_68`) is already merged there.

- **Ownership bug (same as master):** `V2_43_68` used `CREATE OR REPLACE FUNCTION log_datavalue_audit()` on a function originally created by `V2_43_17`. Postgres requires the connecting role to already own the function (or be superuser) to replace it - on environments where migrations run as a different role than the one that ran `V2_43_17` (e.g. a database refreshed from a dump/snapshot without normalizing object ownership), it fails with `must be owner of function log_datavalue_audit`. Because `FlywayConfig` groups all pending migrations into a single transaction, that failure blocks every later migration too - a follow-up migration can't route around it.
- **Second bug found while porting:** `V2_43_68` as merged is also missing the `select setval('datavalueaudit_sequence', ...)` reseed that `V2_44_23` has on master. `datavalueaudit_sequence` has been dead since `V2_43_17` in the 2.43 line too, so switching the trigger back to it without reseeding emits an id that already exists in `datavalueaudit` (inserted via `hibernate_sequence` in the meantime) - `duplicate key value violates unique constraint "datavalueaudit_pkey"` on the very next data value save. This one isn't ownership-dependent - it would hit every 2.43 environment that applies the migration as merged, once someone saves a data value.

Fix (same pattern as #25019): define the trigger logic under a new function name (`log_datavalue_audit_v2`, always owned by whoever creates it) and repoint `trg_datavalue_audit` to it - retargeting a trigger only needs table ownership, not function ownership. Re-added the missing `setval()` reseed.

## Test plan

- [x] Reproduced the missing-reseed PK collision independently (sequence drift only, matching function owner) against a local Postgres 14 instance - confirmed `duplicate key value violates unique constraint "datavalueaudit_pkey"` with the merged `V2_43_68`.
- [x] Reproduced both defects together (function owned by a different role + sequence drift) - confirmed the merged `V2_43_68` fails on the ownership check; the rewritten version applies cleanly in a single transaction, repoints the trigger, and produces correct non-colliding audit rows afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
