### PR TITLE
perf: replace CAT_OPTIONS correlated subselect with LATERAL JOIN

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/store/query/EventQuery.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/store/query/EventQuery.java
@@ -37,7 +37,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.dxf2.deprecated.tracker.trackedentity.store.Function;
 import org.hisp.dhis.dxf2.deprecated.tracker.trackedentity.store.QueryElement;
-import org.hisp.dhis.dxf2.deprecated.tracker.trackedentity.store.Subselect;
 import org.hisp.dhis.dxf2.deprecated.tracker.trackedentity.store.TableColumn;
 
 /**
@@ -71,15 +70,7 @@ public class EventQuery {
     ORGUNIT_UID(new TableColumn("o", "uid", "ou_uid")),
     ORGUNIT_NAME(new TableColumn("o", "name", "ou_name")),
     COC_UID(new TableColumn("coc", "uid", "cocuid")),
-    CAT_OPTIONS(
-        new Subselect(
-            "( "
-                + "SELECT string_agg(opt.uid::text, ',') "
-                + "FROM categoryoption opt "
-                + "join categoryoptioncombos_categoryoptions ccc "
-                + "on opt.categoryoptionid = ccc.categoryoptionid "
-                + "WHERE coc.categoryoptioncomboid = ccc.categoryoptioncomboid )",
-            "catoptions")),
+    CAT_OPTIONS(new TableColumn("catopts", "catoptions")),
     ASSIGNED_USER(new TableColumn("ui", "uid", "userid")),
     ASSIGNED_USER_FIRST_NAME(new TableColumn("ui", "firstname")),
     ASSIGNED_USER_SURNAME(new TableColumn("ui", "surname")),
@@ -118,6 +109,13 @@ public class EventQuery {
         + "join organisationunit o on psi.organisationunitid = o.organisationunitid "
         + "join categoryoptioncombo coc on psi.attributeoptioncomboid = coc.categoryoptioncomboid "
         + "left join userinfo ui on psi.assigneduserid = ui.userinfoid "
+        + "left join lateral ("
+        + "select string_agg(opt.uid::text, ',') as catoptions "
+        + "from categoryoption opt "
+        + "join categoryoptioncombos_categoryoptions ccc "
+        + "on opt.categoryoptionid = ccc.categoryoptionid "
+        + "where coc.categoryoptioncomboid = ccc.categoryoptioncomboid "
+        + ") catopts on true "
         + "where pi.enrollmentid in (:ids)";
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/query/EventQuery.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/query/EventQuery.java
@@ -67,15 +67,7 @@ public class EventQuery {
     ORGUNIT_UID(new TableColumn("o", "uid", "ou_uid")),
     ORGUNIT_NAME(new TableColumn("o", "name", "ou_name")),
     COC_UID(new TableColumn("coc", "uid", "cocuid")),
-    CAT_OPTIONS(
-        new Subselect(
-            "( "
-                + "SELECT string_agg(opt.uid::text, ';') "
-                + "FROM categoryoption opt "
-                + "join categoryoptioncombos_categoryoptions ccc "
-                + "on opt.categoryoptionid = ccc.categoryoptionid "
-                + "WHERE coc.categoryoptioncomboid = ccc.categoryoptioncomboid )",
-            "catoptions")),
+    CAT_OPTIONS(new TableColumn("catopts", "catoptions")),
     ASSIGNED_USER(new TableColumn("ui", "uid", "userid")),
     ASSIGNED_USER_FIRST_NAME(new TableColumn("ui", "firstname")),
     ASSIGNED_USER_SURNAME(new TableColumn("ui", "surname")),
@@ -114,6 +106,13 @@ public class EventQuery {
         + "join organisationunit o on ev.organisationunitid = o.organisationunitid "
         + "join categoryoptioncombo coc on ev.attributeoptioncomboid = coc.categoryoptioncomboid "
         + "left join userinfo ui on ev.assigneduserid = ui.userinfoid "
+        + "left join lateral ("
+        + "select string_agg(opt.uid::text, ';') as catoptions "
+        + "from categoryoption opt "
+        + "join categoryoptioncombos_categoryoptions ccc "
+        + "on opt.categoryoptionid = ccc.categoryoptionid "
+        + "where coc.categoryoptioncomboid = ccc.categoryoptioncomboid "
+        + ") catopts on true "
         + "where en.enrollmentid in (:ids)";
   }
 


### PR DESCRIPTION
Applies to both the deprecated DXF2 store and the new tracker aggregates store. Correlated subselects in the SELECT list re-execute per row; the LATERAL JOIN lets the planner materialise the aggregation once per COC.


---
_Migrated from dhis2/dhis2-core#23744 to a fork-based PR (previously opened from a branch directly on this repo)._
