### PR TITLE
perf: skip per-row AOC data-sharing check for default-CC data set exports

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportStore.java
@@ -50,6 +50,24 @@ public interface DataExportStore {
   UID getAttributeOptionCombo(
       @CheckForNull UID categoryCombo, @Nonnull Stream<UID> categoryOptions);
 
+  /**
+   * Resolves the default attribute option combo for an export that is scoped to data set(s), but
+   * only when every given data set uses the default attribute category combo.
+   *
+   * <p>In that case the only valid attribute option combo is the default one, so it can be applied
+   * as an explicit filter. This allows the export query to skip the (expensive) per-row attribute
+   * option combo data-sharing check that would otherwise scan the entire {@code categoryoptioncombo}
+   * table.
+   *
+   * @param dataSets the data sets that scope the export
+   * @return the UID of the default {@link org.hisp.dhis.category.CategoryOptionCombo} when every
+   *     given data set uses the default attribute {@link org.hisp.dhis.category.CategoryCombo};
+   *     {@code null} when any given data set uses a non-default attribute category combo, or when
+   *     none of the given data sets exist
+   */
+  @CheckForNull
+  UID getDefaultAttributeOptionComboForDataSets(@Nonnull Stream<UID> dataSets);
+
   /*
   Export
    */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportStore.java
@@ -56,8 +56,8 @@ public interface DataExportStore {
    *
    * <p>In that case the only valid attribute option combo is the default one, so it can be applied
    * as an explicit filter. This allows the export query to skip the (expensive) per-row attribute
-   * option combo data-sharing check that would otherwise scan the entire {@code categoryoptioncombo}
-   * table.
+   * option combo data-sharing check that would otherwise scan the entire {@code
+   * categoryoptioncombo} table.
    *
    * @param dataSets the data sets that scope the export
    * @return the UID of the default {@link org.hisp.dhis.category.CategoryOptionCombo} when every

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataExportStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataExportStore.java
@@ -332,6 +332,7 @@ public class HibernateDataExportStore implements DataExportStore {
     return createQuery(sql)
         .setParameter("ds", dataSets)
         .useEqualsOverInForParameters("ds")
+        .eraseNullParameterLines()
         .stream(String.class)
         .map(UID::of)
         .findFirst()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataExportStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataExportStore.java
@@ -305,6 +305,39 @@ public class HibernateDataExportStore implements DataExportStore {
         .orElse(null);
   }
 
+  @CheckForNull
+  @Override
+  public UID getDefaultAttributeOptionComboForDataSets(@Nonnull Stream<UID> dataSets) {
+    // Returns the default category option combo UID only when at least one of the given data sets
+    // exists and every existing one uses the default attribute category combo. A data set with a
+    // missing or non-default attribute category combo yields no row (=> null), disabling the
+    // fast-path so the regular per-row AOC data-sharing check is used instead.
+    String sql =
+        """
+        SELECT coc.uid
+        FROM categoryoptioncombo coc
+        JOIN categorycombos_optioncombos ccoc ON ccoc.categoryoptioncomboid = coc.categoryoptioncomboid
+        JOIN categorycombo cc ON cc.categorycomboid = ccoc.categorycomboid
+        WHERE cc.name = 'default'
+          AND EXISTS (
+            SELECT 1 FROM dataset ds
+            WHERE ds.uid = ANY(:ds)
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM dataset ds
+            LEFT JOIN categorycombo dscc ON dscc.categorycomboid = ds.categorycomboid
+            WHERE ds.uid = ANY(:ds)
+              AND (dscc.name IS NULL OR dscc.name <> 'default')
+          )""";
+    return createQuery(sql)
+        .setParameter("ds", dataSets)
+        .useEqualsOverInForParameters("ds")
+        .stream(String.class)
+        .map(UID::of)
+        .findFirst()
+        .orElse(null);
+  }
+
   @Override
   @Nonnull
   public List<String> getDataSetsNoDataReadAccess(@Nonnull Stream<UID> dataSets) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataExportService.java
@@ -359,15 +359,17 @@ public class DefaultDataExportService implements DataExportService {
     if (ouIn == null) ouIn = anyIn;
     if (degIn == null) degIn = anyIn;
 
+    List<UID> dataSets = decodeIds(DS, dsIn, params.getDataSet());
+
     return DataExportParams.builder()
-        .dataSets(decodeIds(DS, dsIn, params.getDataSet()))
+        .dataSets(dataSets)
         .dataElementGroups(decodeIds(DEG, degIn, params.getDataElementGroup()))
         .dataElements(decodeIds(DE, deIn, params.getDataElement()))
         .organisationUnits(decodeIds(OU, ouIn, params.getOrgUnit()))
         .organisationUnitGroups(decodeIds(OUG, anyIn, params.getOrgUnitGroup()))
         .orgUnitLevel(params.getLevel())
         .categoryOptionCombos(decodeIds(COC, anyIn, params.getCategoryOptionCombo()))
-        .attributeOptionCombos(resolveAttributeOptionCombos(anyIn, params))
+        .attributeOptionCombos(resolveAttributeOptionCombos(anyIn, params, dataSets))
         .periods(decodePeriods(params.getPeriod()))
         .startDate(params.getStartDate())
         .endDate(params.getEndDate())
@@ -383,15 +385,25 @@ public class DefaultDataExportService implements DataExportService {
 
   @Nonnull
   private List<UID> resolveAttributeOptionCombos(
-      IdentifiableProperty anyIn, DataExportParams.Input params) {
+      IdentifiableProperty anyIn, DataExportParams.Input params, List<UID> dataSets) {
     List<UID> attributeOptionCombos = decodeIds(COC, anyIn, params.getAttributeOptionCombo());
-    if (!attributeOptionCombos.isEmpty() || params.getAttributeOptions() == null) {
+    if (!attributeOptionCombos.isEmpty()) {
       return attributeOptionCombos;
     }
-    UID aoc =
-        store.getAttributeOptionCombo(
-            params.getAttributeCombo(), params.getAttributeOptions().stream());
-    return aoc == null ? attributeOptionCombos : List.of(aoc);
+    if (params.getAttributeOptions() != null) {
+      UID aoc =
+          store.getAttributeOptionCombo(
+              params.getAttributeCombo(), params.getAttributeOptions().stream());
+      return aoc == null ? attributeOptionCombos : List.of(aoc);
+    }
+    // Fast path: when the export is scoped to data set(s) that all use the default attribute
+    // category combo, the only valid attribute option combo is the default one. Applying it as an
+    // explicit filter lets the export query skip the per-row AOC data-sharing check.
+    if (!dataSets.isEmpty()) {
+      UID defaultAoc = store.getDefaultAttributeOptionComboForDataSets(dataSets.stream());
+      if (defaultAoc != null) return List.of(defaultAoc);
+    }
+    return attributeOptionCombos;
   }
 
   private List<Order> resolveOrders(DataExportParams.Input params) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataExportServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataExportServiceTest.java
@@ -34,12 +34,19 @@ import static org.hisp.dhis.test.TestBase.injectSecurityContextNoSettings;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.hisp.dhis.common.IdCoder;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.datavalue.DataExportParams;
 import org.hisp.dhis.datavalue.DataExportStore;
+import org.hisp.dhis.datavalue.DataExportValue;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.user.SystemUser;
@@ -47,6 +54,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -114,5 +122,51 @@ class DefaultDataExportServiceTest {
     DataExportParams.Input params = validFiltersBuilder().lastUpdatedDuration(" ").build();
 
     assertDoesNotThrow(() -> service().exportValues(params));
+  }
+
+  @Test
+  void testExportValues_DefaultCcDataSet_AppliesDefaultAocFilter() throws Exception {
+    // Every requested data set uses the default attribute category combo, so the only valid
+    // attribute option combo is the default one. It must be applied as an explicit AOC filter
+    // so the export query can skip the per-row AOC data-sharing check.
+    UID defaultAoc = UID.generate();
+    when(store.getDefaultAttributeOptionComboForDataSets(any())).thenReturn(defaultAoc);
+    when(store.exportValues(any())).thenReturn(Stream.<DataExportValue>empty());
+
+    service().exportValues(validFiltersBuilder().build());
+
+    ArgumentCaptor<DataExportParams> captor = ArgumentCaptor.forClass(DataExportParams.class);
+    verify(store).exportValues(captor.capture());
+    assertEquals(List.of(defaultAoc), captor.getValue().getAttributeOptionCombos());
+  }
+
+  @Test
+  void testExportValues_NonDefaultCcDataSet_NoAocFilter() throws Exception {
+    // A requested data set uses a non-default attribute category combo, so the default AOC
+    // fast path must not apply and no AOC filter is added.
+    when(store.getDefaultAttributeOptionComboForDataSets(any())).thenReturn(null);
+    when(store.exportValues(any())).thenReturn(Stream.<DataExportValue>empty());
+
+    service().exportValues(validFiltersBuilder().build());
+
+    ArgumentCaptor<DataExportParams> captor = ArgumentCaptor.forClass(DataExportParams.class);
+    verify(store).exportValues(captor.capture());
+    assertEquals(List.of(), captor.getValue().getAttributeOptionCombos());
+  }
+
+  @Test
+  void testExportValues_ExplicitAocGiven_DefaultCcFastPathSkipped() throws Exception {
+    // An explicit attributeOptionCombo filter wins and the default-CC resolution must not run.
+    UID explicitAoc = UID.generate();
+    when(store.exportValues(any())).thenReturn(Stream.<DataExportValue>empty());
+
+    service()
+        .exportValues(
+            validFiltersBuilder().attributeOptionCombo(Set.of(explicitAoc.getValue())).build());
+
+    ArgumentCaptor<DataExportParams> captor = ArgumentCaptor.forClass(DataExportParams.class);
+    verify(store).exportValues(captor.capture());
+    assertEquals(List.of(explicitAoc), captor.getValue().getAttributeOptionCombos());
+    verify(store, never()).getDefaultAttributeOptionComboForDataSets(any());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataExportServiceExportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataExportServiceExportTest.java
@@ -176,9 +176,14 @@ class DataExportServiceExportTest extends PostgresIntegrationTestBase {
     atA.setCategoryOptionComboAttribute(true);
     idObjectManager.save(atA);
     dsA = createDataSet('A');
+    // dsA/dsB carry attribute category combo ccA: every data value below is stored with an
+    // attribute option combo (cocA/cocB) that belongs to ccA, which is only valid if the data
+    // sets use ccA as their attribute category combo (enforced on import, E8023).
+    dsA.setCategoryCombo(ccA);
     dsA.addDataSetElement(deA);
     dsA.addDataSetElement(deB);
     dsB = createDataSet('B');
+    dsB.setCategoryCombo(ccA);
     dsB.addDataSetElement(deA);
     dataSetService.addDataSet(dsA);
     dataSetService.addDataSet(dsB);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataExportServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataExportServiceIntegrationTest.java
@@ -51,6 +51,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.time.DateUtils;
 import org.awaitility.Awaitility;
 import org.hisp.dhis.attribute.Attribute;
@@ -64,6 +65,7 @@ import org.hisp.dhis.common.IdProperty;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -139,6 +141,8 @@ class DataExportServiceIntegrationTest extends PostgresIntegrationTestBase {
 
   private CategoryOptionCombo ocDef;
 
+  private CategoryCombo categoryComboA;
+
   private CategoryOption categoryOptionA;
 
   private CategoryOption categoryOptionB;
@@ -177,7 +181,7 @@ class DataExportServiceIntegrationTest extends PostgresIntegrationTestBase {
     categoryOptionB.getCategories().add(categoryA);
     categoryService.addCategoryOption(categoryOptionB);
     categoryService.addCategoryOption(categoryOptionA);
-    CategoryCombo categoryComboA = createCategoryCombo('A', categoryA);
+    categoryComboA = createCategoryCombo('A', categoryA);
     CategoryCombo categoryComboDef = categoryService.getDefaultCategoryCombo();
     ocDef = categoryService.getDefaultCategoryOptionCombo();
     ocDef.setCode("OC_DEF_CODE");
@@ -1303,5 +1307,33 @@ class DataExportServiceIntegrationTest extends PostgresIntegrationTestBase {
         () -> assertEquals(deleted, totals.getDeleted(), "unexpected deleted count"),
         () -> assertEquals(ignored, totals.getIgnored(), "unexpected ignored count"),
         () -> assertNotEquals(ImportStatus.ERROR, summary.getStatus(), summary.getDescription()));
+  }
+
+  @Test
+  void testGetDefaultAttributeOptionComboForDataSets_AllDefaultCc() {
+    // dsA uses the default attribute category combo => the default AOC is returned
+    UID expected = UID.of(categoryService.getDefaultCategoryOptionCombo().getUid());
+
+    assertEquals(
+        expected,
+        dataExportStore.getDefaultAttributeOptionComboForDataSets(Stream.of(UID.of(dsA.getUid()))));
+  }
+
+  @Test
+  void testGetDefaultAttributeOptionComboForDataSets_NonDefaultCc() {
+    DataSet dsNonDefault = createDataSet('N', new MonthlyPeriodType());
+    dsNonDefault.setCategoryCombo(categoryComboA);
+    dataSetService.addDataSet(dsNonDefault);
+
+    // one of the data sets uses a non-default attribute category combo => no fast path
+    assertNull(
+        dataExportStore.getDefaultAttributeOptionComboForDataSets(
+            Stream.of(UID.of(dsA.getUid()), UID.of(dsNonDefault.getUid()))));
+  }
+
+  @Test
+  void testGetDefaultAttributeOptionComboForDataSets_NoDataSetExists() {
+    assertNull(
+        dataExportStore.getDefaultAttributeOptionComboForDataSets(Stream.of(UID.generate())));
   }
 }


### PR DESCRIPTION
Solves https://dhis2.atlassian.net/browse/DHIS2-22077

## Summary

Data value set exports scoped to data set(s) that **all use the default attribute category combo** can only ever match the default attribute option combo. This PR resolves that default AOC up front and applies it as an explicit filter, so the export query skips the per-row AOC data-sharing check that otherwise scans the whole `categoryoptioncombo` table.

For instances with large category metadata (e.g. Nigeria), that per-row check is a significant cost on an export path that, for default-CC data sets, can never exclude anything.

Live Glowroot traces from a production server running 43 revealed 

## Changes

- **`DataExportStore#getDefaultAttributeOptionComboForDataSets(Stream<UID>)`** (new) — returns the default category-option-combo UID **only when** at least one of the given data sets exists and every existing one uses the default attribute category combo. Returns `null` when any data set has a missing or non-default attribute category combo, or when none of the data sets exist — in which case the regular per-row check is used unchanged.
- **`HibernateDataExportStore`** — implements it with a single native query.
- **`DefaultDataExportService#resolveAttributeOptionCombos`** — applies the fast path only when no explicit `attributeOptionCombo` / `attributeOptions` filter is given and the export is data-set-scoped. An explicit AOC filter still wins and the default-CC resolution does not run.

## Behaviour

No result change: if every data set uses the default attribute category combo, every stored value for those data sets already has the default AOC (**this invariant is enforced on import** — see below), and the default category option is world-readable — so the explicit default-AOC filter returns exactly the same rows as the per-row check did.

## ⚠️ Why `DataExportServiceExportTest` had to change — please read

**The fixture in `DataExportServiceExportTest` was persisting data that cannot exist in a real instance, and this optimisation exposed it.**

- The test builds its rows with data sets `dsA` / `dsB` that use the **default** attribute category combo, but stores those rows with attribute option combos `cocA` / `cocB`, which belong to a **non-default** category combo (`ccA`).
- That state is **rejected on import**. `DefaultDataEntryService.validateKeyConsistency` enforces *"AOC must link (belong) to the CC of the DS"* and throws **`E8023`** (*"Data set … not usable with attribute option combo(s)"*). A default-attribute-CC data set only accepts the default AOC.
- The test only reached that state because it writes rows through `dataDumpService.upsertValues(...)`, a raw bulk path that bypasses that validation.
- Previously nothing noticed, because the export applied a per-row AOC data-sharing check rather than an AOC equality filter. This PR replaces that with `aoc = <default>` for default-CC data sets, which correctly excludes the invalid `cocA` / `cocB` rows — so the assertions dropped to `0`.

**Fix:** give `dsA` / `dsB` the `ccA` attribute category combo in `setUp()`, so the fixture is internally consistent (the AOCs on the rows now legitimately belong to the data sets' attribute CC). As a side effect the fast path no longer applies to these data sets (non-default CC → no filter), so the pre-existing export counts are restored.

**No production behaviour is being weakened to make a test pass** — the test was asserting on a state the import layer forbids. If reviewers believe there is a supported write path that can still produce an AOC mismatched to a default-CC data set (legacy import, sync, direct SQL, historical data from before `E8023`), please flag it: the optimisation's correctness rests on that invariant holding for all existing rows.

## Tests

- `DefaultDataExportServiceTest` — 3 unit tests: default-CC data set applies the default AOC filter; non-default CC adds no filter; an explicit AOC filter skips the fast path entirely.
- `DataExportServiceIntegrationTest` — 3 integration tests exercising the SQL against Postgres: all-default-CC → default AOC; mixed non-default CC → `null`; non-existent data set → `null`.
- `DataExportServiceExportTest` — fixture corrected as described above.


🤖 Wrangled with AI assistance, but with careful guidance. 
