### PR TITLE
feat: bound the tracker file endpoints' object store fetch DHIS2-21390

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceContentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceContentStore.java
@@ -39,6 +39,7 @@ import java.util.NoSuchElementException;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.storage.BlobKey;
+import org.hisp.dhis.storage.BlobReadOptions;
 
 /**
  * @author Halvdan Hoem Grelland
@@ -130,7 +131,13 @@ public interface FileResourceContentStore {
    * @param key the key used to store a resource
    * @return byte array of the content
    */
-  byte[] copyContent(BlobKey key) throws IOException, NoSuchElementException;
+  default byte[] copyContent(BlobKey key) throws IOException, NoSuchElementException {
+    return copyContent(key, BlobReadOptions.none());
+  }
+
+  /** {@link #copyContent(BlobKey)} bounded by {@code options}. */
+  byte[] copyContent(BlobKey key, BlobReadOptions options)
+      throws IOException, NoSuchElementException;
 
   /**
    * Opens a stream to the resource stored under key.
@@ -138,5 +145,11 @@ public interface FileResourceContentStore {
    * @param key the key used to store a resource
    * @return content stream
    */
-  InputStream openStream(BlobKey key) throws IOException, NoSuchElementException;
+  default InputStream openStream(BlobKey key) throws IOException, NoSuchElementException {
+    return openStream(key, BlobReadOptions.none());
+  }
+
+  /** {@link #openStream(BlobKey)} bounded by {@code options}. */
+  InputStream openStream(BlobKey key, BlobReadOptions options)
+      throws IOException, NoSuchElementException;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
@@ -43,6 +43,7 @@ import javax.annotation.Nonnull;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.storage.BlobReadOptions;
 
 /**
  * @author Halvdan Hoem Grelland
@@ -168,8 +169,17 @@ public interface FileResourceService {
   byte[] copyImageContent(FileResource fileResource, ImageFileDimension dimension)
       throws BadRequestException, IOException;
 
+  /** {@link #copyImageContent(FileResource, ImageFileDimension)} bounded by {@code options}. */
+  byte[] copyImageContent(
+      FileResource fileResource, ImageFileDimension dimension, BlobReadOptions options)
+      throws BadRequestException, IOException;
+
   /** Opens a stream to the file resource content. */
   InputStream openContentStream(FileResource fileResource)
+      throws IOException, NoSuchElementException;
+
+  /** {@link #openContentStream(FileResource)} bounded by {@code options}. */
+  InputStream openContentStream(FileResource fileResource, BlobReadOptions options)
       throws IOException, NoSuchElementException;
 
   /**
@@ -182,6 +192,13 @@ public interface FileResourceService {
    *     dimensions or does not have multiple dimension files stored
    */
   InputStream openContentStreamToImage(FileResource fileResource, ImageFileDimension dimension)
+      throws IOException, NoSuchElementException, BadRequestException;
+
+  /**
+   * {@link #openContentStreamToImage(FileResource, ImageFileDimension)} bounded by {@code options}.
+   */
+  InputStream openContentStreamToImage(
+      FileResource fileResource, ImageFileDimension dimension, BlobReadOptions options)
       throws IOException, NoSuchElementException, BadRequestException;
 
   boolean fileResourceExists(String uid);

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/storage/BlobReadOptions.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/storage/BlobReadOptions.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.storage;
+
+import java.time.Duration;
+import java.util.function.LongSupplier;
+import javax.annotation.CheckForNull;
+
+/**
+ * Per-call overrides for a blob read, so a caller under its own time limit can bound the read by
+ * it. Stores that reach no remote system ignore them.
+ *
+ * <p>Asks the caller what is left rather than holding a duration, because one read makes several
+ * calls to the store and they share the caller's limit, so each gets the remainder rather than the
+ * whole of it again. The caller owns the clock, so there is none here to disagree with it.
+ *
+ * @param remainingNanos supplies the nanoseconds the read has left, or null to leave it to the
+ *     store's own configuration
+ */
+public record BlobReadOptions(@CheckForNull LongSupplier remainingNanos) {
+
+  private static final BlobReadOptions NONE = new BlobReadOptions(null);
+
+  /** No overrides, the store's own configuration applies. */
+  public static BlobReadOptions none() {
+    return NONE;
+  }
+
+  /**
+   * A read bounded by the caller's own limit, re-read before every call to the store.
+   *
+   * @param remainingNanos how much of that limit is left, negative once it is spent
+   */
+  public static BlobReadOptions remaining(LongSupplier remainingNanos) {
+    return new BlobReadOptions(remainingNanos);
+  }
+
+  /**
+   * What the next call to the store may take, or null if it is unbounded.
+   *
+   * @throws BlobReadTimeoutException if under a millisecond is left, the AWS SDK's resolution, so
+   *     the call could only time out and is not made
+   */
+  @CheckForNull
+  public Duration nextTimeout() {
+    if (remainingNanos == null) {
+      return null;
+    }
+    Duration remaining = Duration.ofNanos(remainingNanos.getAsLong());
+    if (remaining.toMillis() <= 0) {
+      throw new BlobReadTimeoutException("Blob read budget is spent");
+    }
+    return remaining;
+  }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/storage/BlobReadTimeoutException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/storage/BlobReadTimeoutException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.storage;
+
+/**
+ * Thrown when a blob read did not finish within the {@link BlobReadOptions#nextTimeout()} its
+ * caller asked for, so it always means that caller's own limit was reached rather than a fault of
+ * the store.
+ */
+public class BlobReadTimeoutException extends RuntimeException {
+
+  public BlobReadTimeoutException(String message) {
+    super(message);
+  }
+
+  public BlobReadTimeoutException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/BlobStoreFileResourceContentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/BlobStoreFileResourceContentStore.java
@@ -46,6 +46,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.hisp.dhis.storage.BlobKey;
+import org.hisp.dhis.storage.BlobReadOptions;
 import org.hisp.dhis.storage.BlobStoreService;
 import org.hisp.dhis.storage.BlobStoreService.ContentDisposition;
 import org.hisp.dhis.storage.ContentHash;
@@ -181,7 +182,7 @@ public class BlobStoreFileResourceContentStore implements FileResourceContentSto
   @Override
   public void copyContent(BlobKey key, OutputStream output)
       throws IOException, NoSuchElementException {
-    ensureBlobExists(key);
+    ensureBlobExists(key, BlobReadOptions.none());
 
     try (InputStream in = blobStore.openStream(key)) {
       IOUtils.copy(in, output);
@@ -189,22 +190,24 @@ public class BlobStoreFileResourceContentStore implements FileResourceContentSto
   }
 
   @Override
-  public byte[] copyContent(BlobKey key) throws IOException, NoSuchElementException {
-    ensureBlobExists(key);
+  public byte[] copyContent(BlobKey key, BlobReadOptions options)
+      throws IOException, NoSuchElementException {
+    ensureBlobExists(key, options);
 
-    try (InputStream in = blobStore.openStream(key)) {
+    try (InputStream in = blobStore.openStream(key, options)) {
       return IOUtils.toByteArray(in);
     }
   }
 
   @Override
-  public InputStream openStream(BlobKey key) throws IOException, NoSuchElementException {
-    ensureBlobExists(key);
-    return blobStore.openStream(key);
+  public InputStream openStream(BlobKey key, BlobReadOptions options)
+      throws IOException, NoSuchElementException {
+    ensureBlobExists(key, options);
+    return blobStore.openStream(key, options);
   }
 
-  private void ensureBlobExists(BlobKey key) {
-    if (!blobStore.blobExists(key)) {
+  private void ensureBlobExists(BlobKey key, BlobReadOptions options) {
+    if (!blobStore.blobExists(key, options)) {
       throw new NoSuchElementException("key '" + key + "' not found.");
     }
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.fileresource.events.FileSavedEvent;
 import org.hisp.dhis.fileresource.events.ImageFileSavedEvent;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.storage.BlobKey;
+import org.hisp.dhis.storage.BlobReadOptions;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.util.ObjectUtils;
 import org.joda.time.DateTime;
@@ -325,30 +326,50 @@ public class DefaultFileResourceService implements FileResourceService {
   @Override
   public byte[] copyImageContent(FileResource fileResource, ImageFileDimension dimension)
       throws NoSuchElementException, BadRequestException, IOException {
+    return copyImageContent(fileResource, dimension, BlobReadOptions.none());
+  }
+
+  @Override
+  public byte[] copyImageContent(
+      FileResource fileResource, ImageFileDimension dimension, BlobReadOptions options)
+      throws NoSuchElementException, BadRequestException, IOException {
     ImageFileDimension imageDimension =
         ObjectUtils.firstNonNull(dimension, ImageFileDimension.ORIGINAL);
 
     hasImageDimensionSupport(fileResource, imageDimension);
 
-    return fileResourceContentStore.copyContent(imageKey(fileResource, imageDimension));
+    return fileResourceContentStore.copyContent(imageKey(fileResource, imageDimension), options);
   }
 
   @Override
   public InputStream openContentStream(FileResource fileResource)
       throws IOException, NoSuchElementException {
-    return fileResourceContentStore.openStream(fileResource.asBlobKey());
+    return openContentStream(fileResource, BlobReadOptions.none());
+  }
+
+  @Override
+  public InputStream openContentStream(FileResource fileResource, BlobReadOptions options)
+      throws IOException, NoSuchElementException {
+    return fileResourceContentStore.openStream(fileResource.asBlobKey(), options);
   }
 
   @Override
   public InputStream openContentStreamToImage(
       FileResource fileResource, ImageFileDimension dimension)
       throws IOException, NoSuchElementException, BadRequestException {
+    return openContentStreamToImage(fileResource, dimension, BlobReadOptions.none());
+  }
+
+  @Override
+  public InputStream openContentStreamToImage(
+      FileResource fileResource, ImageFileDimension dimension, BlobReadOptions options)
+      throws IOException, NoSuchElementException, BadRequestException {
     ImageFileDimension imageDimension =
         ObjectUtils.firstNonNull(dimension, ImageFileDimension.ORIGINAL);
 
     hasImageDimensionSupport(fileResource, imageDimension);
 
-    return fileResourceContentStore.openStream(imageKey(fileResource, imageDimension));
+    return fileResourceContentStore.openStream(imageKey(fileResource, imageDimension), options);
   }
 
   private static void hasImageDimensionSupport(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/storage/BlobStoreService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/storage/BlobStoreService.java
@@ -66,17 +66,33 @@ public interface BlobStoreService {
   }
 
   /** Returns {@code true} if a blob with the given key exists in the container. */
-  boolean blobExists(BlobKey key);
+  default boolean blobExists(BlobKey key) {
+    return blobExists(key, BlobReadOptions.none());
+  }
+
+  /** {@link #blobExists(BlobKey)} bounded by {@code options}. */
+  boolean blobExists(BlobKey key, BlobReadOptions options);
 
   /**
    * Opens a stream for the blob content. Returns {@code null} if no blob exists for the key.
    * Callers are responsible for closing the returned stream.
    */
   @CheckForNull
-  InputStream openStream(BlobKey key);
+  default InputStream openStream(BlobKey key) {
+    return openStream(key, BlobReadOptions.none());
+  }
+
+  /** {@link #openStream(BlobKey)} bounded by {@code options}. */
+  @CheckForNull
+  InputStream openStream(BlobKey key, BlobReadOptions options);
 
   /** Returns the content length in bytes of the blob, or {@code 0} if the blob does not exist. */
-  long contentLength(BlobKey key);
+  default long contentLength(BlobKey key) {
+    return contentLength(key, BlobReadOptions.none());
+  }
+
+  /** {@link #contentLength(BlobKey)} bounded by {@code options}. */
+  long contentLength(BlobKey key, BlobReadOptions options);
 
   /**
    * Stores a streaming payload under the given key.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/storage/FileSystemBlobStoreService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/storage/FileSystemBlobStoreService.java
@@ -88,7 +88,7 @@ public class FileSystemBlobStoreService implements BlobStoreService {
   }
 
   @Override
-  public boolean blobExists(BlobKey key) {
+  public boolean blobExists(BlobKey key, BlobReadOptions options) {
     if (key == null) return false;
     Path p = resolve(key);
     return Files.isRegularFile(p);
@@ -96,7 +96,7 @@ public class FileSystemBlobStoreService implements BlobStoreService {
 
   @Override
   @CheckForNull
-  public InputStream openStream(BlobKey key) {
+  public InputStream openStream(BlobKey key, BlobReadOptions options) {
     Path p = resolve(key);
     if (!Files.isRegularFile(p)) return null;
     try {
@@ -108,7 +108,7 @@ public class FileSystemBlobStoreService implements BlobStoreService {
   }
 
   @Override
-  public long contentLength(BlobKey key) {
+  public long contentLength(BlobKey key, BlobReadOptions options) {
     Path p = resolve(key);
     if (!Files.isRegularFile(p)) return 0L;
     try {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/storage/S3BlobStoreService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/storage/S3BlobStoreService.java
@@ -52,6 +52,8 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -197,34 +199,75 @@ public class S3BlobStoreService implements BlobStoreService {
   }
 
   @Override
-  public boolean blobExists(BlobKey key) {
+  public boolean blobExists(BlobKey key, BlobReadOptions options) {
     if (key == null) return false;
+    AwsRequestOverrideConfiguration override = override(options);
     try {
-      s3.headObject(b -> b.bucket(container.value()).key(key.value()));
+      s3.headObject(
+          b -> b.bucket(container.value()).key(key.value()).overrideConfiguration(override));
       return true;
     } catch (NoSuchKeyException e) {
       return false;
+    } catch (ApiCallTimeoutException e) {
+      throw timedOut(key, e);
     }
   }
 
   @Override
   @CheckForNull
-  public InputStream openStream(BlobKey key) {
+  public InputStream openStream(BlobKey key, BlobReadOptions options) {
+    AwsRequestOverrideConfiguration override = override(options);
     try {
-      return s3.getObject(b -> b.bucket(container.value()).key(key.value()));
+      return s3.getObject(
+          b -> b.bucket(container.value()).key(key.value()).overrideConfiguration(override));
     } catch (NoSuchKeyException e) {
       return null;
+    } catch (ApiCallTimeoutException e) {
+      throw timedOut(key, e);
     }
   }
 
   @Override
-  public long contentLength(BlobKey key) {
+  public long contentLength(BlobKey key, BlobReadOptions options) {
+    AwsRequestOverrideConfiguration override = override(options);
     try {
-      HeadObjectResponse head = s3.headObject(b -> b.bucket(container.value()).key(key.value()));
+      HeadObjectResponse head =
+          s3.headObject(
+              b -> b.bucket(container.value()).key(key.value()).overrideConfiguration(override));
       return head.contentLength();
     } catch (NoSuchKeyException e) {
       return 0L;
+    } catch (ApiCallTimeoutException e) {
+      throw timedOut(key, e);
     }
+  }
+
+  /**
+   * Only reachable when the caller supplied a timeout, since the client sets none of its own, so
+   * this always means the caller's own limit was reached.
+   */
+  private static BlobReadTimeoutException timedOut(BlobKey key, ApiCallTimeoutException e) {
+    return new BlobReadTimeoutException("Reading blob '" + key + "' timed out", e);
+  }
+
+  /**
+   * Turns {@link BlobReadOptions} into a per-request override, which takes precedence over the
+   * client configuration. Called per request, so each gets what is left of the caller's limit.
+   *
+   * <p>{@code apiCallTimeout} covers the whole call including retries, unlike {@code
+   * apiCallAttemptTimeout} which bounds one attempt. The SDK retries by default and {@code
+   * AWS_RETRY_MODE} can change how often, so per attempt would give an unpredictable ceiling.
+   *
+   * <p>The timer also runs while the body is read, so a slow client can have its download cut short
+   * after the response status is committed.
+   */
+  private static AwsRequestOverrideConfiguration override(BlobReadOptions options) {
+    AwsRequestOverrideConfiguration.Builder builder = AwsRequestOverrideConfiguration.builder();
+    Duration timeout = options.nextTimeout();
+    if (timeout != null) {
+      builder.apiCallTimeout(timeout);
+    }
+    return builder.build();
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/storage/TransientBlobStoreService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/storage/TransientBlobStoreService.java
@@ -63,19 +63,19 @@ public class TransientBlobStoreService implements BlobStoreService {
   }
 
   @Override
-  public boolean blobExists(BlobKey key) {
+  public boolean blobExists(BlobKey key, BlobReadOptions options) {
     return key != null && blobs.containsKey(key.value());
   }
 
   @Override
   @CheckForNull
-  public InputStream openStream(BlobKey key) {
+  public InputStream openStream(BlobKey key, BlobReadOptions options) {
     byte[] payload = blobs.get(key.value());
     return payload == null ? null : new ByteArrayInputStream(payload);
   }
 
   @Override
-  public long contentLength(BlobKey key) {
+  public long contentLength(BlobKey key, BlobReadOptions options) {
     byte[] payload = blobs.get(key.value());
     return payload == null ? 0L : payload.length;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/storage/S3BlobStoreServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/storage/S3BlobStoreServiceTest.java
@@ -32,20 +32,28 @@ package org.hisp.dhis.storage;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Error;
@@ -61,6 +69,19 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 class S3BlobStoreServiceTest {
 
   private final BlobContainerName container = new BlobContainerName("dhis2");
+
+  /** Test clock so the timeout assertions do not depend on how long the test itself takes. */
+  private long nanos = TimeUnit.SECONDS.toNanos(1_000);
+
+  private void elapse(Duration elapsed) {
+    nanos += elapsed.toNanos();
+  }
+
+  /** Options bounded by {@code budget} from the test clock's current reading. */
+  private BlobReadOptions remainingFrom(Duration budget) {
+    long deadline = nanos + budget.toNanos();
+    return BlobReadOptions.remaining(() -> deadline - nanos);
+  }
 
   @Test
   void listKeys_paginatesAcrossMultiplePages() {
@@ -152,6 +173,91 @@ class S3BlobStoreServiceTest {
 
     assertEquals(List.of("apps/a", "apps/b/c"), keys);
     assertTrue(keys.stream().noneMatch(k -> k.endsWith("/")));
+  }
+
+  @Test
+  void openStream_passesTheTimeoutOnToTheRequest() {
+    S3Client s3 = mock(S3Client.class);
+    BlobStoreService svc = new S3BlobStoreService(container, s3, mock(S3Presigner.class));
+
+    svc.openStream(BlobKey.of("apps/a"), remainingFrom(Duration.ofSeconds(7)));
+
+    assertEquals(
+        Optional.of(Duration.ofSeconds(7)),
+        capturedRequest(s3).overrideConfiguration().flatMap(o -> o.apiCallTimeout()),
+        "the caller's remaining budget must bound the fetch");
+  }
+
+  @Test
+  void openStream_boundsASecondCallByTheRemainderOfTheSameOptions() {
+    // One read through the content store makes several calls, headObject then getObject, sharing
+    // one BlobReadOptions. Each must get what is left rather than the whole limit again.
+    S3Client s3 = mock(S3Client.class);
+    BlobStoreService svc = new S3BlobStoreService(container, s3, mock(S3Presigner.class));
+    BlobReadOptions options = remainingFrom(Duration.ofSeconds(10));
+
+    svc.blobExists(BlobKey.of("apps/a"), options);
+    elapse(Duration.ofSeconds(4));
+    svc.openStream(BlobKey.of("apps/a"), options);
+
+    assertEquals(
+        Optional.of(Duration.ofSeconds(6)),
+        capturedRequest(s3).overrideConfiguration().flatMap(o -> o.apiCallTimeout()),
+        "the second call must be bounded by the remaining budget, not by the full one");
+  }
+
+  @Test
+  void openStream_doesNotCallTheStoreWithNoneOfTheBudgetLeft() {
+    // The SDK truncates apiCallTimeout to whole milliseconds and treats 0 as no timeout at all, so
+    // there is no bound left to ask for and the call could only time out. It is not made.
+    S3Client s3 = mock(S3Client.class);
+    BlobStoreService svc = new S3BlobStoreService(container, s3, mock(S3Presigner.class));
+    BlobKey key = BlobKey.of("apps/a");
+    BlobReadOptions options = remainingFrom(Duration.ofMillis(1));
+
+    elapse(Duration.ofNanos(999_999));
+
+    assertThrows(BlobReadTimeoutException.class, () -> svc.openStream(key, options));
+    verifyNoInteractions(s3);
+  }
+
+  @Test
+  void openStream_withoutATimeoutLeavesTheRequestUnbounded() {
+    S3Client s3 = mock(S3Client.class);
+    BlobStoreService svc = new S3BlobStoreService(container, s3, mock(S3Presigner.class));
+
+    svc.openStream(BlobKey.of("apps/a"));
+
+    assertEquals(
+        Optional.empty(),
+        capturedRequest(s3).overrideConfiguration().flatMap(o -> o.apiCallTimeout()),
+        "callers that pass no options must keep the client configuration");
+  }
+
+  @Test
+  void openStream_translatesTheSdkTimeoutSoCallersNeedNoSdkTypes() {
+    S3Client s3 = mock(S3Client.class);
+    when(s3.getObject(any(Consumer.class)))
+        .thenThrow(ApiCallTimeoutException.builder().message("timed out").build());
+    BlobStoreService svc = new S3BlobStoreService(container, s3, mock(S3Presigner.class));
+    BlobKey key = BlobKey.of("apps/a");
+    BlobReadOptions options = remainingFrom(Duration.ofSeconds(1));
+
+    assertThrows(BlobReadTimeoutException.class, () -> svc.openStream(key, options));
+  }
+
+  /**
+   * The service calls the {@code Consumer<Builder>} overload, so what Mockito records is the lambda
+   * rather than a request. Applying it to a builder yields the request the SDK would have built.
+   */
+  @SuppressWarnings("unchecked")
+  private static GetObjectRequest capturedRequest(S3Client s3) {
+    ArgumentCaptor<Consumer<GetObjectRequest.Builder>> captor =
+        ArgumentCaptor.forClass(Consumer.class);
+    verify(s3).getObject(captor.capture());
+    GetObjectRequest.Builder builder = GetObjectRequest.builder();
+    captor.getValue().accept(builder);
+    return builder.build();
   }
 
   private static ListObjectsV2Response page(

--- a/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/FileResourceStream.java
+++ b/dhis-2/dhis-tracker/src/main/java/org/hisp/dhis/tracker/export/FileResourceStream.java
@@ -35,10 +35,16 @@ import java.io.InputStream;
 import java.util.NoSuchElementException;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.fileresource.ImageFileDimension;
+import org.hisp.dhis.storage.BlobReadOptions;
+import org.hisp.dhis.storage.BlobReadTimeoutException;
+import org.hisp.dhis.tracker.export.timeout.Deadline;
+import org.hisp.dhis.tracker.export.timeout.DeadlineExceededException;
+import org.hisp.dhis.tracker.export.timeout.DeadlineHolder;
 import org.hisp.dhis.util.ObjectUtils;
 
 /**
@@ -59,6 +65,53 @@ public record FileResourceStream(
 
   public record Content(long length, InputStream stream) {}
 
+  /**
+   * Bounds the store fetch by what is left of this request's budget. Unbounded when {@code
+   * tracker.export.timeout} is disabled, the only case where a request has no deadline.
+   *
+   * <p>One fetch can make several calls to the store, an existence check before the read among
+   * them. The options carry the deadline rather than a fixed duration, so each call is bounded by
+   * the remainder and the fetch as a whole cannot outlast the budget.
+   *
+   * @throws DeadlineExceededException if the budget is spent, so we fail fast
+   */
+  private static BlobReadOptions readOptions() {
+    Deadline deadline = DeadlineHolder.get();
+    if (deadline == null) {
+      return BlobReadOptions.none();
+    }
+    DeadlineHolder.checkNotExpired();
+    return BlobReadOptions.remaining(() -> deadline.remaining().toNanos());
+  }
+
+  /**
+   * Runs {@code fetch} and maps what the store can fail with onto what the API reports. {@link
+   * NoSuchElementException} is taken to mean the content is not stored yet, the same assumption the
+   * other file endpoints make from {@code storageStatus = PENDING}.
+   */
+  private static Content fetch(ContentFetch fetch) throws ConflictException, BadRequestException {
+    try {
+      return fetch.get();
+    } catch (BlobReadTimeoutException e) {
+      Deadline deadline = DeadlineHolder.get();
+      if (deadline == null) {
+        // a timeout from some other source, not ours to translate
+        throw e;
+      }
+      throw new DeadlineExceededException(deadline.budget(), e);
+    } catch (NoSuchElementException e) {
+      throw new ConflictException(EXCEPTION_PENDING);
+    } catch (IOException e) {
+      throw new ConflictException(EXCEPTION_IO, EXCEPTION_IO_DEV);
+    }
+  }
+
+  /** What the three suppliers do before {@link #fetch} maps their failures. */
+  @FunctionalInterface
+  private interface ContentFetch {
+    Content get() throws IOException, BadRequestException;
+  }
+
   @Nonnull
   public static FileResourceStream of(
       @Nonnull FileResourceService fileResourceService, @Nonnull FileResource fileResource) {
@@ -66,20 +119,12 @@ public record FileResourceStream(
         fileResource.getUid(),
         fileResource.getName(),
         fileResource.getContentType(),
-        () -> {
-          try {
-            return new Content(
-                fileResource.getContentLength(),
-                fileResourceService.openContentStream(fileResource));
-          } catch (NoSuchElementException e) {
-            // Note: we are assuming that the file resource is not available yet. The same approach
-            // is taken in other file endpoints or code relying on the storageStatus = PENDING.
-            // All we know for sure is the file resource is in the DB but not in the store.
-            throw new ConflictException(EXCEPTION_PENDING);
-          } catch (IOException e) {
-            throw new ConflictException(EXCEPTION_IO, EXCEPTION_IO_DEV);
-          }
-        });
+        () ->
+            fetch(
+                () ->
+                    new Content(
+                        fileResource.getContentLength(),
+                        fileResourceService.openContentStream(fileResource, readOptions()))));
   }
 
   /**
@@ -105,39 +150,26 @@ public record FileResourceStream(
           fileResource.getUid(),
           fileResource.getName(),
           fileResource.getContentType(),
-          () -> {
-            try {
-              return new Content(
-                  fileResource.getContentLength(),
-                  fileResourceService.openContentStreamToImage(fileResource, imageDimension));
-            } catch (NoSuchElementException e) {
-              // Note: we are assuming that the file resource is not available yet. The same
-              // approach
-              // is taken in other file endpoints or code relying on the storageStatus = PENDING.
-              // All we know for sure is the file resource is in the DB but not in the store.
-              throw new ConflictException(EXCEPTION_PENDING);
-            } catch (IOException e) {
-              throw new ConflictException(EXCEPTION_IO, EXCEPTION_IO_DEV);
-            }
-          });
+          () ->
+              fetch(
+                  () ->
+                      new Content(
+                          fileResource.getContentLength(),
+                          fileResourceService.openContentStreamToImage(
+                              fileResource, imageDimension, readOptions()))));
     }
 
     return new FileResourceStream(
         fileResource.getUid(),
         fileResource.getName(),
         fileResource.getContentType(),
-        () -> {
-          try {
-            byte[] content = fileResourceService.copyImageContent(fileResource, imageDimension);
-            return new Content(content.length, new ByteArrayInputStream(content));
-          } catch (NoSuchElementException e) {
-            // Note: we are assuming that the file resource is not available yet. The same approach
-            // is taken in other file endpoints or code relying on the storageStatus = PENDING.
-            // All we know for sure is the file resource is in the DB but not in the store.
-            throw new ConflictException(EXCEPTION_PENDING);
-          } catch (IOException e) {
-            throw new ConflictException(EXCEPTION_IO, EXCEPTION_IO_DEV);
-          }
-        });
+        () ->
+            fetch(
+                () -> {
+                  byte[] content =
+                      fileResourceService.copyImageContent(
+                          fileResource, imageDimension, readOptions());
+                  return new Content(content.length, new ByteArrayInputStream(content));
+                }));
   }
 }

--- a/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/export/FileResourceStreamTest.java
+++ b/dhis-2/dhis-tracker/src/test/java/org/hisp/dhis/tracker/export/FileResourceStreamTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.fileresource.FileResourceService;
+import org.hisp.dhis.fileresource.ImageFileDimension;
+import org.hisp.dhis.storage.BlobReadOptions;
+import org.hisp.dhis.storage.BlobReadTimeoutException;
+import org.hisp.dhis.tracker.export.timeout.Deadline;
+import org.hisp.dhis.tracker.export.timeout.DeadlineExceededException;
+import org.hisp.dhis.tracker.export.timeout.DeadlineHolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * How the file suppliers bound their object store fetch by the export budget. The store is mocked,
+ * so these assert what tracker hands it and when it is left alone; {@code S3BlobStoreServiceTest}
+ * covers what the timeout does to the request, and the export controller tests cover how a fetch
+ * failure is reported.
+ */
+class FileResourceStreamTest {
+
+  private final FileResourceService fileResourceService = mock(FileResourceService.class);
+
+  @AfterEach
+  void clearDeadline() {
+    DeadlineHolder.clear();
+  }
+
+  private static FileResource fileResource() {
+    FileResource fileResource = new FileResource();
+    fileResource.setUid("fileResourc1");
+    fileResource.setName("a.pdf");
+    fileResource.setContentType("application/pdf");
+    fileResource.setContentLength(3L);
+    return fileResource;
+  }
+
+  private BlobReadOptions capturedOptions() throws Exception {
+    ArgumentCaptor<BlobReadOptions> captor = ArgumentCaptor.forClass(BlobReadOptions.class);
+    verify(fileResourceService).openContentStream(any(FileResource.class), captor.capture());
+    return captor.getValue();
+  }
+
+  @Test
+  void shouldBoundTheFetchByWhatIsLeftOfTheBudgetRatherThanTheWholeOfIt() throws Exception {
+    // a 10s budget with 4s already spent on the database lookup
+    long[] clock = {0};
+    DeadlineHolder.set(Deadline.in(Duration.ofSeconds(10), () -> clock[0]));
+    clock[0] = Duration.ofSeconds(4).toNanos();
+    when(fileResourceService.openContentStream(any(FileResource.class), any()))
+        .thenReturn(new ByteArrayInputStream(new byte[3]));
+
+    FileResourceStream.of(fileResourceService, fileResource()).contentSupplier().get();
+
+    assertEquals(
+        Duration.ofSeconds(6),
+        capturedOptions().nextTimeout(),
+        "the fetch must get what is left of the budget, not a fresh one");
+  }
+
+  @Test
+  void shouldLeaveTheFetchUnboundedWhenTheTimeoutIsDisabled() throws Exception {
+    // no deadline armed, as when tracker.export.timeout is off
+    when(fileResourceService.openContentStream(any(FileResource.class), any()))
+        .thenReturn(new ByteArrayInputStream(new byte[3]));
+
+    FileResourceStream.of(fileResourceService, fileResource()).contentSupplier().get();
+
+    assertNull(
+        capturedOptions().nextTimeout(),
+        "callers without a budget must keep the store configuration");
+  }
+
+  @Test
+  void shouldFailFastWhenTheBudgetIsAlreadySpentBeforeReachingTheStore() {
+    // a 5s budget armed 6s ago, so the store is never reached
+    long[] clock = {0};
+    DeadlineHolder.set(Deadline.in(Duration.ofSeconds(5), () -> clock[0]));
+    clock[0] = Duration.ofSeconds(6).toNanos();
+
+    FileResourceSupplier<FileResourceStream.Content> content =
+        FileResourceStream.of(fileResourceService, fileResource()).contentSupplier();
+
+    assertThrows(DeadlineExceededException.class, content::get);
+    verifyNoInteractions(fileResourceService);
+  }
+
+  @Test
+  void shouldReportAStoreTimeoutAsTheBudgetBeingExceeded() throws Exception {
+    DeadlineHolder.set(Deadline.in(Duration.ofSeconds(5)));
+    when(fileResourceService.openContentStream(any(FileResource.class), any()))
+        .thenThrow(new BlobReadTimeoutException("timed out", new RuntimeException()));
+
+    FileResourceSupplier<FileResourceStream.Content> content =
+        FileResourceStream.of(fileResourceService, fileResource()).contentSupplier();
+
+    DeadlineExceededException e = assertThrows(DeadlineExceededException.class, content::get);
+    assertEquals(
+        "Tracker export exceeded its time budget of 5s",
+        e.getMessage(),
+        "the error must name the budget, as a timed out query does");
+  }
+
+  @Test
+  void shouldBoundTheBufferedImageFetchTooSinceItReadsTheWholeImage() throws Exception {
+    DeadlineHolder.set(Deadline.in(Duration.ofSeconds(10)));
+    ArgumentCaptor<BlobReadOptions> captor = ArgumentCaptor.forClass(BlobReadOptions.class);
+    when(fileResourceService.copyImageContent(
+            any(FileResource.class), eq(ImageFileDimension.MEDIUM), any()))
+        .thenReturn(new byte[3]);
+
+    FileResourceStream.ofImage(fileResourceService, fileResource(), ImageFileDimension.MEDIUM)
+        .contentSupplier()
+        .get();
+
+    verify(fileResourceService)
+        .copyImageContent(any(FileResource.class), eq(ImageFileDimension.MEDIUM), captor.capture());
+    assertNotNull(
+        captor.getValue().nextTimeout(), "the buffered image path must be bounded as well");
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -81,6 +81,7 @@ import org.hisp.dhis.query.QueryException;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.schema.SchemaPathException;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationException;
+import org.hisp.dhis.storage.BlobReadTimeoutException;
 import org.hisp.dhis.system.util.HttpUtils;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.deduplication.PotentialDuplicateConflictException;
@@ -287,6 +288,17 @@ public class CrudControllerAdvice {
   @ResponseBody
   public WebMessage deadlineExceededExceptionHandler(DeadlineExceededException ex) {
     return createWebMessage(ex.getMessage(), Status.ERROR, HttpStatus.GATEWAY_TIMEOUT);
+  }
+
+  /**
+   * For callers that do not translate this themselves, as the tracker export does to name the
+   * budget in the message.
+   */
+  @ExceptionHandler(BlobReadTimeoutException.class)
+  @ResponseBody
+  public WebMessage blobReadTimeoutExceptionHandler(BlobReadTimeoutException ex) {
+    return createWebMessage(
+        "Reading the file exceeded the time allowed", Status.ERROR, HttpStatus.GATEWAY_TIMEOUT);
   }
 
   @ExceptionHandler(IllegalQueryException.class)


### PR DESCRIPTION
Follow-up to #24970.

## Problem

The tracker file and image endpoints are bounded on their database lookup but not on the object store fetch that follows, and `S3BlobStoreService` sets no timeout of its own, so a wedged store holds the request indefinitely. Only `filestore.provider = s3` or `aws-s3` are affected; `filesystem`, the default, and `transient` have no remote call to hang on.

```
GET /api/tracker/trackedEntities/{te}/attributes/{attribute}/file   budget armed
  -> DB lookup                                                      bounded
  -> FileResourceStream supplier -> ... -> s3.getObject(...)        unbounded
```

## Fix

Blob reads take optional per-call `BlobReadOptions`, which ask the caller how much time is left. Tracker answers from the [export budget](https://github.com/dhis2/dhis2-core/pull/24970) and fails fast if it is already spent, the same check the query paths do.

Scoped by caller, not by bean: the one `BlobStoreService` bean is shared with app storage, so a client level timeout would have hit app install and serving too. Callers that pass nothing, the import jobs among them, keep today's behaviour.

Asking rather than carrying a duration because one read makes several calls, the existence check before the fetch among them, and they share the budget, so each gets the remainder rather than the whole of it again. It keeps the clock in the caller's deadline, the one source of truth for time, and out of `dhis-api`, which cannot see the tracker deadline type anyway since `dhis-service-core` cannot depend on `dhis-tracker`.

Only the S3 store acts on the timeout. `filesystem` and `transient` have nothing to hand it to but still get the fail fast check, so a spent budget is a 504 rather than a read nobody is waiting for. A read already underway is not interrupted, unchanged from today.

## Why `apiCallTimeout`

It covers the whole call including retries, unlike `apiCallAttemptTimeout` which bounds one attempt. The SDK retries by default, 4 attempts in the `LEGACY` mode it defaults to, and `AWS_RETRY_MODE` can change that from the environment, so a per attempt bound would give an unpredictable ceiling.

Two accepted limitations:

* it is not precise, the SDK only promises to abort somewhere after the timer fires
* the timer runs while the body is read, so a slow client can have its download cut short after the response status is committed, the same structural limit as serialization in #24970

Under a millisecond the SDK truncates to `0`, which means no timeout at all, so such a read is refused rather than sent unbounded. It could only time out anyway. The query paths hit the same thing at second granularity, `setQueryTimeout(0)` also meaning unbounded, and answer it the same way by failing fast on a spent budget.

The SDK's own timeout type is translated to `BlobReadTimeoutException` in `dhis-api`, so callers need no backend types. Tracker turns that into the `DeadlineExceededException` it already uses, naming the budget as a timed out query does, and passes it through untranslated when no budget is armed. `CrudControllerAdvice` maps it to 504 as well, so a caller that does not translate still gets 504 rather than 500.

## Tests

`S3BlobStoreServiceTest` covers what the timeout does to the request, `FileResourceStreamTest` what tracker hands the store: bounded by the remainder, all three suppliers included, unbounded when the timeout is disabled, and not called at all on a spent budget.

### Manual

MinIO behind [toxiproxy](https://github.com/Shopify/toxiproxy), `tracker.export.timeout = 5`, a PDF and an image on tracked entity attributes. The setup is not part of this PR, it lives on [`DHIS2-21390-s3-manual-test-setup`](https://github.com/dhis2/dhis2-core/blob/31c04e16f1cb8f552fe7c80828014520a56ce104/dhis-2/dhis-test-performance/docker-compose.s3-chaos.yml).

With 15s of latency injected against a 5s budget:

```console
$ docker compose exec proxy /toxiproxy-cli toxic add -t latency -a latency=15000 dhis2_minio
$ curl -i -u admin:district ".../api/tracker/trackedEntities/{te}/attributes/{attr}/file?program={p}"
HTTP/1.1 504
{"httpStatus":"Gateway Timeout","httpStatusCode":504,"status":"ERROR","message":"Tracker export exceeded its time budget of 5s"}
```

| endpoint | healthy | 15s latency |
|---|---|---|
| `/file` | 200 in 0.25s | 504 in 5.13s |
| `/image` | 200 in 0.11s | 504 in 5.09s |
| `/image?dimension=MEDIUM` | 200 in 0.14s | 504 in 5.10s |

All three suppliers, the buffered `MEDIUM` path included. The SDK logged the timeout it was handed as `4981 millis`, so the fetch got what was left of the budget after the database lookup rather than a fresh one. With the proxy disabled entirely the request fails in 0.58s, unchanged, since a store outage is not a timeout.
