### PR TITLE
perf: use like for single parent in hierarchy search [DHIS2-22091]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -391,7 +391,11 @@ public class OrganisationUnitController
       }
     }
     if (parents != null && !parents.isEmpty()) {
-      specialFilters.add(token("path", String.join("|", parents), MatchMode.ANYWHERE));
+      if (parents.size() == 1) {
+        specialFilters.add(like("path", parents.iterator().next(), MatchMode.ANYWHERE));
+      } else {
+        specialFilters.add(token("path", String.join("|", parents), MatchMode.ANYWHERE));
+      }
     }
     if (params.isUserOnly())
       specialFilters.add(in("id", getCurrentUserDetails().getUserOrgUnitIds()));


### PR DESCRIPTION
### Summary
Using `token` search results in a regex search in the DB that becomes a table scan as no index can be utilized which is intensive and slow. For a single parent the same search can be done using a `like` which can use indexes to a degree. 

### Performance Impact
See Jason's https://github.com/dhis2/dhis2-core/pull/25125#issuecomment-5602140839 below