### PR TITLE
fix: share one connection between Hibernate and JDBC DHIS2-22067

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -84,8 +84,16 @@ public class HibernateConfig {
   }
 
   @Bean
-  public JpaTransactionManager jpaTransactionManager(EntityManagerFactory entityManagerFactory) {
-    return new JpaTransactionManager(entityManagerFactory);
+  public JpaTransactionManager jpaTransactionManager(
+      EntityManagerFactory entityManagerFactory,
+      @Qualifier("actualDataSource") DataSource dataSource) {
+    JpaTransactionManager transactionManager = new JpaTransactionManager(entityManagerFactory);
+    // Must be the same bean instance the JdbcTemplates get. Spring keys transactional connections
+    // by DataSource identity, so without this a @Transactional method mixing Hibernate and
+    // JdbcTemplate takes a second connection which is not enlisted in the transaction: its
+    // statements commit immediately and a rollback does not cover them.
+    transactionManager.setDataSource(dataSource);
+    return transactionManager;
   }
 
   @Bean


### PR DESCRIPTION
`JpaTransactionManager` was created without a `DataSource`, so Spring never registered a `ConnectionHolder` under the `DataSource` key. Every `@Transactional` method mixing Hibernate with a plain `JdbcTemplate` took a second connection from the same pool which was **not enlisted in the transaction**: its statements commit immediately and a rollback does not cover them.

Fixed by passing the same injected `actualDataSource` bean the `JdbcTemplate`s get.

**Why it matters: the org unit merge can destroy data.** [`merge()`](https://github.com/dhis2/dhis2-core/blob/6645798f84b713bbd064c337c84c406037128041/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/orgunit/DefaultOrgUnitMergeService.java#L78-L91) is one transaction over 20 handlers, interleaving Hibernate ones with two raw-JDBC ones that delete `datavalue` and `dataapproval`. Those deletes commit as they run, so a later failure (a tracker handler, deleting the sources, an optimistic lock at commit) rolls back the Hibernate work and leaves the source org units present with their data gone. About a dozen handlers run inside that window.

Introduced in 2.41 by 6eb421d7d285dfdec6b17a86b5258df083c7f982 ("feat: support JPA annotation mapping for object model", #14626, TECH-1517), which swapped `HibernateTransactionManager` for `JpaTransactionManager` and dropped its `setDataSource` call. Affects 2.41, 2.42, 2.43 and master.

Analysis: https://dhis2.atlassian.net/browse/DHIS2-22067
