### PR TITLE
fix: share one connection between Hibernate and JDBC DHIS2-22067 [41]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -83,8 +83,15 @@ public class HibernateConfig {
   @Bean("jpaTransactionManager")
   @DependsOn("entityManagerFactory")
   public JpaTransactionManager jpaTransactionManager(
-      @Qualifier("entityManagerFactory") EntityManagerFactory emf) {
-    return new JpaTransactionManager(emf);
+      @Qualifier("entityManagerFactory") EntityManagerFactory emf,
+      @Qualifier("dataSource") DataSource dataSource) {
+    JpaTransactionManager transactionManager = new JpaTransactionManager(emf);
+    // Must be the same bean instance the JdbcTemplates get. Spring keys transactional connections
+    // by DataSource identity, so without this a @Transactional method mixing Hibernate and
+    // JdbcTemplate takes a second connection which is not enlisted in the transaction: its
+    // statements commit immediately and a rollback does not cover them.
+    transactionManager.setDataSource(dataSource);
+    return transactionManager;
   }
 
   @Bean("transactionTemplate")


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/25041

Conflict resolved: 2.41 keeps its named `@Bean("jpaTransactionManager")`, `@DependsOn("entityManagerFactory")` and qualified `emf` parameter, so only the `setDataSource` call is added.

2.41 also has two DataSource beans: `actualDataSource` (raw pool) and `dataSource` (`@Primary`, wraps it via `createLoggingDataSource`). The JdbcTemplates and the `entityManagerFactory` both take `dataSource`, so this uses `@Qualifier("dataSource")` rather than master's `actualDataSource`. Spring keys transactional connections by DataSource identity, so qualifying `actualDataSource` here would silently not share when query logging is enabled.