### PR TITLE
fix: reject DCR scopes with SAS 1.5.8 (2.43)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2Constants.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2Constants.java
@@ -79,9 +79,9 @@ public final class OAuth2Constants {
 
   /**
    * Server-side default scopes assigned to DCR-registered clients when the registration omits
-   * scopes. Spring Authorization Server 7 forbids client-supplied {@code scope} on DCR requests, so
-   * these are the only scopes a DCR client gets. Matches the Android reference client's authorize
-   * scopes; deliberately excludes {@code email} (PR-H decision D3).
+   * scopes. Spring Authorization Server 1.5.8 forbids client-supplied {@code scope} on DCR
+   * requests, so these are the only scopes a DCR client gets. Matches the Android reference
+   * client's authorize scopes; deliberately excludes {@code email} (PR-H decision D3).
    */
   public static final List<String> DCR_DEFAULT_SCOPES =
       List.of(SCOPE_OPENID, SCOPE_PROFILE, SCOPE_USERNAME);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/DcrControllerTest.java
@@ -209,6 +209,21 @@ class DcrControllerTest extends ControllerWithJwtTokenAuthTestBase {
   }
 
   @Test
+  @DisplayName("Test DCR registration with client-supplied scopes is rejected")
+  void testRegisterClientWithScopesRejected() throws Exception {
+    // Given a valid IAT and key pair, and an otherwise-valid registration that supplies scope
+    String initialAccessToken = createClientAndIat();
+    KeyPair keyPair = createKeys();
+
+    // Then SAS 1.5.8 rejects client-supplied scope on /connect/register
+    mvc.perform(
+            getGetClientRegPost(
+                initialAccessToken, keyPair, "[\"client_credentials\"]", "openid profile username"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("invalid_scope"));
+  }
+
+  @Test
   @DisplayName("Test DCR-registered client refresh token settings")
   void testDcrRegisteredClientRefreshTokenSettings() throws Exception {
     // Given an initial access token (iat)
@@ -509,6 +524,16 @@ class DcrControllerTest extends ControllerWithJwtTokenAuthTestBase {
 
   private static MockHttpServletRequestBuilder getGetClientRegPost(
       String iat, KeyPair keyPair, String grantTypesJson) {
+    return getGetClientRegPost(iat, keyPair, grantTypesJson, null);
+  }
+
+  /**
+   * Builds a DCR request without scopes by default. A supplied scope is used to verify rejection;
+   * authorize and token requests still send scope.
+   */
+  private static MockHttpServletRequestBuilder getGetClientRegPost(
+      String iat, KeyPair keyPair, String grantTypesJson, String scope) {
+    String scopeJson = scope == null ? "" : "\"scope\": \"" + scope + "\",";
     return post("/connect/register")
         .header(HttpHeaders.AUTHORIZATION, "Bearer " + iat)
         .contentType(MediaType.APPLICATION_JSON)
@@ -522,17 +547,16 @@ class DcrControllerTest extends ControllerWithJwtTokenAuthTestBase {
                    "response_types": ["code"],
                    "token_endpoint_auth_method": "private_key_jwt",
                    "token_endpoint_auth_signing_alg": "RS256",
-                   "scope": "openid profile username",
+                   %s
                    "jwks_uri": "https://dhis2.org/jwks.json",
                    "jwks": %s
                  }
                 """,
                 grantTypesJson,
+                scopeJson,
                 keyPair
                     .jwkSet())); // Inline JWKS , note jwks_uri is also set but should be ignored,
     // validation will fail if not set, only jwks is used
-    // NOTE: Scope is defined here BUT this is only because we use client_credentials grant
-    // when using /authorize first in the real world, you define scope in there.
   }
 
   private String createClientAndIat() {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/InlineJwksClientMetadataConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/InlineJwksClientMetadataConfig.java
@@ -122,10 +122,10 @@ final class InlineJwksClientMetadataConfig {
               .reuseRefreshTokens(false)
               .build();
 
-      // Client-supplied scopes on DCR requests are overridden with the server-side first-party
-      // defaults (openid, profile, username — see OAuth2Constants.DCR_DEFAULT_SCOPES) so
-      // authorize and token requests have usable scopes. Defense-in-depth: any scopes that
-      // arrive on the registration are filtered against the allowed-client-scope set.
+      // SAS 1.5.8 forbids "scope" on DCR requests; assign the server-side first-party defaults
+      // (openid, profile, username; see OAuth2Constants.DCR_DEFAULT_SCOPES) so authorize and
+      // token requests have usable scopes. Defense-in-depth: any scopes that somehow arrive on
+      // the registration are filtered against the allowed-client-scope set.
       RegisteredClient.Builder builder =
           RegisteredClient.from(rc).clientSettings(cs.build()).tokenSettings(tokenSettings);
       if (rc.getScopes() == null || rc.getScopes().isEmpty()) {

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -101,7 +101,7 @@
     <!-- Security -->
     <spring-security.version>6.5.10</spring-security.version>
     <spring-security-jwt.version>1.1.1.RELEASE</spring-security-jwt.version>
-    <spring-authorization-server.version>1.5.2</spring-authorization-server.version>
+    <spring-authorization-server.version>1.5.8</spring-authorization-server.version>
     <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
     <jasypt.version>1.9.3</jasypt.version>
     <nimbus.jose.jwt.version>10.9</nimbus.jose.jwt.version>


### PR DESCRIPTION
## Change

- Upgrade Spring Authorization Server from 1.5.2 to 1.5.8.
- Match master: reject client-supplied DCR registration scopes and retain server defaults `openid profile username`.
- Update registration fixtures, add the `400 invalid_scope` regression, and correct scope documentation. Authorization and token request scopes are unchanged.

## Verification

- All 13 targeted H2 tests passed: DCR, PKCE, and federated token exchange.
- Rejection regression fails with 1.5.2 (`201` instead of `400`) and passes with 1.5.8.
- Changed-file Spotless passed.

AI Assisted