### PR TITLE
fix: Filter translated display names in SQL

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.hibernate.InternalHibernateGenericStore;
 import org.hisp.dhis.hibernate.jsonb.type.JsonbFunctions;
+import org.hisp.dhis.query.operators.LikeOperator;
 import org.hisp.dhis.query.operators.Operator;
 import org.hisp.dhis.query.planner.PropertyPath;
 import org.hisp.dhis.schema.Property;
@@ -361,6 +362,67 @@ public class JpaCriteriaQueryEngine implements QueryEngine {
     return Stream.of(path.getAlias());
   }
 
+  /** Only root displayName LIKE/ILIKE has a computed SQL filtering implementation. */
+  public static boolean supportsTranslatedNameFilter(Schema schema, Filter filter) {
+    if (!"displayName".equals(filter.getPath())
+        || !(filter.getOperator() instanceof LikeOperator)) {
+      return false;
+    }
+    Property displayName = schema.getProperty("displayName");
+    Property name = schema.getProperty("name");
+    return displayName != null
+        && displayName.isSimple()
+        && name != null
+        && name.isPersisted()
+        && name.canBeTranslated()
+        && "NAME".equals(name.getTranslationKey())
+        && schema.hasPersistedProperty("translations");
+  }
+
+  private <Y> Expression<String> getDisplayName(CriteriaBuilder builder, Root<Y> root) {
+    Locale locale = UserSettings.getCurrentSettings().getUserDbLocale();
+    if (locale == null) return root.get("name");
+    return builder.function(
+        JsonbFunctions.GET_DISPLAY_NAME,
+        String.class,
+        root.get("translations"),
+        root.get("name"),
+        builder.literal(displayNameTranslationPath(locale)),
+        builder.literal(locale.toString()));
+  }
+
+  private static String displayNameTranslationPath(Locale locale) {
+    // Locale validates every component as ASCII letters/digits. Only these validated components,
+    // never the request string, enter the regex. Keep canonical language-only locales on equality.
+    String language =
+        switch (locale.language()) {
+          case "id" -> "(id|in)";
+          case "he" -> "(he|iw)";
+          case "yi" -> "(yi|ji)";
+          default -> locale.language();
+        };
+    String localeMatch = "@.locale == $locale";
+    if (locale.region() != null || !language.equals(locale.language())) {
+      String separator = "(-|_#?)";
+      String pattern = language;
+      if (locale.region() != null) {
+        String region = locale.region();
+        String script = locale.script();
+        pattern +=
+            separator
+                + (script == null
+                    ? region
+                    : "(" + region + separator + script + "|" + script + separator + region + ")");
+        // String.split in Locale.of discards trailing empty parts, including repeated separators.
+        pattern += separator + "*";
+      }
+      localeMatch += " || @.locale like_regex \"^" + pattern + "$\"";
+    }
+    return "$[*] ? (@.property like_regex \"^name$\" flag \"i\" && ("
+        + localeMatch
+        + ") && @.value != null && @.value != \"\")";
+  }
+
   private <Y> Predicate buildFilter(
       CriteriaBuilder builder,
       Root<Y> root,
@@ -369,14 +431,12 @@ public class JpaCriteriaQueryEngine implements QueryEngine {
       CriteriaQuery<?> criteriaQuery) {
     if (filter == null || filter.getOperator() == null) return null;
     if (!filter.isVirtual()) {
-      String filterPath = filter.getPath();
-      // Map display properties to their base properties
-      PropertyPath path = schemaService.getPropertyPath(query.getObjectType(), filterPath);
-      if (path == null && filterPath.startsWith("display")) {
-        filterPath = Property.resolveTranslationBasePropertyName(filterPath);
-        filter = new Filter(filterPath, filter.getOperator());
-        path = schemaService.getPropertyPath(query.getObjectType(), filterPath);
+      Schema schema = schemaService.getSchema(query.getObjectType());
+      if (supportsTranslatedNameFilter(schema, filter)) {
+        return ((LikeOperator<?>) filter.getOperator())
+            .getLiteralPredicate(builder, getDisplayName(builder, root));
       }
+      PropertyPath path = schemaService.getPropertyPath(query.getObjectType(), filter.getPath());
       if (path == null) {
         return null;
       }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LikeOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LikeOperator.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.query.operators;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import java.util.List;
@@ -66,6 +67,30 @@ public class LikeOperator<T extends Comparable<T>> extends Operator<T> {
         getPropertyPath(root, path),
         String.valueOf(args.get(0)).replace("%", ""),
         jpaMatchMode);
+  }
+
+  /**
+   * Applies the literal string semantics of {@link #test(Object)} to a computed SQL value.
+   * Persisted-property filters retain their existing wildcard handling.
+   */
+  public Predicate getLiteralPredicate(CriteriaBuilder builder, Expression<String> value) {
+    String search = getValue(String.class);
+    if (!caseSensitive) {
+      value = builder.lower(value);
+      search = search.toLowerCase();
+    }
+    if (jpaMatchMode == JpaQueryUtils.StringSearchMode.EQUALS) {
+      return builder.equal(value, search);
+    }
+    String escaped = search.replace("!", "!!").replace("%", "!%").replace("_", "!_");
+    String pattern =
+        switch (jpaMatchMode) {
+          case STARTING_LIKE -> escaped + "%";
+          case ENDING_LIKE -> "%" + escaped;
+          case ANYWHERE -> "%" + escaped + "%";
+          default -> throw new IllegalStateException("Unsupported LIKE mode: " + jpaMatchMode);
+        };
+    return builder.like(value, pattern, '!');
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
@@ -37,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.query.Filter;
+import org.hisp.dhis.query.JpaCriteriaQueryEngine;
 import org.hisp.dhis.query.Junction;
 import org.hisp.dhis.query.Order;
 import org.hisp.dhis.query.Query;
@@ -62,7 +63,7 @@ public class DefaultQueryPlanner implements QueryPlanner {
     Query<T> memoryQuery = plan.memoryQuery();
     Query<T> dbQuery = plan.dbQuery();
 
-    // if there are any non persisted filters, leave the paging to the in-memory engine
+    // Remaining in-memory filtering or ordering must happen before paging.
     if (!memoryQuery.isEmpty()) {
       dbQuery.setSkipPaging(true);
     } else {
@@ -215,8 +216,9 @@ public class DefaultQueryPlanner implements QueryPlanner {
   /**
    * Returns whether a filter can be executed in the DB query plan.
    *
-   * <p>Virtual filters are DB-eligible only for `identifiable` and `query`. For regular filters,
-   * the path must resolve to a persisted property and not require in-memory alias traversal (for
+   * <p>Virtual filters are DB-eligible only for `identifiable` and `query`. Root displayName LIKE
+   * filters are eligible when the engine implements their translated expression. Other regular
+   * filters must resolve to persisted properties and not require in-memory alias traversal (for
    * example collection/embedded paths handled by {@code pathRequiresInMemoryFiltering(...)}).
    *
    * @param query query containing the filter
@@ -225,6 +227,10 @@ public class DefaultQueryPlanner implements QueryPlanner {
    */
   private boolean isDbFilter(Query<?> query, Filter filter) {
     if (filter.isVirtual()) return filter.isIdentifiable() || filter.isQuery();
+    if (JpaCriteriaQueryEngine.supportsTranslatedNameFilter(
+        schemaService.getSchema(query.getObjectType()), filter)) {
+      return true;
+    }
     PropertyPath path = schemaService.getPropertyPath(query.getObjectType(), filter.getPath());
     if (path == null || !path.isPersisted()) return false;
     if (Attribute.ObjectType.isValidType(path.getPath())) return false;
@@ -234,6 +240,16 @@ public class DefaultQueryPlanner implements QueryPlanner {
         return true;
       }
       if (pathRequiresInMemoryFiltering(query.getObjectType(), path.getAlias())) {
+        return false;
+      }
+      // Implicit relationship joins are not null-preserving. Keep the old all-memory OR
+      // fallback when displayName pushdown would otherwise discard matching parentless objects.
+      if (query.getRootJunctionType() == Junction.Type.OR
+          && query.getFilters().stream()
+              .anyMatch(
+                  f ->
+                      JpaCriteriaQueryEngine.supportsTranslatedNameFilter(
+                          schemaService.getSchema(query.getObjectType()), f))) {
         return false;
       }
       return path.getProperty().isSimple();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/planner/DefaultQueryPlannerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/planner/DefaultQueryPlannerTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.when;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.query.Filters;
+import org.hisp.dhis.query.Junction;
 import org.hisp.dhis.query.Order;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.operators.MatchMode;
@@ -48,6 +49,8 @@ import org.hisp.dhis.schema.SchemaService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -71,20 +74,22 @@ class DefaultQueryPlannerTest {
     queryPlanner = new DefaultQueryPlanner(schemaService);
   }
 
-  @Test
-  void testDisplayNameFilterResultsInDatabaseQuery() {
+  @ParameterizedTest
+  @EnumSource(Junction.Type.class)
+  void testDisplayNameFilterResultsInDatabaseQuery(Junction.Type junction) {
     // Given: A query with a filter on displayName (a translatable property)
-    Query<DataElement> query = Query.of(DataElement.class);
+    Query<DataElement> query = Query.of(DataElement.class, junction);
     query.add(Filters.like("displayName", "Health", MatchMode.ANYWHERE));
+    query.setMaxResults(2);
 
-    // Mock schema to indicate displayName is persisted and translatable
+    // displayName is computed; its persisted name and translations support this SQL predicate.
     Schema schema = mockSchema();
     Property displayNameProperty = mockTranslatableProperty("displayName", "NAME");
     when(schema.getProperty("displayName")).thenReturn(displayNameProperty);
     when(schema.hasPersistedProperty("name")).thenReturn(true);
     when(schema.hasPersistedProperty("id")).thenReturn(true);
 
-    PropertyPath displayNamePath = new PropertyPath(displayNameProperty, true);
+    PropertyPath displayNamePath = new PropertyPath(displayNameProperty, false);
     when(schemaService.getSchema(DataElement.class)).thenReturn(schema);
     when(schemaService.getPropertyPath(DataElement.class, "displayName"))
         .thenReturn(displayNamePath);
@@ -99,15 +104,16 @@ class DefaultQueryPlannerTest {
         plan.memoryQuery().getFilters().size(),
         "displayName filter should NOT be in memory query");
     assertTrue(plan.memoryQuery().isEmpty(), "Memory query should be empty");
+    assertEquals(2, plan.dbQuery().getMaxResults());
   }
 
   @Test
-  void testDisplayDescriptionFilterResultsInDatabaseQuery() {
+  void testDisplayDescriptionFilterRemainsInMemory() {
     // Given: A query with a filter on displayDescription (a translatable property)
     Query<DataElement> query = Query.of(DataElement.class);
     query.add(Filters.like("displayDescription", "program", MatchMode.ANYWHERE));
 
-    // Mock schema to indicate displayDescription is persisted and translatable
+    // No SQL filtering semantics are declared for displayDescription.
     Schema schema = mockSchema();
     Property displayDescriptionProperty =
         mockTranslatableProperty("displayDescription", "DESCRIPTION");
@@ -115,7 +121,7 @@ class DefaultQueryPlannerTest {
     when(schema.hasPersistedProperty("name")).thenReturn(true);
     when(schema.hasPersistedProperty("id")).thenReturn(true);
 
-    PropertyPath displayDescriptionPath = new PropertyPath(displayDescriptionProperty, true);
+    PropertyPath displayDescriptionPath = new PropertyPath(displayDescriptionProperty, false);
     when(schemaService.getSchema(DataElement.class)).thenReturn(schema);
     when(schemaService.getPropertyPath(DataElement.class, "displayDescription"))
         .thenReturn(displayDescriptionPath);
@@ -123,26 +129,25 @@ class DefaultQueryPlannerTest {
     // When: Query plan is created
     QueryPlan<DataElement> plan = queryPlanner.planQuery(query);
 
-    // Then: The filter should be in the database query
-    assertEquals(
-        1, plan.dbQuery().getFilters().size(), "displayDescription filter should be in DB query");
-    assertTrue(plan.memoryQuery().isEmpty(), "Memory query should be empty");
+    assertTrue(plan.dbQuery().getFilters().isEmpty());
+    assertEquals(1, plan.memoryQuery().getFilters().size());
+    assertTrue(plan.dbQuery().isSkipPaging());
   }
 
   @Test
-  void testDisplayShortNameFilterResultsInDatabaseQuery() {
+  void testDisplayShortNameFilterRemainsInMemory() {
     // Given: A query with a filter on displayShortName (a translatable property)
     Query<DataElement> query = Query.of(DataElement.class);
     query.add(Filters.like("displayShortName", "ANC", MatchMode.ANYWHERE));
 
-    // Mock schema to indicate displayShortName is persisted and translatable
+    // No SQL filtering semantics are declared for displayShortName.
     Schema schema = mockSchema();
     Property displayShortNameProperty = mockTranslatableProperty("displayShortName", "SHORT_NAME");
     when(schema.getProperty("displayShortName")).thenReturn(displayShortNameProperty);
     when(schema.hasPersistedProperty("name")).thenReturn(true);
     when(schema.hasPersistedProperty("id")).thenReturn(true);
 
-    PropertyPath displayShortNamePath = new PropertyPath(displayShortNameProperty, true);
+    PropertyPath displayShortNamePath = new PropertyPath(displayShortNameProperty, false);
     when(schemaService.getSchema(DataElement.class)).thenReturn(schema);
     when(schemaService.getPropertyPath(DataElement.class, "displayShortName"))
         .thenReturn(displayShortNamePath);
@@ -150,10 +155,9 @@ class DefaultQueryPlannerTest {
     // When: Query plan is created
     QueryPlan<DataElement> plan = queryPlanner.planQuery(query);
 
-    // Then: The filter should be in the database query
-    assertEquals(
-        1, plan.dbQuery().getFilters().size(), "displayShortName filter should be in DB query");
-    assertTrue(plan.memoryQuery().isEmpty(), "Memory query should be empty");
+    assertTrue(plan.dbQuery().getFilters().isEmpty());
+    assertEquals(1, plan.memoryQuery().getFilters().size());
+    assertTrue(plan.dbQuery().isSkipPaging());
   }
 
   @Test
@@ -185,7 +189,7 @@ class DefaultQueryPlannerTest {
 
   @Test
   void testMixedPersistedAndNonPersistedFilters() {
-    // Given: A query with both displayName (persisted) and a non-persisted property filter
+    // A supported displayName filter can run in SQL, but the other filter still disables paging.
     Query<DataElement> query = Query.of(DataElement.class);
     query.add(Filters.like("displayName", "Health", MatchMode.ANYWHERE));
     query.add(Filters.eq("customProperty", "value")); // Non-persisted property
@@ -200,7 +204,7 @@ class DefaultQueryPlannerTest {
     when(schema.hasPersistedProperty("name")).thenReturn(true);
     when(schema.hasPersistedProperty("id")).thenReturn(true);
 
-    PropertyPath displayNamePath = new PropertyPath(displayNameProperty, true);
+    PropertyPath displayNamePath = new PropertyPath(displayNameProperty, false);
     PropertyPath customPropertyPath = new PropertyPath(customProperty, false);
 
     when(schemaService.getSchema(DataElement.class)).thenReturn(schema);
@@ -216,6 +220,7 @@ class DefaultQueryPlannerTest {
     assertEquals(1, plan.dbQuery().getFilters().size(), "DB query should have 1 filter");
     assertEquals(1, plan.memoryQuery().getFilters().size(), "Memory query should have 1 filter");
     assertFalse(plan.memoryQuery().isEmpty(), "Memory query should NOT be empty");
+    assertTrue(plan.dbQuery().isSkipPaging());
   }
 
   @Test
@@ -243,6 +248,64 @@ class DefaultQueryPlannerTest {
     assertEquals(0, plan.dbQuery().getFilters().size(), "DB query should have no filters");
     assertEquals(1, plan.memoryQuery().getFilters().size(), "Memory query should have 1 filter");
     assertFalse(plan.memoryQuery().isEmpty(), "Memory query should NOT be empty");
+  }
+
+  @Test
+  void testUnsupportedDisplayNameOperatorsRemainInMemory() {
+    Schema schema = mockSchema();
+    Property displayName = mockTranslatableProperty("displayName", "NAME");
+    when(schema.getProperty("displayName")).thenReturn(displayName);
+    when(schemaService.getSchema(DataElement.class)).thenReturn(schema);
+    when(schemaService.getPropertyPath(DataElement.class, "displayName"))
+        .thenReturn(new PropertyPath(displayName, false));
+    Query<DataElement> query =
+        Query.of(DataElement.class)
+            .add(Filters.eq("displayName", "Health"))
+            .add(Filters.token("displayName", "Health", MatchMode.START))
+            .add(Filters.notLike("displayName", "Health", MatchMode.ANYWHERE));
+    QueryPlan<DataElement> plan = queryPlanner.planQuery(query);
+    assertTrue(plan.dbQuery().getFilters().isEmpty());
+    assertEquals(query.getFilters(), plan.memoryQuery().getFilters());
+    assertTrue(plan.dbQuery().isSkipPaging());
+  }
+
+  @Test
+  void testNestedDisplayNameRemainsInMemory() {
+    Schema schema = mockSchema();
+    Property displayName = mockTranslatableProperty("displayName", "NAME");
+    when(schemaService.getSchema(DataElement.class)).thenReturn(schema);
+    when(schemaService.getPropertyPath(DataElement.class, "parent.displayName"))
+        .thenReturn(new PropertyPath(displayName, false, new String[] {"parent"}));
+    Query<DataElement> query =
+        Query.of(DataElement.class)
+            .add(Filters.ilike("parent.displayName", "Health", MatchMode.ANYWHERE));
+    QueryPlan<DataElement> plan = queryPlanner.planQuery(query);
+    assertTrue(plan.dbQuery().getFilters().isEmpty());
+    assertEquals(query.getFilters(), plan.memoryQuery().getFilters());
+    assertTrue(plan.dbQuery().isSkipPaging());
+  }
+
+  @Test
+  void testMixedOrRetainsAllFiltersInMemory() {
+    Schema schema = mockSchema();
+    Property displayName = mockTranslatableProperty("displayName", "NAME");
+    Property displayShortName = mockTranslatableProperty("displayShortName", "SHORT_NAME");
+    when(schema.getProperty("displayName")).thenReturn(displayName);
+    when(schema.getProperty("displayShortName")).thenReturn(displayShortName);
+    when(schemaService.getSchema(DataElement.class)).thenReturn(schema);
+    when(schemaService.getPropertyPath(DataElement.class, "displayName"))
+        .thenReturn(new PropertyPath(displayName, false));
+    when(schemaService.getPropertyPath(DataElement.class, "displayShortName"))
+        .thenReturn(new PropertyPath(displayShortName, false));
+    Query<DataElement> query =
+        Query.of(DataElement.class, Junction.Type.OR)
+            .add(Filters.ilike("displayName", "Health", MatchMode.ANYWHERE))
+            .add(Filters.eq("displayShortName", "ANC"))
+            .setMaxResults(2);
+    QueryPlan<DataElement> plan = queryPlanner.planQuery(query);
+    assertTrue(plan.dbQuery().getFilters().isEmpty());
+    assertEquals(query.getFilters(), plan.memoryQuery().getFilters());
+    assertTrue(plan.dbQuery().isSkipPaging());
   }
 
   // -------------------------------------------------------------------------
@@ -452,12 +515,14 @@ class DefaultQueryPlannerTest {
 
   /**
    * Tests mixing simple filter with single nested many-to-one filter (e.g., id:eq:X AND
-   * parent.id:eq:Y). Both should go to DB because there's only one distinct root alias.
+   * parent.id:eq:Y), under either junction. Both should go to DB because there's only one distinct
+   * root alias.
    */
-  @Test
-  void testMixingSimpleAndSingleNestedFilterGoToDb() {
+  @ParameterizedTest
+  @EnumSource(Junction.Type.class)
+  void testMixingSimpleAndSingleNestedFilterGoToDb(Junction.Type junction) {
     // Given: A simple filter and a single nested filter (one root alias)
-    Query<DataElement> query = Query.of(DataElement.class);
+    Query<DataElement> query = Query.of(DataElement.class, junction);
     query.add(Filters.eq("id", "element123"));
     query.add(Filters.eq("parent.id", "parent123"));
 
@@ -549,6 +614,8 @@ class DefaultQueryPlannerTest {
   private Schema mockSchema() {
     Schema schema = mock(Schema.class);
     when(schema.hasPersistedProperty(any())).thenReturn(false);
+    when(schema.getProperty("name")).thenReturn(mockTranslatableProperty("name", "NAME"));
+    when(schema.hasPersistedProperty("translations")).thenReturn(true);
     return schema;
   }
 
@@ -556,7 +623,7 @@ class DefaultQueryPlannerTest {
     Property property = new Property();
     property.setName(name);
     property.setFieldName(name);
-    property.setPersisted(true);
+    property.setPersisted(!name.startsWith("display"));
     property.setSimple(true);
     property.setTranslatable(true);
     property.setTranslationKey(translationKey);

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/dialect/DhisH2Dialect.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/dialect/DhisH2Dialect.java
@@ -69,6 +69,9 @@ public class DhisH2Dialect extends H2Dialect {
     registerFunction(
         JsonbFunctions.CHECK_USER_ACCESS,
         new StandardSQLFunction(JsonbFunctions.CHECK_USER_ACCESS, StandardBasicTypes.BOOLEAN));
+    registerFunction(
+        JsonbFunctions.GET_DISPLAY_NAME,
+        new StandardSQLFunction(JsonbFunctions.GET_DISPLAY_NAME, StandardBasicTypes.STRING));
     registerFunction("array_agg", new StandardSQLFunction("array_agg", StringArrayType.INSTANCE));
   }
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/dialect/DhisPostgresDialect.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/dialect/DhisPostgresDialect.java
@@ -31,9 +31,12 @@ package org.hisp.dhis.hibernate.dialect;
 
 import io.hypersistence.utils.hibernate.type.array.StringArrayType;
 import java.sql.Types;
+import java.util.List;
 import org.hibernate.dialect.function.StandardSQLFunction;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.spatial.dialect.postgis.PostgisPG95Dialect;
 import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.Type;
 import org.hisp.dhis.hibernate.jsonb.type.JsonbFunctions;
 
 /**
@@ -81,6 +84,30 @@ public class DhisPostgresDialect extends PostgisPG95Dialect {
     registerFunction(
         JsonbFunctions.GET_TRANSLATED_VALUE,
         new StandardSQLFunction(JsonbFunctions.GET_TRANSLATED_VALUE, StandardBasicTypes.STRING));
+    // Unlike translated ordering, display-name filtering must skip empty values and match the
+    // getter's case-insensitive property key and conditional String.trim() fallback.
+    registerFunction(
+        JsonbFunctions.GET_DISPLAY_NAME,
+        new StandardSQLFunction(JsonbFunctions.GET_DISPLAY_NAME, StandardBasicTypes.STRING) {
+          @Override
+          public String render(
+              Type firstArgumentType, List arguments, SessionFactoryImplementor factory) {
+            // Keep this scalar: an array-expansion subquery per candidate inflates both execution
+            // cost and PostgreSQL's cost estimate, triggering expensive JIT for simple searches.
+            // SQLFunctionTemplate cannot represent the JSONPath '?' operator.
+            // Preserve argument order: Criteria binds the path before the locale.
+            return """
+                case when coalesce(jsonb_array_length(%1$s), 0) = 0 then %2$s
+                else coalesce(
+                  jsonb_path_query_first(
+                    %1$s, cast(%3$s as jsonpath),
+                    jsonb_build_object('locale', cast(%4$s as text))) ->> 'value',
+                  regexp_replace(%2$s, '^[\\x01-\\x20]+|[\\x01-\\x20]+$', '', 'g'))
+                end
+                """
+                .formatted(arguments.get(0), arguments.get(1), arguments.get(2), arguments.get(3));
+          }
+        });
     registerFunction("array_agg", new StandardSQLFunction("array_agg", StringArrayType.INSTANCE));
   }
 }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonSetBinaryType.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonSetBinaryType.java
@@ -32,6 +32,8 @@ package org.hisp.dhis.hibernate.jsonb.type;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -44,6 +46,9 @@ public class JsonSetBinaryType extends JsonBinaryType {
     MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     MAPPER.setAnnotationIntrospector(
         new IgnoreJsonPropertyWriteOnlyAccessJacksonAnnotationIntrospector());
+    // Preserve the stored winner when consumers select the first matching entry (translations).
+    MAPPER.registerModule(
+        new SimpleModule().addAbstractTypeMapping(Set.class, LinkedHashSet.class));
   }
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonbFunctions.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonbFunctions.java
@@ -100,4 +100,11 @@ public class JsonbFunctions {
    * @return the translated value as text, or NULL if not found
    */
   public static final String GET_TRANSLATED_VALUE = "jsonb_get_translated_value";
+
+  /**
+   * Hibernate expression for the display-name getter: translations, base name, a JSONPath matching
+   * accepted persisted locale representations, and the canonical effective locale. PostgreSQL
+   * expands the path inline without installing a function; H2 uses the locale with the Java parser.
+   */
+  public static final String GET_DISPLAY_NAME = "jsonb_get_display_name";
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/h2/H2SqlFunction.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/h2/H2SqlFunction.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonString;
 import org.hisp.dhis.jsontree.JsonValue;
@@ -59,6 +60,7 @@ public class H2SqlFunction {
       createAliasForFunction(connection, "jsonb_has_user_id");
       createAliasForFunction(connection, "jsonb_check_user_access");
       createAliasForFunction(connection, "jsonb_get_translated_value");
+      createAliasForFunction(connection, "jsonb_get_display_name");
     } catch (SQLException exception) {
       log.info(
           "Failed to register custom H2Functions, probably already registered, ignoring this.",
@@ -216,5 +218,32 @@ public class H2SqlFunction {
       log.error("Failed to get translated value", e);
       throw e;
     }
+  }
+
+  public static String jsonb_get_display_name(
+      PGobject input, String name, String translationPath, String locale) {
+    if (locale == null || input == null || input.getValue() == null) return name;
+    JsonArray translations = new Gson().fromJson(input.getValue(), JsonArray.class);
+    if (translations == null || translations.isEmpty()) return name;
+    // H2 has no PostgreSQL JSONPath evaluator; compare with the same parser used on hydration.
+    Locale effectiveLocale = Locale.of(locale);
+    for (JsonElement element : translations) {
+      JsonObject translation = element.getAsJsonObject();
+      JsonElement property = translation.get("property");
+      JsonElement language = translation.get("locale");
+      JsonElement value = translation.get("value");
+      if (property != null
+          && !property.isJsonNull()
+          && "NAME".equalsIgnoreCase(property.getAsString())
+          && language != null
+          && !language.isJsonNull()
+          && effectiveLocale.equals(Locale.ofNullable(language.getAsString()))
+          && value != null
+          && !value.isJsonNull()
+          && !value.getAsString().isEmpty()) {
+        return value.getAsString();
+      }
+    }
+    return name == null ? null : name.trim();
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/NullableRelationshipOrQueryTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/NullableRelationshipOrQueryTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.List;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Morten Svanæs
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+@Transactional
+class NullableRelationshipOrQueryTest extends PostgresIntegrationTestBase {
+
+  @Autowired private QueryService queryService;
+
+  @Autowired private IdentifiableObjectManager identifiableObjectManager;
+
+  private OrganisationUnit standalone;
+
+  private OrganisationUnit child;
+
+  @BeforeEach
+  void setUpOrganisationUnits() {
+    standalone = createOrganisationUnit('A');
+    standalone.setName("Standalone");
+    identifiableObjectManager.save(standalone);
+
+    OrganisationUnit parent = createOrganisationUnit('B');
+    parent.setName("Parent");
+    identifiableObjectManager.save(parent);
+
+    child = createOrganisationUnit('C', parent);
+    child.setName("Child");
+    identifiableObjectManager.save(child);
+    clearSession();
+  }
+
+  @Test
+  void displayNameOrParentNameIncludesParentlessMatchesBeforePagingAndCounting() {
+    Query<OrganisationUnit> query = search(1, 10);
+    assertEquals(List.of(standalone.getUid(), child.getUid()), searchUids(query));
+    assertEquals(2, queryService.count(query));
+
+    Query<OrganisationUnit> firstPage = search(1, 1);
+    Query<OrganisationUnit> secondPage = search(2, 1);
+    assertEquals(List.of(standalone.getUid()), searchUids(firstPage));
+    assertEquals(List.of(child.getUid()), searchUids(secondPage));
+    assertEquals(2, queryService.count(firstPage));
+    assertEquals(2, queryService.count(secondPage));
+  }
+
+  @Test
+  void mandatoryScopeStillRestrictsTheMemoryOrLeg() {
+    Query<OrganisationUnit> query =
+        search(1, 1)
+            .addPredicateSupplier(
+                new JpaPredicateSupplier() {
+                  @Override
+                  public <Y> Predicate getPredicate(
+                      CriteriaBuilder builder, Root<Y> root, CriteriaQuery<?> criteriaQuery) {
+                    return builder.equal(root.get("uid"), standalone.getUid());
+                  }
+                });
+
+    assertEquals(List.of(standalone.getUid()), searchUids(query));
+    assertEquals(1, queryService.count(query));
+  }
+
+  private Query<OrganisationUnit> search(int page, int pageSize) {
+    return queryService.getQueryFromUrl(
+        OrganisationUnit.class,
+        new GetObjectListParams()
+            .setRootJunction(Junction.Type.OR)
+            .setFilters(List.of("displayName:ilike:Standalone", "parent.name:eq:Parent"))
+            .setOrders(List.of("id:asc"))
+            .setPage(page)
+            .setPageSize(pageSize));
+  }
+
+  private List<String> searchUids(Query<OrganisationUnit> query) {
+    return queryService.query(query).stream().map(OrganisationUnit::getUid).toList();
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
@@ -38,10 +38,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
@@ -50,14 +56,20 @@ import org.hisp.dhis.query.operators.MatchMode;
 import org.hisp.dhis.relationship.RelationshipConstraint;
 import org.hisp.dhis.relationship.RelationshipEntity;
 import org.hisp.dhis.relationship.RelationshipType;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.setting.ThreadUserSettings;
 import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackerdataview.TrackerDataView;
+import org.hisp.dhis.translation.Translation;
 import org.jfree.data.time.Year;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -71,6 +83,13 @@ class QueryServiceTest extends PostgresIntegrationTestBase {
   @Autowired private QueryService queryService;
 
   @Autowired private IdentifiableObjectManager identifiableObjectManager;
+
+  @Autowired private SchemaService schemaService;
+
+  @AfterEach
+  void clearUserSettings() {
+    ThreadUserSettings.clear();
+  }
 
   @BeforeEach
   void createDataElements() {
@@ -901,6 +920,301 @@ class QueryServiceTest extends PostgresIntegrationTestBase {
     query2.add(Filters.eq("parent.id", "wrongparent"));
     List<OrganisationUnit> results2 = queryService.query(query2);
     assertEquals(0, results2.size());
+  }
+
+  @Test
+  void displayNameSearchUsesTranslationsInsteadOfBaseNames() {
+    ThreadUserSettings.put(Map.of("keyDbLocale", "fr"));
+    OrganisationUnit translated =
+        saveSearchOrganisationUnit(
+            'A',
+            "Base name",
+            new Translation(Locale.FRENCH, "NAME", ""),
+            new Translation(Locale.FRENCH, "name", "Clinique"));
+    OrganisationUnit hidden =
+        saveSearchOrganisationUnit(
+            'B', "Clinique hidden", new Translation(Locale.FRENCH, "NAME", "Hopital"));
+
+    assertFalse(
+        schemaService.getSchema(OrganisationUnit.class).getProperty("displayName").isPersisted());
+    assertEquals(List.of(translated.getUid()), searchDisplayName("clinique"));
+    assertEquals(List.of(), searchDisplayName("Base name"));
+    assertEquals(
+        List.of(hidden.getUid()),
+        queryService
+            .query(
+                Query.of(OrganisationUnit.class)
+                    .add(Filters.ilike("name", "clinique", MatchMode.ANYWHERE)))
+            .stream()
+            .map(OrganisationUnit::getUid)
+            .toList());
+    assertEquals(
+        1,
+        queryService.count(
+            Query.of(OrganisationUnit.class)
+                .add(Filters.ilike("displayName", "clinique", MatchMode.ANYWHERE))));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "in, id",
+    "iw, he",
+    "ji, yi",
+    "in-ID, id_ID",
+    "iw_#IL, he_IL",
+    "ji_US, yi_US",
+    "fil-PH, fil_PH",
+    "es_#419, es_419",
+    "sr-Latn-RS, sr_RS_Latn",
+    "sr_RS_#Latn, sr_RS_Latn",
+    "sr_#Latn_RS, sr_RS_Latn",
+    "in-Latn_#ID, id_ID_Latn",
+    "sr_RS_#Latn-_#_, sr_RS_Latn",
+    "en-US-_#_, en_US"
+  })
+  void displayNameSearchNormalizesPersistedLocales(String persistedLocale, String effectiveLocale) {
+    Locale effective = Locale.of(effectiveLocale);
+    ThreadUserSettings.put(Map.of("keyDbLocale", effectiveLocale));
+    OrganisationUnit unit = saveSearchOrganisationUnit('A', "Untranslated base");
+    Locale otherLocale =
+        effective.script() != null
+            ? new Locale(effective.language(), effective.region())
+            : new Locale(effective.language(), effective.region() == null ? "US" : null);
+    saveSearchOrganisationUnit(
+        'B', "Other locale", new Translation(otherLocale, "NAME", "Legacy translated"));
+    entityManager.flush();
+    // Current API writes canonicalize locales. Patch only this row to reproduce existing metadata.
+    entityManager
+        .createNativeQuery(
+            "update organisationunit set translations = cast(:translations as jsonb) where uid = :uid")
+        .setParameter(
+            "translations",
+            "[{\"locale\":\""
+                + persistedLocale
+                + "\",\"property\":\"NAME\",\"value\":\"Legacy translated\"}]")
+        .setParameter("uid", unit.getUid())
+        .executeUpdate();
+    OrganisationUnit reloaded = reloadSearchOrganisationUnit(unit);
+
+    assertEquals("Legacy translated", reloaded.getDisplayName());
+    assertDisplayNameMatch(reloaded, reloaded.getDisplayName(), true);
+    assertDisplayNameMatch(reloaded, "Untranslated base", false);
+  }
+
+  @Test
+  void displayNameSearchPreservesStoredWinnerForCaseInsensitiveTranslationKeys() {
+    ThreadUserSettings.put(Map.of("keyDbLocale", "fr"));
+    Set<Translation> input = new HashSet<>();
+    input.add(new Translation(Locale.FRENCH, "NAME", "P"));
+    input.add(new Translation(Locale.FRENCH, "name", "B"));
+    for (int i = 0; i < 10; i++) {
+      input.add(new Translation(Locale.FRENCH, "X" + i, "x"));
+    }
+    OrganisationUnit unit = saveSearchOrganisationUnit('A', "Untranslated base");
+    // Match the translations endpoint's copy of the deserialized request Set. Its capacity differs
+    // from a default HashSet used during hydration, changing the winner unless array order
+    // survives.
+    unit.setTranslations(new HashSet<>(input));
+    identifiableObjectManager.update(unit);
+    String storedWinner = unit.getDisplayName();
+    OrganisationUnit reloaded = reloadSearchOrganisationUnit(unit);
+
+    assertEquals(storedWinner, reloaded.getDisplayName());
+    assertDisplayNameMatch(reloaded, storedWinner, true);
+    assertDisplayNameMatch(reloaded, storedWinner.equals("P") ? "B" : "P", false);
+    assertDisplayNameMatch(reloaded, "Untranslated base", false);
+  }
+
+  @Test
+  void displayNameFallbackPreservesConditionalTrimmingAndWhitespaceTranslations() {
+    ThreadUserSettings.put(Map.of("keyDbLocale", "fr"));
+    OrganisationUnit absent = saveSearchOrganisationUnit('A', "\t Fallback absent \r");
+    OrganisationUnit missing =
+        saveSearchOrganisationUnit(
+            'B', "\t Fallback missing \r", new Translation(Locale.ENGLISH, "NAME", "English"));
+    OrganisationUnit empty =
+        saveSearchOrganisationUnit(
+            'C', "\t Fallback empty \r", new Translation(Locale.FRENCH, "NAME", ""));
+    OrganisationUnit whitespace =
+        saveSearchOrganisationUnit(
+            'D', "Fallback hidden", new Translation(Locale.FRENCH, "NAME", "   "));
+
+    for (OrganisationUnit unit : List.of(absent, missing, empty, whitespace)) {
+      Query<OrganisationUnit> query =
+          Query.of(OrganisationUnit.class)
+              .add(Filters.like("displayName", unit.getDisplayName(), MatchMode.EXACT));
+      assertEquals(
+          List.of(unit.getUid()),
+          queryService.query(query).stream().map(OrganisationUnit::getUid).toList());
+    }
+    assertEquals(List.of(), searchDisplayName("hidden"));
+    assertEquals(
+        List.of(absent.getUid()),
+        queryService
+            .query(
+                Query.of(OrganisationUnit.class)
+                    .add(Filters.like("displayName", "\t", MatchMode.START)))
+            .stream()
+            .map(OrganisationUnit::getUid)
+            .toList());
+  }
+
+  @Test
+  void displayNameSearchWithoutConfiguredDbLocaleUsesDefaultLocaleFallback() {
+    ThreadUserSettings.clear();
+    OrganisationUnit unit =
+        saveSearchOrganisationUnit(
+            'A', "Default name", new Translation(Locale.FRENCH, "NAME", "Clinique"));
+    assertEquals(List.of(unit.getUid()), searchDisplayName("Default name"));
+    assertEquals(List.of(), searchDisplayName("Clinique"));
+  }
+
+  @Test
+  void displayNameSearchTreatsWildcardsAndEscapeCharactersLiterally() {
+    ThreadUserSettings.put(Map.of("keyDbLocale", "fr"));
+    OrganisationUnit literal =
+        saveSearchOrganisationUnit(
+            'A', "Literal", new Translation(Locale.FRENCH, "NAME", "Clinic %_!\\ North"));
+    saveSearchOrganisationUnit(
+        'B', "Wildcard decoy", new Translation(Locale.FRENCH, "NAME", "Clinic anything North"));
+    saveSearchOrganisationUnit(
+        'C', "Underscore decoy", new Translation(Locale.FRENCH, "NAME", "Clinic %X!\\ North"));
+
+    assertEquals(List.of(literal.getUid()), searchDisplayName("%_!\\"));
+    assertEquals(
+        List.of(literal.getUid()),
+        queryService
+            .query(
+                Query.of(OrganisationUnit.class)
+                    .add(Filters.like("displayName", "%_!\\ North", MatchMode.END)))
+            .stream()
+            .map(OrganisationUnit::getUid)
+            .toList());
+    Query<OrganisationUnit> caseSensitive =
+        Query.of(OrganisationUnit.class)
+            .add(Filters.like("displayName", "clinic", MatchMode.ANYWHERE));
+    assertEquals(List.of(), queryService.query(caseSensitive));
+  }
+
+  @Test
+  void displayNamePagingAndCountDoNotLoadAllCandidates() {
+    ThreadUserSettings.put(Map.of("keyDbLocale", "fr"));
+    for (char suffix = 'A'; suffix <= 'Z'; suffix++) {
+      saveSearchOrganisationUnit(
+          suffix,
+          "Base " + suffix,
+          new Translation(
+              Locale.FRENCH, "NAME", suffix >= 'V' ? "Needle " + suffix : "Unrelated " + suffix));
+    }
+    clearSession();
+    SessionFactory sessionFactory =
+        entityManager.getEntityManagerFactory().unwrap(SessionFactory.class);
+    sessionFactory.getCache().evictEntityData(OrganisationUnit.class);
+    Statistics statistics = sessionFactory.getStatistics();
+    boolean enabled = statistics.isStatisticsEnabled();
+    statistics.setStatisticsEnabled(true);
+    try {
+      long loaded = statistics.getEntityStatistics(OrganisationUnit.class.getName()).getLoadCount();
+      Query<OrganisationUnit> query =
+          Query.of(OrganisationUnit.class)
+              .add(Filters.ilike("displayName", "needle", MatchMode.ANYWHERE))
+              .addOrder(Order.asc("id"))
+              .setFirstResult(2)
+              .setMaxResults(2);
+
+      assertEquals(5, queryService.count(query));
+      assertEquals(
+          loaded, statistics.getEntityStatistics(OrganisationUnit.class.getName()).getLoadCount());
+      assertEquals(
+          List.of("ouabcdefghX", "ouabcdefghY"),
+          queryService.query(query).stream().map(OrganisationUnit::getUid).toList());
+      assertEquals(
+          loaded + 2,
+          statistics.getEntityStatistics(OrganisationUnit.class.getName()).getLoadCount());
+      query.setFirstResult(4);
+      assertEquals(
+          List.of("ouabcdefghZ"),
+          queryService.query(query).stream().map(OrganisationUnit::getUid).toList());
+      assertEquals(5, queryService.count(query));
+    } finally {
+      statistics.setStatisticsEnabled(enabled);
+    }
+  }
+
+  @Test
+  void displayNameAndComputedFiltersPreserveMixedJunctionPaging() {
+    ThreadUserSettings.put(Map.of("keyDbLocale", "fr"));
+    saveSearchOrganisationUnit('A', "First", new Translation(Locale.FRENCH, "NAME", "Clinique"));
+    OrganisationUnit second =
+        saveSearchOrganisationUnit(
+            'B', "Second", new Translation(Locale.FRENCH, "SHORT_NAME", "Memory"));
+    OrganisationUnit third =
+        saveSearchOrganisationUnit(
+            'C',
+            "Third",
+            new Translation(Locale.FRENCH, "NAME", "Clinique"),
+            new Translation(Locale.FRENCH, "SHORT_NAME", "Memory"));
+
+    Query<OrganisationUnit> either =
+        Query.of(OrganisationUnit.class, Junction.Type.OR)
+            .add(Filters.ilike("displayName", "clinique", MatchMode.ANYWHERE))
+            .add(Filters.eq("displayShortName", "Memory"))
+            .addOrder(Order.asc("id"))
+            .setFirstResult(1)
+            .setMaxResults(1);
+    assertEquals(
+        List.of(second.getUid()),
+        queryService.query(either).stream().map(OrganisationUnit::getUid).toList());
+    Query<OrganisationUnit> both =
+        Query.of(OrganisationUnit.class)
+            .add(Filters.ilike("displayName", "clinique", MatchMode.ANYWHERE))
+            .add(Filters.eq("displayShortName", "Memory"))
+            .addOrder(Order.asc("id"))
+            .setMaxResults(1);
+    assertEquals(
+        List.of(third.getUid()),
+        queryService.query(both).stream().map(OrganisationUnit::getUid).toList());
+  }
+
+  private OrganisationUnit reloadSearchOrganisationUnit(OrganisationUnit unit) {
+    entityManager.flush();
+    entityManager.clear();
+    entityManager
+        .getEntityManagerFactory()
+        .unwrap(SessionFactory.class)
+        .getCache()
+        .evictEntityData(OrganisationUnit.class);
+    return entityManager.find(OrganisationUnit.class, unit.getId());
+  }
+
+  private void assertDisplayNameMatch(OrganisationUnit unit, String value, boolean matches) {
+    Query<OrganisationUnit> query =
+        Query.of(OrganisationUnit.class).add(Filters.like("displayName", value, MatchMode.EXACT));
+    assertEquals(
+        matches ? List.of(unit.getUid()) : List.of(),
+        queryService.query(query).stream().map(OrganisationUnit::getUid).toList());
+    assertEquals(matches ? 1 : 0, queryService.count(query));
+  }
+
+  private OrganisationUnit saveSearchOrganisationUnit(
+      char suffix, String name, Translation... translations) {
+    OrganisationUnit unit = createOrganisationUnit(suffix);
+    unit.setUid("ouabcdefgh" + suffix);
+    unit.setName(name);
+    unit.setTranslations(Set.of(translations));
+    identifiableObjectManager.save(unit);
+    return unit;
+  }
+
+  private List<String> searchDisplayName(String term) {
+    return queryService
+        .query(
+            Query.of(OrganisationUnit.class)
+                .add(Filters.ilike("displayName", term, MatchMode.ANYWHERE))
+                .addOrder(Order.asc("id")))
+        .stream()
+        .map(OrganisationUnit::getUid)
+        .toList();
   }
 
   private boolean collectionContainsUid(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyControllerTest.java
@@ -37,12 +37,17 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Set;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.Locale;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.http.HttpStatus;
 import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonUser;
+import org.hisp.dhis.translation.Translation;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -128,6 +133,41 @@ class AbstractFullReadOnlyControllerTest extends H2ControllerIntegrationTestBase
     assertNotNull(response);
     int rowCount = getRowCountFromCsv(response);
     assertEquals(10, rowCount);
+  }
+
+  @Test
+  void testTranslatedDisplayNameFilteringAndPaging() {
+    DataElement translated = createDataElement('A');
+    translated.setName("Untranslated name");
+    translated.setTranslations(Set.of(new Translation(Locale.FRENCH, "NAME", "H2 filtre traduit")));
+    dataElementService.addDataElement(translated);
+    DataElement fallback = createDataElement('B');
+    fallback.setName("H2 filtre base");
+    dataElementService.addDataElement(fallback);
+    DataElement masked = createDataElement('C');
+    masked.setName("H2 filtre hidden");
+    masked.setTranslations(Set.of(new Translation(Locale.FRENCH, "NAME", "Different label")));
+    dataElementService.addDataElement(masked);
+
+    String previousLocale = GET("/userSettings/keyDbLocale").content("text/plain");
+    try {
+      assertEquals(HttpStatus.OK, POST("/userSettings/keyDbLocale?value=fr").status());
+      String query =
+          "/dataElements?fields=id,displayName&filter=displayName:ilike:FILTRE"
+              + "&paging=true&pageSize=1&order=displayName:asc";
+      JsonObject first = GET(query).content();
+      JsonObject second = GET(query + "&page=2").content();
+      assertEquals(2, first.getObject("pager").getNumber("total").intValue());
+      assertEquals(2, second.getObject("pager").getNumber("total").intValue());
+      JsonObject firstMatch = first.getList("dataElements", JsonObject.class).get(0);
+      JsonObject secondMatch = second.getList("dataElements", JsonObject.class).get(0);
+      assertEquals(fallback.getUid(), firstMatch.getString("id").string());
+      assertEquals("H2 filtre base", firstMatch.getString("displayName").string());
+      assertEquals(translated.getUid(), secondMatch.getString("id").string());
+      assertEquals("H2 filtre traduit", secondMatch.getString("displayName").string());
+    } finally {
+      POST("/userSettings/keyDbLocale?value=" + previousLocale);
+    }
   }
 
   private void createDataElements(int count) {


### PR DESCRIPTION
## Summary
- Apply supported `displayName` LIKE/ILIKE filters in SQL before paging and counting.
- Preserve legacy locale normalization and stored translation order; retain memory fallback for nullable-relationship OR groups.
- Use scalar PostgreSQL JSONPath without a Flyway migration.

Related: hierarchy search #25127; Data Entry https://github.com/dhis2/aggregate-data-entry-app/pull/593.

## Verification
101 targeted tests passed on this standalone branch, covering PostgreSQL/H2 queries, controllers, planner and JSON-set behavior. Spotless passes.

## Before merge
- [ ] Create/link the Jira issue.
- [ ] Confirm the supported PostgreSQL floor for backports (JSONPath requires PostgreSQL 12+).

AI Assisted
