### PR TITLE
fix: avoid eager OptionSet.getOptions() dead work in analytics MetadataItemsHandler

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/MetadataItemsHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/MetadataItemsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023, University of Oslo
+ * Copyright (c) 2004-2026, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import org.hisp.dhis.analytics.common.CommonRequestParams;
 import org.hisp.dhis.analytics.common.params.CommonParamsDelegator;
 import org.hisp.dhis.analytics.common.params.CommonParsedParams;
@@ -99,12 +100,16 @@ public class MetadataItemsHandler {
         delegator.getAllItems().stream()
             .filter(it -> isInOriginalRequest(it.getItem().getUid(), commonRequestParams))
             .toList();
-    Set<Option> itemOptions =
-        delegator.getItemsOptions().stream()
-            .filter(o -> isInOriginalRequest(o.getUid(), commonRequestParams))
-            .collect(toSet());
     Map<String, List<Option>> optionsPresentInGrid = getItemOptions(grid, items);
-    Set<Option> optionItems = getOptionItems(grid, itemOptions, items, optionsPresentInGrid);
+    Set<Option> optionItems =
+        getOptionItems(
+            grid,
+            () ->
+                delegator.getItemsOptions().stream()
+                    .filter(o -> isInOriginalRequest(o.getUid(), commonRequestParams))
+                    .collect(toSet()),
+            items,
+            optionsPresentInGrid);
     List<DimensionalObject> allDimensionalObjects = delegator.getAllDimensionalObjects();
     List<DimensionItemKeywords.Keyword> periodKeywords = delegator.getPeriodKeywords();
     Set<Legend> itemLegends = delegator.getItemsLegends();
@@ -184,14 +189,16 @@ public class MetadataItemsHandler {
    * Gets the set of {@link Option} based on the given items and options.
    *
    * @param grid the {@link Grid}.
-   * @param itemOptions the set of {@link Option}.
+   * @param itemOptions supplies the set of {@link Option}, only invoked when the grid has no
+   *     results. This avoids paying for a full {@link OptionSet#getOptions()} collection reload
+   *     when the grid-scoped {@code optionsPresentInGrid} is what actually gets used.
    * @param items the list of {@link QueryItem}.
    * @param optionsPresentInGrid the map of {@link Option} present in the grid.
    * @return the set of relevant {@link Option}.
    */
   private Set<Option> getOptionItems(
       Grid grid,
-      Set<Option> itemOptions,
+      Supplier<Set<Option>> itemOptions,
       List<QueryItem> items,
       Map<String, List<Option>> optionsPresentInGrid) {
     Set<Option> optionItems = new LinkedHashSet<>();
@@ -205,7 +212,7 @@ public class MetadataItemsHandler {
               .distinct()
               .collect(toList()));
     } else {
-      optionItems.addAll(getItemOptionsAsFilter(itemOptions, items));
+      optionItems.addAll(getItemOptionsAsFilter(itemOptions.get(), items));
     }
 
     return optionItems;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/processing/MetadataItemsHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/processing/MetadataItemsHandlerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.common.processing;
+
+import static java.util.Collections.emptyList;
+import static org.hisp.dhis.test.TestBase.createDataElement;
+import static org.hisp.dhis.test.TestBase.createOption;
+import static org.hisp.dhis.test.TestBase.createOptionSet;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Map;
+import org.hisp.dhis.analytics.common.CommonRequestParams;
+import org.hisp.dhis.analytics.common.params.CommonParsedParams;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParamType;
+import org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset;
+import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.MetadataItem;
+import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.option.Option;
+import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.system.grid.ListGrid;
+import org.junit.jupiter.api.Test;
+
+class MetadataItemsHandlerTest {
+
+  private final MetadataItemsHandler handler = new MetadataItemsHandler();
+
+  @Test
+  void handleDoesNotEagerlyReloadFullOptionSetWhenGridHasResults() {
+    // Option set actually referenced by a grid row: resolved via the grid-scoped path.
+    Option rowOption = createOption('R');
+    OptionSet gridOptionSet = createOptionSet('G', rowOption);
+
+    // Option set attached only to the query item, as seen by CommonParamsDelegator. Spied so we
+    // can prove its full option collection is never reloaded once the grid already has results -
+    // that eager reload is dead work, since getOptionItems() only reads it on the empty-grid path.
+    Option unusedOption = createOption('U');
+    OptionSet queryItemOptionSet = spy(createOptionSet('Q', unusedOption));
+
+    DataElement dataElement = createDataElement('A');
+    QueryItem queryItem =
+        new QueryItem(
+            dataElement,
+            null,
+            dataElement.getValueType(),
+            dataElement.getAggregationType(),
+            queryItemOptionSet);
+
+    DimensionParam dimensionParam =
+        DimensionParam.ofObject(
+            queryItem, DimensionParamType.DIMENSIONS, IdScheme.UID, emptyList());
+    DimensionIdentifier<DimensionParam> dimensionIdentifier =
+        DimensionIdentifier.of(
+            ElementWithOffset.emptyElementWithOffset(),
+            ElementWithOffset.emptyElementWithOffset(),
+            dimensionParam);
+
+    CommonParsedParams commonParsedParams =
+        CommonParsedParams.builder().dimensionIdentifiers(List.of(dimensionIdentifier)).build();
+
+    ListGrid grid = new ListGrid();
+    grid.addHeader(
+        new GridHeader(
+            dataElement.getUid(),
+            dataElement.getUid(),
+            ValueType.TEXT,
+            false,
+            true,
+            gridOptionSet,
+            null));
+    grid.addRow();
+    grid.addValue(rowOption.getCode());
+
+    Map<String, MetadataItem> result =
+        handler.handle(grid, commonParsedParams, new CommonRequestParams());
+
+    assertNotNull(result);
+    verify(queryItemOptionSet, never()).getOptions();
+  }
+
+  @Test
+  void handleStillSurfacesFilterOptionsWhenGridHasNoResults() {
+    // Proves the fix doesn't change behaviour on the empty-grid path: itemOptions is now lazy,
+    // but it's still computed and used exactly as before whenever the grid has no rows.
+    Option filterOption = createOption('F');
+    OptionSet queryItemOptionSet = createOptionSet('Q', filterOption);
+
+    DataElement dataElement = createDataElement('A');
+    QueryItem queryItem =
+        new QueryItem(
+            dataElement,
+            null,
+            dataElement.getValueType(),
+            dataElement.getAggregationType(),
+            queryItemOptionSet);
+    queryItem.addFilter(new QueryFilter(QueryOperator.EQ, filterOption.getCode()));
+
+    DimensionParam dimensionParam =
+        DimensionParam.ofObject(
+            queryItem, DimensionParamType.DIMENSIONS, IdScheme.UID, emptyList());
+    DimensionIdentifier<DimensionParam> dimensionIdentifier =
+        DimensionIdentifier.of(
+            ElementWithOffset.emptyElementWithOffset(),
+            ElementWithOffset.emptyElementWithOffset(),
+            dimensionParam);
+
+    CommonParsedParams commonParsedParams =
+        CommonParsedParams.builder().dimensionIdentifiers(List.of(dimensionIdentifier)).build();
+
+    CommonRequestParams commonRequestParams = new CommonRequestParams();
+    commonRequestParams.getFilter().add(dataElement.getUid());
+    commonRequestParams.getFilter().add(filterOption.getUid());
+
+    ListGrid grid = new ListGrid();
+
+    Map<String, MetadataItem> result =
+        handler.handle(grid, commonParsedParams, commonRequestParams);
+
+    assertTrue(
+        result.containsKey(filterOption.getUid()),
+        "Filter option metadata should still be surfaced when the grid has no results");
+  }
+}


### PR DESCRIPTION
## Summary

`MetadataItemsHandler.handle()` computed `itemOptions` (a full `OptionSet.getOptions()`
collection reload for every option-set-backed query item) unconditionally on every
request, but `getOptionItems()` only ever reads it on the empty-grid branch — the
grid-scoped `optionsPresentInGrid` is what's actually used whenever the grid has rows
(the common case). So on every request that returns any rows at all, the full option
set (e.g. ~10,000 rows for a large option set) was reloaded and immediately discarded.

Found while live-validating #24850 via a Glowroot trace on `/analytics/events/aggregate`
for a 10k-option ICD-10 data element: only 12 SQL executions (~187ms DB time) but a
~1.13s total transaction — ~945ms of unaccounted Java-side work from this eager-then-
discarded reload plus its in-memory stream/filter work, invisible to JDBC-only
instrumentation.

- Wraps the `itemOptions` computation in a `Supplier<Set<Option>>`, only invoked inside
  `getOptionItems()`'s empty-grid branch.
- No behavior change on the empty-grid path (still computes and uses the same result,
  just lazily).
- Removes a full `OptionSet` collection reload from the has-results path entirely.

Not in scope (follow-up candidate): even the grid-scoped path resolves the *entire*
option set via `optionSet.getOptions()` and filters down to matching codes in Java —
pushing a `code IN (:codes)` filter into the query would avoid materializing unused
rows for very large option sets.

## Test plan

- [x] Added `MetadataItemsHandlerTest#handleDoesNotEagerlyReloadFullOptionSetWhenGridHasResults`
      — spies on the query item's `OptionSet`, asserts `getOptions()` is never invoked
      when the grid already has rows. Verified red (fails on the eager call) before the
      fix, green after.
- [x] Added `MetadataItemsHandlerTest#handleStillSurfacesFilterOptionsWhenGridHasNoResults`
      — proves the empty-grid path (used to surface filter-referenced option metadata
      when a query returns zero rows) is unchanged by the fix. Mutation-tested by
      temporarily breaking the lazy path and confirming this test fails for the right
      reason.
- [x] Full `dhis-service-analytics` module test suite passes locally.


---
_Migrated from dhis2/dhis2-core#24876 to a fork-based PR (previously opened from a branch directly on this repo)._
