### PR TITLE
fix: return 503 instead of 500 when the DB connection pool is exhausted DHIS2-22066

### DIFF
--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityAggregate.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityAggregate.java
@@ -41,6 +41,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
@@ -109,8 +110,17 @@ public class TrackedEntityAggregate {
             getPool(),
             mdc);
 
-    allOf(trackedEntitiesAsync, attributesAsync, enrollmentsAsync, programOwnersAsync).join();
+    try {
+      allOf(trackedEntitiesAsync, attributesAsync, enrollmentsAsync, programOwnersAsync).join();
+    } catch (CompletionException e) {
+      // unwrap so a branch failure keeps its own handling rather than surfacing as a 500
+      if (e.getCause() instanceof RuntimeException cause) {
+        throw cause;
+      }
+      throw e;
+    }
 
+    // these join()s need no unwrapping: allOf above already threw if any branch failed
     Map<String, TrackedEntity> trackedEntities = trackedEntitiesAsync.join();
     Multimap<String, TrackedEntityAttributeValue> attributes = attributesAsync.join();
     Multimap<String, Enrollment> enrollments = enrollmentsAsync.join();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -51,7 +51,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -146,6 +145,10 @@ public class CrudControllerAdvice {
   private static final String GENERIC_ERROR_MESSAGE =
       "An unexpected error has occured. Please contact your system administrator";
 
+  /** Safe to state, unlike the exception message which carries pool sizes and timings. */
+  private static final String NO_CONNECTION_MESSAGE =
+      "The server could not obtain a database connection. Please try again later";
+
   private final List<Class<?>> enumClasses;
 
   public CrudControllerAdvice() {
@@ -227,7 +230,7 @@ public class CrudControllerAdvice {
   /**
    * Reports an exhausted connection pool as 503 so clients retry rather than treat it as a defect.
    * Spring also raises {@link DataAccessResourceFailureException} for failures unrelated to
-   * obtaining a connection, which stay 500. The message is kept generic, see {@link
+   * obtaining a connection, which stay 500 with a message scrubbed by {@link
    * #SENSITIVE_EXCEPTIONS}.
    */
   @ExceptionHandler(DataAccessResourceFailureException.class)
@@ -235,8 +238,7 @@ public class CrudControllerAdvice {
   public WebMessage dataAccessResourceFailureException(DataAccessResourceFailureException ex) {
     log.error(DataAccessResourceFailureException.class.getName(), ex);
     if (failedToObtainConnection(ex)) {
-      return createWebMessage(
-          getExceptionMessage(ex), Status.ERROR, HttpStatus.SERVICE_UNAVAILABLE);
+      return createWebMessage(NO_CONNECTION_MESSAGE, Status.ERROR, HttpStatus.SERVICE_UNAVAILABLE);
     }
     return error(getExceptionMessage(ex));
   }
@@ -246,29 +248,14 @@ public class CrudControllerAdvice {
    * transaction rather than while running a query. Spring wraps that in a {@link
    * TransactionException}, a separate hierarchy from {@link
    * org.springframework.dao.DataAccessException}, so it needs its own handler. Its message is not
-   * scrubbed by {@link #SENSITIVE_EXCEPTIONS}, hence the generic message here.
+   * scrubbed by {@link #SENSITIVE_EXCEPTIONS}, hence the generic message on the 500 branch.
    */
   @ExceptionHandler(CannotCreateTransactionException.class)
   @ResponseBody
   public WebMessage cannotCreateTransactionException(CannotCreateTransactionException ex) {
     log.error(CannotCreateTransactionException.class.getName(), ex);
     if (failedToObtainConnection(ex)) {
-      return createWebMessage(GENERIC_ERROR_MESSAGE, Status.ERROR, HttpStatus.SERVICE_UNAVAILABLE);
-    }
-    return error(GENERIC_ERROR_MESSAGE);
-  }
-
-  /**
-   * Tracker exports fan out over {@link java.util.concurrent.CompletableFuture}, so a connection
-   * failure in one of those threads surfaces wrapped in a {@link CompletionException}, which is
-   * neither a Spring data access nor a transaction exception.
-   */
-  @ExceptionHandler(CompletionException.class)
-  @ResponseBody
-  public WebMessage completionException(CompletionException ex) {
-    log.error(CompletionException.class.getName(), ex);
-    if (failedToObtainConnection(ex)) {
-      return createWebMessage(GENERIC_ERROR_MESSAGE, Status.ERROR, HttpStatus.SERVICE_UNAVAILABLE);
+      return createWebMessage(NO_CONNECTION_MESSAGE, Status.ERROR, HttpStatus.SERVICE_UNAVAILABLE);
     }
     return error(GENERIC_ERROR_MESSAGE);
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -51,6 +51,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -58,6 +59,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.exception.ConstraintViolationException;
+import org.hibernate.exception.JDBCConnectionException;
 import org.hisp.dhis.common.DeleteNotAllowedException;
 import org.hisp.dhis.common.IdentifiableProperty;
 import org.hisp.dhis.common.IllegalQueryException;
@@ -103,11 +105,14 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.jdbc.BadSqlGrammarException;
+import org.springframework.jdbc.CannotGetJdbcConnectionException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.server.resource.BearerTokenError;
+import org.springframework.transaction.CannotCreateTransactionException;
+import org.springframework.transaction.TransactionException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
@@ -217,6 +222,77 @@ public class CrudControllerAdvice {
   @ResponseBody
   public WebMessage restClientExceptionHandler(RestClientException ex) {
     return createWebMessage(ex.getMessage(), Status.ERROR, HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  /**
+   * Reports an exhausted connection pool as 503 so clients retry rather than treat it as a defect.
+   * Spring also raises {@link DataAccessResourceFailureException} for failures unrelated to
+   * obtaining a connection, which stay 500. The message is kept generic, see {@link
+   * #SENSITIVE_EXCEPTIONS}.
+   */
+  @ExceptionHandler(DataAccessResourceFailureException.class)
+  @ResponseBody
+  public WebMessage dataAccessResourceFailureException(DataAccessResourceFailureException ex) {
+    log.error(DataAccessResourceFailureException.class.getName(), ex);
+    if (failedToObtainConnection(ex)) {
+      return createWebMessage(
+          getExceptionMessage(ex), Status.ERROR, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+    return error(getExceptionMessage(ex));
+  }
+
+  /**
+   * Same failure as {@link #dataAccessResourceFailureException}, but raised while starting the
+   * transaction rather than while running a query. Spring wraps that in a {@link
+   * TransactionException}, a separate hierarchy from {@link
+   * org.springframework.dao.DataAccessException}, so it needs its own handler. Its message is not
+   * scrubbed by {@link #SENSITIVE_EXCEPTIONS}, hence the generic message here.
+   */
+  @ExceptionHandler(CannotCreateTransactionException.class)
+  @ResponseBody
+  public WebMessage cannotCreateTransactionException(CannotCreateTransactionException ex) {
+    log.error(CannotCreateTransactionException.class.getName(), ex);
+    if (failedToObtainConnection(ex)) {
+      return createWebMessage(GENERIC_ERROR_MESSAGE, Status.ERROR, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+    return error(GENERIC_ERROR_MESSAGE);
+  }
+
+  /**
+   * Tracker exports fan out over {@link java.util.concurrent.CompletableFuture}, so a connection
+   * failure in one of those threads surfaces wrapped in a {@link CompletionException}, which is
+   * neither a Spring data access nor a transaction exception.
+   */
+  @ExceptionHandler(CompletionException.class)
+  @ResponseBody
+  public WebMessage completionException(CompletionException ex) {
+    log.error(CompletionException.class.getName(), ex);
+    if (failedToObtainConnection(ex)) {
+      return createWebMessage(GENERIC_ERROR_MESSAGE, Status.ERROR, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+    return error(GENERIC_ERROR_MESSAGE);
+  }
+
+  /**
+   * Whether the failure was a failure to obtain a database connection, most commonly an exhausted
+   * connection pool.
+   *
+   * <p>Do not narrow this to transient JDBC exceptions or SQL states: {@code hikari} raises {@code
+   * SQLTransientConnectionException} on pool timeout while {@code unpooled} raises a plain {@code
+   * PSQLException} with state 53300, which is neither transient nor non-transient. What they share
+   * is failing at connection acquisition, which both types below capture.
+   */
+  private static boolean failedToObtainConnection(Throwable ex) {
+    for (Throwable cause = ex; cause != null; cause = cause.getCause()) {
+      if (cause instanceof CannotGetJdbcConnectionException
+          || cause instanceof JDBCConnectionException) {
+        return true;
+      }
+      if (cause.getCause() == cause) {
+        break;
+      }
+    }
+    return false;
   }
 
   @ExceptionHandler(IllegalQueryException.class)

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/CrudControllerAdviceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/CrudControllerAdviceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.SQLException;
+import java.sql.SQLTransientConnectionException;
+import org.hibernate.exception.JDBCConnectionException;
+import org.hisp.dhis.dxf2.webmessage.WebMessage;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.transaction.CannotCreateTransactionException;
+
+/**
+ * Pins the exception chains a failure to obtain a database connection arrives in, so an upgrade
+ * that changes how Hibernate or Spring translate it fails here instead of silently returning 500.
+ */
+class CrudControllerAdviceTest {
+
+  private final CrudControllerAdvice advice = new CrudControllerAdvice();
+
+  @Test
+  void shouldReturnServiceUnavailableWhenHikariPoolTimedOut() {
+    // Hikari leaves the SQL state null when nothing failed underneath, only the wait timed out
+    SQLTransientConnectionException poolTimeout =
+        new SQLTransientConnectionException(
+            "HikariPool-1 - Connection is not available, request timed out after 2000ms", null, 0);
+
+    WebMessage message =
+        advice.cannotCreateTransactionException(
+            new CannotCreateTransactionException(
+                "Could not open JPA EntityManager for transaction",
+                new JDBCConnectionException("Unable to acquire JDBC Connection", poolTimeout)));
+
+    assertEquals(503, message.getHttpStatusCode());
+  }
+
+  @Test
+  void shouldReturnServiceUnavailableWhenDatabaseHasTooManyClients() {
+    // PostgreSQL 53300, class 53 "insufficient resources", which Hibernate does not classify as a
+    // connection error by state. It only reaches the handler via the connection-creator fallback.
+    SQLException tooManyClients =
+        new SQLException("FATAL: sorry, too many clients already", "53300");
+
+    WebMessage message =
+        advice.cannotCreateTransactionException(
+            new CannotCreateTransactionException(
+                "Could not open JPA EntityManager for transaction",
+                new JDBCConnectionException("Unable to acquire JDBC Connection", tooManyClients)));
+
+    assertEquals(503, message.getHttpStatusCode());
+  }
+
+  @Test
+  void shouldReturnInternalServerErrorWhenTheFailureWasNotInObtainingAConnection() {
+    WebMessage message =
+        advice.dataAccessResourceFailureException(
+            new DataAccessResourceFailureException(
+                "Could not copy into LOB stream", new SQLException("stream closed")));
+
+    assertEquals(500, message.getHttpStatusCode());
+  }
+}


### PR DESCRIPTION
Failing to obtain a DB connection returned **HTTP 500 Internal Server Error**, which says "broken, do not retry". Pool exhaustion is transient overload, so it now returns **HTTP 503 Service Unavailable**. No `Retry-After`, we cannot predict when capacity returns.

503 Service Unavailable not 504 Gateway Timeout: 504 means we asked the database and got no timely answer, here no query was ever sent. 504 stays correct for the tracker export deadline ([DHIS2-21390](https://github.com/dhis2/dhis2-core/pull/24970)).

Clients now get:

```json
{"httpStatus":"Service Unavailable","httpStatusCode":503,"status":"ERROR","message":"The server could not obtain a database connection. Please try again later"}
```

## Testing

Sierra Leone DB, 40 concurrent `/api/tracker/trackedEntities` requests, tested with both pool types.

`hikari` with `connection.pool.max_size = 2`, `connection.pool.timeout = 2000` logs:

```
java.sql.SQLTransientConnectionException: actual - Connection is not available, request timed out after 2000ms (total=2, active=2, idle=0, waiting=58)
```

`unpooled` with PostgreSQL `max_connections = 10` logs:

```
org.postgresql.util.PSQLException: FATAL: sorry, too many clients already
```

On master these requests returned HTTP 500. With the fix they return HTTP 503, apart from the filter chain gap below.

## Tracker

The `TrackedEntityAggregate` unwrap is taken from #24970, without it a connection failure in a parallel fetch surfaces as `CompletionException` and stays a 500.

## Known gaps

* Analytics is unaffected, it converts to `QueryRuntimeException(E7131)` before the exception escapes, which maps to 409.
* `CspFilter` calls the `@Transactional` `getCorsWhitelist()`, so it needs a connection of its own:

  ```
  CspFilter.doFilterInternal
    CspFilter.setFrameAncestorsCspRule
      $Proxy290.getCorsWhitelist        <- @Transactional
        JpaTransactionManager.doBegin   <- CannotCreateTransactionException
  ```

  Filters run outside the `DispatcherServlet`, and `@ControllerAdvice` only sees what the dispatcher catches, so this one exception never reaches the new handler and Tomcat renders its own HTML 500 instead. Same failure, same exception type, but thrown one layer too early to map. Fixing it means handling errors in the filter chain, out of scope here.


[DHIS2-21390]: https://dhis2.atlassian.net/browse/DHIS2-21390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ