### PR TITLE
chore(deps): Qualify validation context builder

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRunContext.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRunContext.java
@@ -39,7 +39,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.hisp.dhis.category.CategoryOption;
@@ -61,7 +60,10 @@ import org.hisp.dhis.period.Period;
  * @author Stian Sandvold (persistence)
  */
 @Getter
-@Builder(setterPrefix = "with", builderClassName = "Builder", builderMethodName = "newBuilder")
+@lombok.Builder(
+    setterPrefix = "with",
+    builderClassName = "Builder",
+    builderMethodName = "newBuilder")
 public class ValidationRunContext {
   public static final int ORG_UNITS_PER_TASK = 500;
 


### PR DESCRIPTION
## Summary
Use `@lombok.Builder` to resolve the Lombok 1.18.48 name collision while preserving `ValidationRunContext.Builder` and all existing callers.

Targets the Dependabot branch for #25063 (open, opened 2026-09-08), so merging this one-file fix unblocks the dependency PR without duplicating its version bump.

## Verification
- Spotless applied to the changed file.
- Java 17 clean reporting reactor build passed across 27 modules with Lombok 1.18.48.
- `DataValidationRunnerTest`: 2 passed.
- Compiled-class smoke check passed for the builder API, defaults, explicit settings, cache preload and builder reuse.

AI Assisted