### PR TITLE
fix: Correct organisation unit hierarchy search

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitService.java
@@ -137,6 +137,12 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
   List<OrganisationUnit> getOrganisationUnitsByUid(@Nonnull Collection<String> uids);
 
   /**
+   * Returns the stored paths of existing organisation units with the given UIDs, without loading
+   * their entities or descendants. Missing units and units without a stored path are omitted.
+   */
+  List<String> getOrganisationUnitPathsByUid(@Nonnull Collection<UID> uids);
+
+  /**
    * Returns an OrganisationUnit with a given name.
    *
    * @param name the name of the OrganisationUnit to return.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitStore.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import org.hisp.dhis.common.IdentifiableObjectStore;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.program.Program;
 
@@ -67,6 +68,12 @@ public interface OrganisationUnitStore
    * @return
    */
   List<String> getDataViewOrganisationUnitsUidsByUser(String username);
+
+  /**
+   * Returns non-null stored paths for the given UIDs without loading organisation unit entities.
+   * Missing UIDs are omitted; an empty collection returns no paths.
+   */
+  List<String> getOrganisationUnitPathsByUid(Collection<UID> uids);
 
   /**
    * Returns all OrganisationUnits by lastUpdated.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
@@ -161,6 +161,12 @@ public class DefaultOrganisationUnitService implements OrganisationUnitService {
 
   @Override
   @Transactional(readOnly = true)
+  public List<String> getOrganisationUnitPathsByUid(@Nonnull Collection<UID> uids) {
+    return organisationUnitStore.getOrganisationUnitPathsByUid(uids);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
   public OrganisationUnit getOrganisationUnit(String uid) {
     return organisationUnitStore.getByUid(uid);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitStore.java
@@ -42,6 +42,7 @@ import javax.annotation.Nonnull;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.commons.util.TextUtils;
@@ -96,6 +97,17 @@ public class HibernateOrganisationUnitStore
   public List<String> getDataViewOrganisationUnitsUidsByUser(String username) {
     String sql = getOrgUnitTablesUids(username, "userdatavieworgunits");
     return jdbcTemplate.queryForList(sql, String.class);
+  }
+
+  @Override
+  public List<String> getOrganisationUnitPathsByUid(Collection<UID> uids) {
+    if (uids.isEmpty()) return List.of();
+    return getSession()
+        .createQuery(
+            "select ou.path from OrganisationUnit ou where ou.uid in :uids and ou.path is not null",
+            String.class)
+        .setParameterList("uids", UID.toValueList(uids))
+        .list();
   }
 
   private static String getOrgUnitTablesUids(String username, String orgUnitTableName) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/DescendantOfOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/DescendantOfOperator.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.query.operators;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.Collection;
+import java.util.List;
+import org.hisp.dhis.query.JpaPredicateSupplier;
+import org.hisp.dhis.query.planner.PropertyPath;
+
+/**
+ * Matches a root organisation unit or descendants of any supplied full stored path. This is an
+ * internal hierarchy restriction, not a public filter operator.
+ *
+ * @author Morten Svanæs
+ */
+public final class DescendantOfOperator extends Operator<String> implements JpaPredicateSupplier {
+  public DescendantOfOperator(Collection<String> rootPaths) {
+    super("descendantOf", List.of(String.class), rootPaths);
+  }
+
+  @Override
+  public <Y> Predicate getPredicate(CriteriaBuilder builder, Root<Y> root, PropertyPath path) {
+    return getPredicate(builder, getPropertyPath(root, path));
+  }
+
+  @Override
+  public <Y> Predicate getPredicate(CriteriaBuilder builder, Root<Y> root, CriteriaQuery<?> query) {
+    return getPredicate(builder, root.get("path"));
+  }
+
+  private Predicate getPredicate(CriteriaBuilder builder, Expression<String> path) {
+    Predicate[] roots = new Predicate[args.size()];
+    for (int i = 0; i < args.size(); i++) {
+      String rootPath = args.get(i);
+      String prefix = rootPath.replace("!", "!!").replace("%", "!%").replace("_", "!_") + "/%";
+      roots[i] = builder.or(builder.equal(path, rootPath), builder.like(path, prefix, '!'));
+    }
+    return builder.or(roots);
+  }
+
+  @Override
+  public boolean test(Object value) {
+    if (!(value instanceof String path)) return false;
+    for (String rootPath : args) {
+      if (path.equals(rootPath)
+          || (path.startsWith(rootPath)
+              && path.length() > rootPath.length()
+              && path.charAt(rootPath.length()) == '/')) return true;
+    }
+    return false;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DescendantOfOperatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DescendantOfOperatorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.query;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.hisp.dhis.query.operators.DescendantOfOperator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Morten Svanæs
+ */
+class DescendantOfOperatorTest {
+  @Test
+  void matchesRootsAndDescendantsOfAnyRoot() {
+    DescendantOfOperator scope =
+        new DescendantOfOperator(List.of("/top/first", "/top/second", "/top/first/nested"));
+
+    assertTrue(scope.test("/top/first"));
+    assertTrue(scope.test("/top/second/child"));
+    assertTrue(scope.test("/top/first/nested/child"));
+    assertFalse(scope.test("/top"));
+    assertFalse(scope.test("/top/sibling"));
+    assertFalse(scope.test("/other/first/child"));
+    assertFalse(scope.test("/top/firstSibling/child"));
+  }
+
+  @Test
+  void missingRootsAndMissingPathsDoNotMatch() {
+    assertFalse(new DescendantOfOperator(List.of()).test("/top/first"));
+    assertFalse(new DescendantOfOperator(List.of("/top")).test(null));
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
@@ -30,12 +30,14 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -289,6 +291,152 @@ class OrganisationUnitControllerTest extends PostgresControllerIntegrationTestBa
     // Should only get level 3 org units within the data view hierarchy
     assertListOfOrganisationUnits(
         GET("/organisationUnits?withinDataViewUserHierarchy=true&level=3").content(), "L21", "L22");
+  }
+
+  @Test
+  void testGetWithinUserHierarchyWithDisjointRoots() {
+    switchToHierarchyUser(List.of(ou21, ou22), List.of(), List.of());
+
+    assertListOfOrganisationUnits(
+        GET("/organisationUnits?withinUserHierarchy=true").content(), "L21", "L22", "L31", "L32");
+  }
+
+  @Test
+  void testGetWithinUserSearchHierarchyWithOverlappingRoots() {
+    switchToHierarchyUser(List.of(), List.of(), List.of(ou1, ou21));
+
+    assertListOfOrganisationUnits(
+        GET("/organisationUnits?withinUserSearchHierarchy=true").content(),
+        "L1",
+        "L21",
+        "L22",
+        "L31",
+        "L32");
+  }
+
+  @Test
+  void testGetWithinUserSearchHierarchyUsesSearchInsteadOfCaptureRoots() {
+    switchToHierarchyUser(List.of(ou21), List.of(), List.of(ou22));
+
+    assertListOfOrganisationUnits(
+        GET("/organisationUnits?withinUserSearchHierarchy=true").content(), "L22", "L32");
+  }
+
+  @Test
+  void testGetWithinUserHierarchyFlagsCombineRoots() {
+    switchToHierarchyUser(List.of(ou21), List.of(ou22), List.of(ou1));
+
+    assertListOfOrganisationUnits(
+        GET("/organisationUnits?withinUserHierarchy=true&withinDataViewUserHierarchy=true")
+            .content(),
+        "L21",
+        "L22",
+        "L31",
+        "L32");
+    assertListOfOrganisationUnits(
+        GET("/organisationUnits?withinUserHierarchy=true&withinUserSearchHierarchy=true").content(),
+        "L1",
+        "L21",
+        "L22",
+        "L31",
+        "L32");
+  }
+
+  @Test
+  void testGetWithinUserSearchAndDataViewHierarchyFallBackToCaptureRoots() {
+    switchToHierarchyUser(List.of(ou21), List.of(), List.of());
+
+    assertListOfOrganisationUnits(
+        GET("/organisationUnits?withinUserSearchHierarchy=true").content(), "L21", "L31");
+    assertListOfOrganisationUnits(
+        GET("/organisationUnits?withinDataViewUserHierarchy=true").content(), "L21", "L31");
+  }
+
+  @Test
+  void testGetWithinEmptyUserHierarchyPreservesUnrestrictedResults() {
+    switchToHierarchyUser(List.of(), List.of(), List.of());
+
+    // These optional scope flags historically add no restriction when all effective roots are
+    // empty.
+    assertListOfOrganisationUnits(
+        GET("/organisationUnits?withinUserHierarchy=true&withinDataViewUserHierarchy=true"
+                + "&withinUserSearchHierarchy=true")
+            .content(),
+        "L0",
+        "L1",
+        "L1x",
+        "L21",
+        "L22",
+        "L2x",
+        "L31",
+        "L32",
+        "L3x");
+  }
+
+  @Test
+  void testGetWithinMissingUserHierarchyDoesNotBecomeUnrestricted() {
+    switchToHierarchyUser(List.of(), List.of(), List.of());
+    // Simulate an authenticated session retaining a root UID after its organisation unit is
+    // deleted.
+    getCurrentUserDetails().getUserOrgUnitIds().add("missingRoot");
+
+    assertListOfOrganisationUnits(
+        GET("/organisationUnits?withinUserHierarchy=true&rootJunction=OR&filter=name:eq:L0")
+            .content());
+  }
+
+  @Test
+  void testGetWithinUserHierarchyCannotBeBypassedByRootJunction() {
+    switchToHierarchyUser(List.of(ou21, ou22), List.of(), List.of());
+
+    assertListOfOrganisationUnits(
+        GET("/organisationUnits?withinUserHierarchy=true&rootJunction=OR"
+                + "&filter=name:eq:L0&filter=name:eq:L31")
+            .content(),
+        "L31");
+  }
+
+  @Test
+  void testGetWithinUserHierarchyAndDisplayNamePaging() {
+    switchToHierarchyUser(List.of(ou21, ou22), List.of(), List.of());
+    String request =
+        "/organisationUnits?withinUserHierarchy=true&filter=displayName:ilike:L3"
+            + "&paging=true&pageSize=1&order=displayName:asc,id:asc";
+
+    JsonObject first = GET(request + "&page=1").content();
+    JsonObject second = GET(request + "&page=2").content();
+    assertEquals(List.of("L31"), toOrganisationUnitNames(first));
+    assertEquals(List.of("L32"), toOrganisationUnitNames(second));
+    assertEquals(2, first.getObject("pager").getNumber("total").intValue());
+    assertEquals(2, second.getObject("pager").getNumber("total").intValue());
+  }
+
+  @Test
+  void testGetWithinUserHierarchyAndDisplayNameRootJunctionPaging() {
+    switchToHierarchyUser(List.of(ou21, ou22), List.of(), List.of());
+    String request =
+        "/organisationUnits?withinUserHierarchy=true&rootJunction=OR"
+            + "&filter=displayName:ilike:L3&filter=name:eq:L0"
+            + "&paging=true&pageSize=1&order=name:asc";
+
+    JsonObject first = GET(request + "&page=1").content();
+    JsonObject second = GET(request + "&page=2").content();
+    assertEquals(List.of("L31"), toOrganisationUnitNames(first));
+    assertEquals(List.of("L32"), toOrganisationUnitNames(second));
+    assertEquals(2, first.getObject("pager").getNumber("total").intValue());
+    assertEquals(2, second.getObject("pager").getNumber("total").intValue());
+  }
+
+  private void switchToHierarchyUser(
+      List<String> captureRoots, List<String> dataViewRoots, List<String> searchRoots) {
+    User user = makeUser("h");
+    user.setOrganisationUnits(Set.copyOf(manager.getByUid(OrganisationUnit.class, captureRoots)));
+    user.setDataViewOrganisationUnits(
+        Set.copyOf(manager.getByUid(OrganisationUnit.class, dataViewRoots)));
+    user.setTeiSearchOrganisationUnits(
+        Set.copyOf(manager.getByUid(OrganisationUnit.class, searchRoots)));
+    userService.addUser(user);
+    switchToNewUser(user);
   }
 
   private void assertListOfOrganisationUnits(JsonObject response, String... names) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -35,7 +35,6 @@ import static org.hisp.dhis.query.Filters.eq;
 import static org.hisp.dhis.query.Filters.in;
 import static org.hisp.dhis.query.Filters.le;
 import static org.hisp.dhis.query.Filters.like;
-import static org.hisp.dhis.query.Filters.token;
 import static org.hisp.dhis.security.Authorities.F_ORGANISATION_UNIT_MERGE;
 import static org.hisp.dhis.security.Authorities.F_ORGANISATION_UNIT_SPLIT;
 import static org.hisp.dhis.system.util.GeoUtils.getCoordinatesFromGeometry;
@@ -70,6 +69,8 @@ import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.query.Filter;
 import org.hisp.dhis.query.GetObjectListParams;
+import org.hisp.dhis.query.Query;
+import org.hisp.dhis.query.operators.DescendantOfOperator;
 import org.hisp.dhis.query.operators.MatchMode;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.split.orgunit.OrgUnitSplitQuery;
@@ -391,11 +392,11 @@ public class OrganisationUnitController
       }
     }
     if (parents != null && !parents.isEmpty()) {
-      if (parents.size() == 1) {
-        specialFilters.add(like("path", parents.iterator().next(), MatchMode.ANYWHERE));
-      } else {
-        specialFilters.add(token("path", String.join("|", parents), MatchMode.ANYWHERE));
-      }
+      specialFilters.add(
+          new Filter(
+              "path",
+              new DescendantOfOperator(
+                  organisationUnitService.getOrganisationUnitPathsByUid(UID.of(parents)))));
     }
     if (params.isUserOnly())
       specialFilters.add(in("id", getCurrentUserDetails().getUserOrgUnitIds()));
@@ -406,6 +407,22 @@ public class OrganisationUnitController
       specialFilters.add(in("id", getCurrentUserDetails().getUserDataOrgUnitIds()));
 
     return specialFilters;
+  }
+
+  @Override
+  protected void modifyGetObjectList(
+      GetOrganisationUnitObjectListParams params, Query<OrganisationUnit> query) {
+    // Hierarchy scope is mandatory, even when the caller combines search filters with OR.
+    query
+        .getFilters()
+        .removeIf(
+            filter -> {
+              if (filter.getOperator() instanceof DescendantOfOperator descendants) {
+                query.addPredicateSupplier(descendants);
+                return true;
+              }
+              return false;
+            });
   }
 
   @Override


### PR DESCRIPTION
## Summary
Follow-up to merged #25125 ([DHIS2-22091](https://dhis2.atlassian.net/browse/DHIS2-22091)). Rebased onto its merge commit, `7b38c692f5c`.

- Replace the single-root substring LIKE and remaining multi-root regex with bulk-resolved, indexable full-path subtree predicates, including the selected roots themselves.
- Correct disjoint-root matching and keep requested hierarchy scope outside caller `rootJunction=OR`, for both lists and counts.
- Preserve configured-empty scope behavior; stale nonempty roots cannot become unrestricted. No migration.

## Verification
32 targeted tests passed on the rebased source: 30 OrganisationUnitControllerTest cases and 2 DescendantOfOperatorTest cases. Repository-wide Spotless check passed.


AI Assisted


[DHIS2-22091]: https://dhis2.atlassian.net/browse/DHIS2-22091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ