### PR TITLE
perf: replace CAT_OPTIONS correlated subselect with LATERAL JOIN in DXF2 EventQuery

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/query/EventQuery.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/query/EventQuery.java
@@ -37,7 +37,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.dxf2.events.trackedentity.store.Function;
 import org.hisp.dhis.dxf2.events.trackedentity.store.QueryElement;
-import org.hisp.dhis.dxf2.events.trackedentity.store.Subselect;
 import org.hisp.dhis.dxf2.events.trackedentity.store.TableColumn;
 
 /**
@@ -71,15 +70,7 @@ public class EventQuery {
     ORGUNIT_UID(new TableColumn("o", "uid", "ou_uid")),
     ORGUNIT_NAME(new TableColumn("o", "name", "ou_name")),
     COC_UID(new TableColumn("coc", "uid", "cocuid")),
-    CAT_OPTIONS(
-        new Subselect(
-            "( "
-                + "SELECT string_agg(opt.uid::text, ',') "
-                + "FROM dataelementcategoryoption opt "
-                + "join categoryoptioncombos_categoryoptions ccc "
-                + "on opt.categoryoptionid = ccc.categoryoptionid "
-                + "WHERE coc.categoryoptioncomboid = ccc.categoryoptioncomboid )",
-            "catoptions")),
+    CAT_OPTIONS(new TableColumn("catopts", "catoptions")),
     ASSIGNED_USER(new TableColumn("ui", "uid", "userid")),
     ASSIGNED_USER_FIRST_NAME(new TableColumn("ui", "firstname")),
     ASSIGNED_USER_SURNAME(new TableColumn("ui", "surname")),
@@ -118,6 +109,13 @@ public class EventQuery {
         + "join organisationunit o on psi.organisationunitid = o.organisationunitid "
         + "join categoryoptioncombo coc on psi.attributeoptioncomboid = coc.categoryoptioncomboid "
         + "left join userinfo ui on psi.assigneduserid = ui.userinfoid "
+        + "left join lateral ("
+        + "select string_agg(opt.uid::text, ',') as catoptions "
+        + "from dataelementcategoryoption opt "
+        + "join categoryoptioncombos_categoryoptions ccc "
+        + "on opt.categoryoptionid = ccc.categoryoptionid "
+        + "where coc.categoryoptioncomboid = ccc.categoryoptioncomboid "
+        + ") catopts on true "
         + "where pi.programinstanceid in (:ids)";
   }
 


### PR DESCRIPTION
Correlated sub+selects in the SELECT list execute once per row. Moving to a LATERAL JOIN lets the planner hoist and materialise the aggregation once per COC rather than re-evaluating it for every event row.  The vast majority of programs do not use an AOC, so most of the time, this is always going to be "default". The subselect was doing redundant work proportional to event count even when the answer was identical every time. LATERAL collapses that.      


Testing on a production scale system reveals that the query time can be decreased from 220ms to under 70ms. 


Tracker performance tests were inconclusive, but there appeared to be no regression. The difference on the production scale DB was relatively modest, even with millions of events. 

  ### Median Response Time (p50) (ms)                                                                                                                                                                                      
                                                                                                                                                                                                                           
  | Scenario | Baseline | Feature | Diff | Change |                                                                                                                                                                        
  |:---|---:|---:|---:|:---|                                                                                                                                                                                               
  | Get ANC events\|Go to first page | 9 | 10 | +1 | :arrow_up: +11.1% |                                                                                                                                                   
  | Get ANC events\|Search not assigned | 9 | 10 | +1 | :arrow_up: +11.1% |                                                                                                                                                
  | Get Child Programme TEs\|Get TEs from events | 7 | 6 | -1 | :arrow_down: -14.3% |                                                                                                                                      
  | Get Child Programme TEs\|Get TEs with enrollment status | 42 | 41 | -1 | :arrow_down: -2.4% |                                                                                                                          
  | Get Child Programme TEs\|Get first page of TEs | 39 | 38 | -1 | :arrow_down: -2.6% |                                                                                                                                   
  | Get Child Programme TEs\|Not found TE by name with eq operator | 12 | 12 | +0 | +0.0% |                                                                                                                                
  | Get Child Programme TEs\|Not found TE by name with like operator | 13 | 13 | +0 | +0.0% |                                                                                                                              
  | Get Child Programme TEs\|Search Birth events | 91 | 92 | +1 | :arrow_up: +1.1% |                                                                                                                                       
  | Get Child Programme TEs\|Search TE by name with eq operator | 17 | 17 | +0 | +0.0% |                                                                                                                                   
  | Get Child Programme TEs\|Search TE by name with like operator | 21 | 21 | +0 | +0.0% |                                                                                                                                 
  | Get Child Programme TEs\|Go to single enrollment\|Get first enrollment | 11 | 11 | +0 | +0.0% |                                                                                                                        
  | Get Child Programme TEs\|Go to single enrollment\|Get first tracked entity | 21 | 21 | +0 | +0.0% |                                                                                                                    
  | Get Child Programme TEs\|Go to single enrollment\|Get relationships for first tracked entity | 3 | 2 | -1 | :arrow_down: -33.3% |                                                                                      
  | Get Child Programme TEs\|Go to single enrollment\|Get one event\|Get first event from enrollment | 12 | 11 | -1 | :arrow_down: -8.3% |                                                                                 
  | Get Child Programme TEs\|Go to single enrollment\|Get one event\|Get relationships for first event | 2 | 2 | +0 | +0.0% |                                                                                              
  | Login | 71 | 73 | +2 | :arrow_up: +2.8% |                                                                                                                                                                              
                                                                                                                                                                                                                           
  ### 95th Percentile Response Time (p95) (ms)                                                                                                                                                                             
                                                                                                                                                                                                                           
  | Scenario | Baseline | Feature | Diff | Change |                                                                                                                                                                        
  |:---|---:|---:|---:|:---|                                                                                                                                                                                               
  | Get ANC events\|Go to first page | 12 | 13 | +1 | :arrow_up: +8.3% |                                                                                                                                                   
  | Get ANC events\|Search not assigned | 11 | 13 | +2 | :arrow_up: +18.2% |                                                                                                                                               
  | Get Child Programme TEs\|Get TEs from events | 7 | 7 | +0 | +0.0% |                                                                                                                                                    
  | Get Child Programme TEs\|Get TEs with enrollment status | 45 | 44 | -1 | :arrow_down: -2.2% |                                                                                                                          
  | Get Child Programme TEs\|Get first page of TEs | 43 | 41 | -2 | :arrow_down: -4.7% |                                                                                                                                   
  | Get Child Programme TEs\|Not found TE by name with eq operator | 14 | 13 | -1 | :arrow_down: -7.1% |                                                                                                                   
  | Get Child Programme TEs\|Not found TE by name with like operator | 15 | 15 | +0 | +0.0% |                                                                                                                              
  | Get Child Programme TEs\|Search Birth events | 96 | 98 | +2 | :arrow_up: +2.1% |                                                                                                                                       
  | Get Child Programme TEs\|Search TE by name with eq operator | 21 | 21 | +0 | +0.0% |                                                                                                                                   
  | Get Child Programme TEs\|Search TE by name with like operator | 25 | 25 | +0 | +0.0% |                                                                                                                                 
  | Get Child Programme TEs\|Go to single enrollment\|Get first enrollment | 12 | 13 | +1 | :arrow_up: +8.3% |                                                                                                             
  | Get Child Programme TEs\|Go to single enrollment\|Get first tracked entity | 23 | 23 | +0 | +0.0% |                                                                                                                    
  | Get Child Programme TEs\|Go to single enrollment\|Get relationships for first tracked entity | 4 | 3 | -1 | :arrow_down: -25.0% |                                                                                      
  | Get Child Programme TEs\|Go to single enrollment\|Get one event\|Get first event from enrollment | 13 | 13 | +0 | +0.0% |                                                                                              
  | Get Child Programme TEs\|Go to single enrollment\|Get one event\|Get relationships for first event | 3 | 3 | +0 | +0.0% |                                                                                              
  | Login | 74 | 79 | +5 | :arrow_up: +6.8% |                                                                                                                                                                              
                                                                                                                                                                                                                           
  _:arrow_down: = faster (improvement), :arrow_up: = slower (regression)_  


---
_Migrated from dhis2/dhis2-core#23743 to a fork-based PR (previously opened from a branch directly on this repo)._
