### PR TITLE
fix: skip enrollment-has-events preheat query for enrollments not in the payload

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentsWithAtLeastOneEventSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentsWithAtLeastOneEventSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,10 +29,8 @@ package org.hisp.dhis.tracker.imports.preheat.supplier;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Objects;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -42,6 +40,13 @@ import org.springframework.stereotype.Component;
 /**
  * This supplier adds to the pre-heat object a List of all Enrollment UIDs that have at least ONE
  * Program Stage Instance that is not logically deleted ('deleted = true').
+ *
+ * <p>Only enrollments present in the import payload are checked: {@link
+ * org.hisp.dhis.tracker.imports.validation.validator.enrollment.SecurityOwnershipValidator} is the
+ * sole reader of this result, and it only exists for {@code Enrollment} tracker objects in the
+ * payload. Sourcing from {@link TrackerPreheat#getEnrollments()} instead would also query for every
+ * synthetic enrollment {@code EnrollmentSupplier} preheats for a program without registration, even
+ * on imports that carry no enrollment at all (e.g. a single event import).
  *
  * @author Luciano Fiandesio
  */
@@ -65,15 +70,18 @@ public class EnrollmentsWithAtLeastOneEventSupplier extends JdbcAbstractPreheatS
 
   @Override
   public void preheatAdd(TrackerObjects trackerObjects, TrackerPreheat preheat) {
-    final Map<String, Enrollment> enrollments = preheat.getEnrollments();
-    List<Long> programStageIds =
-        enrollments.values().stream().map(IdentifiableObject::getId).collect(Collectors.toList());
+    List<Long> enrollmentIds =
+        trackerObjects.getEnrollments().stream()
+            .map(e -> preheat.getEnrollment(e.getUid()))
+            .filter(Objects::nonNull)
+            .map(IdentifiableObject::getId)
+            .toList();
 
-    if (!programStageIds.isEmpty()) {
+    if (!enrollmentIds.isEmpty()) {
       List<String> uids = new ArrayList<>();
 
       MapSqlParameterSource parameters = new MapSqlParameterSource();
-      parameters.addValue("ids", programStageIds);
+      parameters.addValue("ids", enrollmentIds);
       jdbcTemplate.query(
           SQL,
           parameters,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentsWithAtLeastOneEventSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentsWithAtLeastOneEventSupplierTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.preheat.supplier;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.List;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.jdbc.core.RowCallbackHandler;
+
+/**
+ * A program without registration (single event) has a synthetic {@link
+ * org.hisp.dhis.program.Enrollment} that {@link EnrollmentSupplier} preheats wholesale for every
+ * import touching that program, regardless of whether the import payload carries any enrollment at
+ * all. This supplier must only query for enrollments that are actually part of the payload (the
+ * only case its result, {@link
+ * org.hisp.dhis.tracker.imports.validation.validator.enrollment.SecurityOwnershipValidator}'s
+ * enrollment-delete check, is ever read) - not for every enrollment preheat happens to hold.
+ */
+@ExtendWith(MockitoExtension.class)
+class EnrollmentsWithAtLeastOneEventSupplierTest {
+
+  @Mock private JdbcTemplate jdbcTemplate;
+
+  private EnrollmentsWithAtLeastOneEventSupplier supplier;
+
+  private TrackerPreheat preheat;
+
+  private org.hisp.dhis.program.Enrollment preheatedEnrollment;
+
+  @org.junit.jupiter.api.BeforeEach
+  void setUp() {
+    supplier = new EnrollmentsWithAtLeastOneEventSupplier(jdbcTemplate);
+
+    preheatedEnrollment = new org.hisp.dhis.program.Enrollment();
+    preheatedEnrollment.setId(42L);
+    preheatedEnrollment.setUid("synthEnrol1");
+
+    preheat = new TrackerPreheat();
+    preheat.putEnrollment(preheatedEnrollment.getUid(), preheatedEnrollment);
+  }
+
+  @Test
+  void doesNotQueryWhenPayloadHasNoEnrollments() {
+    supplier.preheatAdd(TrackerObjects.builder().build(), preheat);
+
+    verifyNoInteractions(jdbcTemplate);
+    assertTrue(preheat.getEnrollmentsWithOneOrMoreNonDeletedEvent().isEmpty());
+  }
+
+  @Test
+  void queriesOnlyForEnrollmentsPresentInThePayload() {
+    TrackerObjects trackerObjects =
+        TrackerObjects.builder()
+            .enrollments(
+                List.of(
+                    org.hisp.dhis.tracker.imports.domain.Enrollment.builder()
+                        .enrollment(preheatedEnrollment.getUid())
+                        .build()))
+            .build();
+
+    supplier.preheatAdd(trackerObjects, preheat);
+
+    verify(jdbcTemplate).query(any(PreparedStatementCreator.class), any(RowCallbackHandler.class));
+  }
+}


### PR DESCRIPTION
## Summary

- `EnrollmentsWithAtLeastOneEventSupplier` sourced its enrollment ids from `preheat.getEnrollments()` (every enrollment preheated for the import) instead of the actual import payload. On this branch, single-event programs don't have their own storage split from tracker events yet, so `EnrollmentSupplier` unconditionally preheats a synthetic `Enrollment` for every `WITHOUT_REGISTRATION` program touched by an import — even a bare `{"events": [...]}` payload with no enrollments at all.
- That made this supplier run its "does this enrollment have a non-deleted event" query on **every single-event import**, for an enrollment the payload never mentions.
- The result has exactly one reader: `SecurityOwnershipValidator.enrollmentHasEvents()`, a `Validator<Enrollment>` that only runs for `Enrollment` objects actually present in the payload, and only checks this when deleting one. A pure event import never reaches it, so the query's result was discarded every time — pure dead work.
- Fix: source the ids from `trackerObjects.getEnrollments()` (the actual payload) instead. For a single-event-only import that list is empty, so the existing `if (!ids.isEmpty())` guard now skips the query entirely. For real tracker imports it also narrows correctly to just the enrollments actually being submitted, rather than every enrollment preheat happens to hold.

## How this was found

Found while profiling a single tracker event import end-to-end with JProfiler against a local test instance, as a follow-up to the preheat work already landed in #24907. After that fix, this query was the largest remaining JDBC cost on a single-event import — about **47% of total JDBC time** for that request, despite the request touching zero enrollments. Confirmed with `EXPLAIN`/tracing that the query itself is fine (indexed, fast per-call); the issue is purely that it runs at all for this request shape.

## Live validation

Validated locally against a running instance with the fix applied:
- The query is completely absent from the JDBC trace on repeated single-event imports (verified across both a small batch and a 25-import repeated run), with no errors and no other side effects (GC stayed trivial across the run).
- Other unrelated JDBC/CPU costs in the same trace are unchanged, as expected, since this fix is narrowly scoped to the one supplier.

## Scope note

`master`'s copy of `EnrollmentsWithAtLeastOneEventSupplier` has the same `preheat.getEnrollments()` vs. payload sourcing pattern, but master's single events don't preheat any enrollment at all (no `EnrollmentSupplier` there), so the single-event dead-work trigger this PR fixes doesn't apply there in the same way. Scoped to 2.41 only for now.

## Test plan

- [x] New unit test `EnrollmentsWithAtLeastOneEventSupplierTest`, written first and confirmed to fail against the pre-fix code (proving it exercises the real behavior change, not just checking values that happen to match either way)
- [x] Full `preheat` and `validation` package test suites in `dhis-service-tracker` pass
- [x] Live-validated against a running local instance (see above)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Migrated from dhis2/dhis2-core#24936 to a fork-based PR (previously opened from a branch directly on this repo)._
