### PR TITLE
perf: cache program rule variable option-set mappings (2.41)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -99,6 +99,8 @@ public interface CacheProvider {
 
   <V> Cache<V> createProgramRuleVariablesCache();
 
+  <V> Cache<V> createProgramRuleVariableOptionsCache();
+
   <V> Cache<V> createUserGroupNameCache();
 
   <V> Cache<V> createUserDisplayNameCache();

--- a/dhis-2/dhis-services/dhis-service-program-rule/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-program-rule/pom.xml
@@ -77,6 +77,10 @@
       <artifactId>javax.persistence-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -114,8 +114,13 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
    * tracker import that touched the owning program: that collection has no L2 cache (see {@code
    * OptionSet.hbm.xml}, deliberately, to avoid a different N+1), so every call re-queried the
    * database and re-populated the {@code Option} entity cache without ever reading from it.
-   * TTL-bounded rather than event-invalidated on Option/OptionSet writes, matching {@code
-   * programRuleVariablesCache}'s existing precedent in this module.
+   *
+   * <p>Invalidated per option set by {@link OptionCacheInvalidationListener} on every local
+   * insert/update/delete of an {@code Option}, since writes can arrive via {@code
+   * DefaultOptionService}, the generic metadata CRUD controller, or a metadata import - none of
+   * which funnel through one service method this class could hook into directly. The 1 hour TTL
+   * (matching {@code programRuleVariablesCache}'s existing precedent in this module) remains as a
+   * backstop for writes on another node in a cluster, which this same-node listener cannot see.
    */
   private final Cache<List<Option>> optionsByOptionSetId;
 
@@ -130,6 +135,15 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
     this.constantService = constantService;
     this.i18nManager = i18nManager;
     this.optionsByOptionSetId = cacheProvider.createProgramRuleVariableOptionsCache();
+  }
+
+  /**
+   * Evicts the cached options of the given option set, so the next {@link
+   * #getOptions(ProgramRuleVariable)} call recomputes them instead of serving a stale list. Called
+   * by {@link OptionCacheInvalidationListener}.
+   */
+  void invalidateOptionsCache(long optionSetId) {
+    optionsByOptionSetId.invalidate(String.valueOf(optionSetId));
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -108,12 +108,12 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
   private final I18nManager i18nManager;
 
   /**
-   * OptionSet id (as string) -> mapped {@code (name, code)} pairs for its options. A program
-   * rule variable's option set almost never changes at the timescale of data entry, but {@link
-   * #getOptions(ProgramRuleVariable)} previously ran {@code optionSet.getOptions()} fresh on
-   * every tracker import that touched the owning program: that collection has no L2 cache (see
-   * {@code OptionSet.hbm.xml}, deliberately, to avoid a different N+1), so every call re-queried
-   * the database and re-populated the {@code Option} entity cache without ever reading from it.
+   * OptionSet id (as string) -> mapped {@code (name, code)} pairs for its options. A program rule
+   * variable's option set almost never changes at the timescale of data entry, but {@link
+   * #getOptions(ProgramRuleVariable)} previously ran {@code optionSet.getOptions()} fresh on every
+   * tracker import that touched the owning program: that collection has no L2 cache (see {@code
+   * OptionSet.hbm.xml}, deliberately, to avoid a different N+1), so every call re-queried the
+   * database and re-populated the {@code Option} entity cache without ever reading from it.
    * TTL-bounded rather than event-invalidated on Option/OptionSet writes, matching {@code
    * programRuleVariablesCache}'s existing precedent in this module.
    */

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -51,13 +51,15 @@ import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.programrule.ProgramRule;
@@ -94,7 +96,6 @@ import org.springframework.stereotype.Service;
  * @author Zubair Asghar
  */
 @Slf4j
-@RequiredArgsConstructor
 @Service("org.hisp.dhis.programrule.engine.ProgramRuleEntityMapperService")
 public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityMapperService {
 
@@ -105,6 +106,31 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
   private final ConstantService constantService;
 
   private final I18nManager i18nManager;
+
+  /**
+   * OptionSet id (as string) -> mapped {@code (name, code)} pairs for its options. A program
+   * rule variable's option set almost never changes at the timescale of data entry, but {@link
+   * #getOptions(ProgramRuleVariable)} previously ran {@code optionSet.getOptions()} fresh on
+   * every tracker import that touched the owning program: that collection has no L2 cache (see
+   * {@code OptionSet.hbm.xml}, deliberately, to avoid a different N+1), so every call re-queried
+   * the database and re-populated the {@code Option} entity cache without ever reading from it.
+   * TTL-bounded rather than event-invalidated on Option/OptionSet writes, matching {@code
+   * programRuleVariablesCache}'s existing precedent in this module.
+   */
+  private final Cache<List<Option>> optionsByOptionSetId;
+
+  public DefaultProgramRuleEntityMapperService(
+      ProgramRuleService programRuleService,
+      ProgramRuleVariableService programRuleVariableService,
+      ConstantService constantService,
+      I18nManager i18nManager,
+      CacheProvider cacheProvider) {
+    this.programRuleService = programRuleService;
+    this.programRuleVariableService = programRuleVariableService;
+    this.constantService = constantService;
+    this.i18nManager = i18nManager;
+    this.optionsByOptionSetId = cacheProvider.createProgramRuleVariableOptionsCache();
+  }
 
   @Override
   public List<Rule> toMappedProgramRules() {
@@ -608,16 +634,20 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
       return List.of();
     }
 
+    OptionSet optionSet;
     if (prv.hasDataElement() && prv.getDataElement().hasOptionSet()) {
-      return prv.getDataElement().getOptionSet().getOptions().stream()
-          .map(op -> new Option(op.getName(), op.getCode()))
-          .toList();
+      optionSet = prv.getDataElement().getOptionSet();
     } else if (prv.hasTrackedEntityAttribute() && prv.getAttribute().hasOptionSet()) {
-      return prv.getAttribute().getOptionSet().getOptions().stream()
-          .map(op -> new Option(op.getName(), op.getCode()))
-          .toList();
+      optionSet = prv.getAttribute().getOptionSet();
+    } else {
+      return List.of();
     }
 
-    return List.of();
+    return optionsByOptionSetId.get(
+        String.valueOf(optionSet.getId()),
+        key ->
+            optionSet.getOptions().stream()
+                .map(op -> new Option(op.getName(), op.getCode()))
+                .toList());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/OptionCacheInvalidationListener.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/OptionCacheInvalidationListener.java
@@ -60,7 +60,11 @@ public class OptionCacheInvalidationListener
         PostCommitUpdateEventListener,
         PostCommitDeleteEventListener {
 
-  private final DefaultProgramRuleEntityMapperService mapperService;
+  // Hibernate's PostInsert/PostUpdate/PostDeleteEventListener all extend Serializable, making this
+  // class transitively Serializable even though it's just a Spring singleton registered with the
+  // EventListenerRegistry and never actually serialized. transient satisfies that contract without
+  // changing runtime behaviour.
+  private final transient DefaultProgramRuleEntityMapperService mapperService;
 
   @Override
   public void onPostInsert(PostInsertEvent event) {

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/OptionCacheInvalidationListener.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/OptionCacheInvalidationListener.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.programrule.engine;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.event.spi.PostCommitDeleteEventListener;
+import org.hibernate.event.spi.PostCommitInsertEventListener;
+import org.hibernate.event.spi.PostCommitUpdateEventListener;
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostInsertEvent;
+import org.hibernate.event.spi.PostUpdateEvent;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hisp.dhis.option.Option;
+import org.springframework.stereotype.Component;
+
+/**
+ * Invalidates {@link DefaultProgramRuleEntityMapperService}'s per-option-set options cache whenever
+ * an {@link Option} is inserted, updated, or deleted. Registered globally against Hibernate's
+ * post-commit events by {@link OptionCacheInvalidationListenerConfigurer}, mirroring {@code
+ * DeletedObjectPostDeleteEventListener}'s registration pattern.
+ *
+ * <p>This has to hook Hibernate directly rather than a service method: Option/OptionSet writes can
+ * arrive via {@code DefaultOptionService}, the generic metadata CRUD controller, or a metadata
+ * import, none of which funnel through a single call site that could invalidate the cache itself.
+ *
+ * <p>Same-node only - a write committed on another node in a cluster is not seen by this listener,
+ * so cross-node staleness still falls back to the cache's TTL.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OptionCacheInvalidationListener
+    implements PostCommitInsertEventListener,
+        PostCommitUpdateEventListener,
+        PostCommitDeleteEventListener {
+
+  private final DefaultProgramRuleEntityMapperService mapperService;
+
+  @Override
+  public void onPostInsert(PostInsertEvent event) {
+    invalidate(event.getEntity());
+  }
+
+  @Override
+  public void onPostUpdate(PostUpdateEvent event) {
+    invalidate(event.getEntity());
+  }
+
+  @Override
+  public void onPostDelete(PostDeleteEvent event) {
+    invalidate(event.getEntity());
+  }
+
+  private void invalidate(Object entity) {
+    if (entity instanceof Option option && option.getOptionSet() != null) {
+      // getId() never triggers a proxy load, even if the OptionSet association is lazy and
+      // otherwise uninitialized at this point.
+      mapperService.invalidateOptionsCache(option.getOptionSet().getId());
+    }
+  }
+
+  @Override
+  public boolean requiresPostCommitHanding(EntityPersister persister) {
+    return true;
+  }
+
+  @Override
+  public boolean requiresPostCommitHandling(EntityPersister persister) {
+    return PostCommitUpdateEventListener.super.requiresPostCommitHandling(persister);
+  }
+
+  @Override
+  public void onPostInsertCommitFailed(PostInsertEvent event) {
+    log.debug("onPostInsertCommitFailed: " + event);
+  }
+
+  @Override
+  public void onPostUpdateCommitFailed(PostUpdateEvent event) {
+    log.debug("onPostUpdateCommitFailed: " + event);
+  }
+
+  @Override
+  public void onPostDeleteCommitFailed(PostDeleteEvent event) {
+    log.debug("onPostDeleteCommitFailed: " + event);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/OptionCacheInvalidationListenerConfigurer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/OptionCacheInvalidationListenerConfigurer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.programrule.engine;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnit;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.springframework.stereotype.Component;
+
+/**
+ * Registers {@link OptionCacheInvalidationListener} against Hibernate's post-commit insert/update/
+ * delete events, the same way {@code DeletedObjectListenerConfigurer} registers its listeners.
+ */
+@Component
+public class OptionCacheInvalidationListenerConfigurer {
+  @PersistenceUnit private EntityManagerFactory emf;
+
+  private final OptionCacheInvalidationListener listener;
+
+  public OptionCacheInvalidationListenerConfigurer(OptionCacheInvalidationListener listener) {
+    this.listener = listener;
+  }
+
+  @PostConstruct
+  protected void init() {
+    SessionFactoryImpl sessionFactory = emf.unwrap(SessionFactoryImpl.class);
+
+    EventListenerRegistry registry =
+        sessionFactory.getServiceRegistry().getService(EventListenerRegistry.class);
+
+    registry.getEventListenerGroup(EventType.POST_COMMIT_INSERT).appendListener(listener);
+    registry.getEventListenerGroup(EventType.POST_COMMIT_UPDATE).appendListener(listener);
+    registry.getEventListenerGroup(EventType.POST_COMMIT_DELETE).appendListener(listener);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/OptionCacheInvalidationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/OptionCacheInvalidationListenerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.programrule.engine;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostInsertEvent;
+import org.hibernate.event.spi.PostUpdateEvent;
+import org.hisp.dhis.option.Option;
+import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.program.Program;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OptionCacheInvalidationListenerTest {
+
+  @Mock private DefaultProgramRuleEntityMapperService mapperService;
+
+  @Mock private PostInsertEvent postInsertEvent;
+
+  @Mock private PostUpdateEvent postUpdateEvent;
+
+  @Mock private PostDeleteEvent postDeleteEvent;
+
+  private OptionCacheInvalidationListener listener;
+
+  @BeforeEach
+  void setUp() {
+    listener = new OptionCacheInvalidationListener(mapperService);
+  }
+
+  private Option optionOf(long optionSetId) {
+    OptionSet optionSet = new OptionSet();
+    optionSet.setId(optionSetId);
+    Option option = new Option();
+    option.setOptionSet(optionSet);
+    return option;
+  }
+
+  @Test
+  void shouldInvalidateOwningOptionSetOnInsert() {
+    when(postInsertEvent.getEntity()).thenReturn(optionOf(42L));
+
+    listener.onPostInsert(postInsertEvent);
+
+    verify(mapperService).invalidateOptionsCache(42L);
+  }
+
+  @Test
+  void shouldInvalidateOwningOptionSetOnUpdate() {
+    when(postUpdateEvent.getEntity()).thenReturn(optionOf(7L));
+
+    listener.onPostUpdate(postUpdateEvent);
+
+    verify(mapperService).invalidateOptionsCache(7L);
+  }
+
+  @Test
+  void shouldInvalidateOwningOptionSetOnDelete() {
+    when(postDeleteEvent.getEntity()).thenReturn(optionOf(13L));
+
+    listener.onPostDelete(postDeleteEvent);
+
+    verify(mapperService).invalidateOptionsCache(13L);
+  }
+
+  @Test
+  void shouldIgnoreNonOptionEntities() {
+    when(postInsertEvent.getEntity()).thenReturn(new Program());
+
+    listener.onPostInsert(postInsertEvent);
+
+    verify(mapperService, never()).invalidateOptionsCache(anyLong());
+  }
+
+  @Test
+  void shouldIgnoreOptionWithoutAnOptionSet() {
+    when(postInsertEvent.getEntity()).thenReturn(new Option());
+
+    listener.onPostInsert(postInsertEvent);
+
+    verify(mapperService, never()).invalidateOptionsCache(anyLong());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -56,6 +56,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.cache.SimpleCacheBuilder;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.constant.Constant;
@@ -99,7 +101,6 @@ import org.hisp.dhis.util.ObjectUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -144,10 +145,17 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest {
 
   @Mock private I18n i18n;
 
-  @InjectMocks private DefaultProgramRuleEntityMapperService mapper;
+  @Mock private CacheProvider cacheProvider;
+
+  private DefaultProgramRuleEntityMapperService mapper;
 
   @BeforeEach
   public void initTest() {
+    when(cacheProvider.<List<Option>>createProgramRuleVariableOptionsCache())
+        .thenReturn(new SimpleCacheBuilder<List<Option>>().build());
+    mapper =
+        new DefaultProgramRuleEntityMapperService(
+            null, programRuleVariableService, constantService, i18nManager, cacheProvider);
 
     program = createProgram('P');
     programStage = createProgramStage('S', program);

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -112,6 +112,7 @@ public class DefaultCacheProvider implements CacheProvider {
     propertyTransformerCache,
     programHasRulesCache,
     programRuleVariablesCache,
+    programRuleVariableOptionsCache,
     userGroupNameCache,
     userDisplayNameCache,
     programWebHookNotificationTemplateCache,
@@ -457,6 +458,17 @@ public class DefaultCacheProvider implements CacheProvider {
         this.<V>newBuilder()
             .forRegion(Region.programRuleVariablesCache.name())
             .expireAfterWrite(3, TimeUnit.HOURS)
+            .withInitialCapacity((int) getActualSize(20))
+            .forceInMemory()
+            .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_1K))));
+  }
+
+  @Override
+  public <V> Cache<V> createProgramRuleVariableOptionsCache() {
+    return registerCache(
+        this.<V>newBuilder()
+            .forRegion(Region.programRuleVariableOptionsCache.name())
+            .expireAfterWrite(1, TimeUnit.HOURS)
             .withInitialCapacity((int) getActualSize(20))
             .forceInMemory()
             .withMaximumSize(orZeroInTestRun(getActualSize(SIZE_1K))));


### PR DESCRIPTION
## Problem

`DefaultProgramRuleEntityMapperService.getOptions(ProgramRuleVariable)` called `optionSet.getOptions()` fresh on every tracker import that touched the owning program, for every option-set-backed rule variable with `useCodeForOptionSet` false. `OptionSet.options` has no L2 collection cache (deliberately, to avoid a different N+1), so every call re-queried `optionvalue` and re-populated the `Option` entity cache without ever reading from it — visible on a live instance as `ehcache_puts_total{cache="Option"}` climbing steadily against a flat `ehcache_hits_total`, correlated with `ProgramRuleAction` cache hits, while the option set itself hadn't changed in over a week.

Also directly visible in query-stats profiling as a `SELECT ... FROM optionset WHERE optionsetid = ?` fired once per rule-variable-mapping pass per option set, because any non-id method call on a Hibernate proxy (like `.getOptions()`) forces the proxy to fully initialize itself first.

## Fix

Memoize the mapped `(name, code)` list per option set id via a new `CacheProvider`-backed cache. On a cache hit, the code now only calls `optionSet.getId()` — which Hibernate special-cases to never trigger proxy initialization — so the `optionset` row load is skipped entirely instead of just its options collection.

## Cache invalidation

`Option` writes can arrive via `DefaultOptionService`, the generic metadata CRUD controller, or a metadata import — none of which funnel through a single call site this class could hook into directly to invalidate the cache itself. So invalidation happens at the Hibernate level instead: `OptionCacheInvalidationListener` is a `PostCommit` insert/update/delete listener for the `Option` entity, registered globally via `OptionCacheInvalidationListenerConfigurer` — the same registration pattern `DeletedObjectListenerConfigurer` already uses elsewhere in the codebase. On any Option write, it evicts just that option's owning option-set entry.

This is same-node only. A write committed on another node in a cluster isn't seen by this listener, so cross-node staleness still relies on the pre-existing 1h TTL as a backstop.

## What this does *not* fix

Worth being explicit about scope: this only caches the `OptionSet` → `Option` leg. It does not touch the separate `DataElement` proxy load that also shows up in the same query-stats profile (`SELECT ... FROM dataelement WHERE dataelementid = ?`) — `toRuleVariable()`/`toMappedValueType()` call `prv.getDataElement().getUid()`/`.getValueType()`/`.hasOptionSet()` unconditionally on every mapping pass, uncached, regardless of whether an option set is involved. That's a separate N+1 (no cache wraps `toMappedProgramRuleVariables()` as a whole) and isn't addressed here.

## Testing

- `ProgramRuleEntityMapperServiceTest` updated for the new `CacheProvider` constructor dependency (was relying on `@InjectMocks` passing `null` for anything unmocked, which broke once the constructor started calling `cacheProvider.createProgramRuleVariableOptionsCache()` eagerly — fixed with explicit construction stubbed with a real `SimpleCacheBuilder`-backed cache rather than a mock, since a mock stubbed after `@InjectMocks` already ran is too late).
- New `OptionCacheInvalidationListenerTest` covers the listener's type/null-guard logic in isolation; mutation-tested (broke the `instanceof Option` check, confirmed all 5 tests fail correctly, restored).
- Full `dhis-service-program-rule` module: 41 tests, 0 failures.

🤖 AI Assisted



---
_Migrated from dhis2/dhis2-core#24852 to a fork-based PR (previously opened from a branch directly on this repo)._
