### PR TITLE
chore(deps): Upgrade Lombok to 1.18.48

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRunContext.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRunContext.java
@@ -39,7 +39,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.hisp.dhis.category.CategoryOption;
@@ -61,7 +60,10 @@ import org.hisp.dhis.period.Period;
  * @author Stian Sandvold (persistence)
  */
 @Getter
-@Builder(setterPrefix = "with", builderClassName = "Builder", builderMethodName = "newBuilder")
+@lombok.Builder(
+    setterPrefix = "with",
+    builderClassName = "Builder",
+    builderMethodName = "newBuilder")
 public class ValidationRunContext {
   public static final int ORG_UNITS_PER_TASK = 500;
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -194,7 +194,7 @@
     <jsr305.version>3.0.2</jsr305.version>
     <imgscalr-lib.version>4.2</imgscalr-lib.version>
     <google-api-client.version>2.9.0</google-api-client.version>
-    <lombok.version>1.18.40</lombok.version>
+    <lombok.version>1.18.48</lombok.version>
     <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
     <joda-time.version>2.14.3</joda-time.version>
     <cron-utils.version>9.2.1</cron-utils.version>


### PR DESCRIPTION
## Summary
- Upgrade Lombok from 1.18.40 to 1.18.48 on `master`.
- Include the fully qualified `@lombok.Builder` fix, preserving `ValidationRunContext.Builder` and all existing callers.

Ports the upgrade from #25063 (opened 2026-09-08) together with #25066 (merged 2026-09-08).

## Verification
- Scoped Spotless formatting passed.
- Java 17 clean reporting reactor build passed across 27 modules with Lombok 1.18.48.
- `DataValidationRunnerTest`: 2 passed.
- Actual compiled-class smoke check passed for the builder API, defaults, explicit settings, cache preload and builder reuse.

AI Assisted