### PR TITLE
fix: Gist API - avoid next link for empty page [DHIS2-22092]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
@@ -29,7 +29,10 @@
  */
 package org.hisp.dhis.gist;
 
+import static java.util.Spliterator.ORDERED;
+import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
 import static org.hisp.dhis.gist.GistBuilder.createCountBuilder;
 import static org.hisp.dhis.gist.GistBuilder.createFetchBuilder;
 import static org.hisp.dhis.gist.GistLogic.isPersistentReferenceField;
@@ -40,6 +43,7 @@ import jakarta.persistence.EntityManager;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -99,7 +103,14 @@ public class DefaultGistService implements GistService {
   public GistObjectList exportObjectList(@Nonnull GistQuery query) {
     GistQuery planned = plan(query);
     Stream<Object[]> values = gist(planned);
-    return new GistObjectList(pager(query), properties(planned), values);
+    if (!query.isPaging())
+      return new GistObjectList(pager(query, true), properties(planned), values);
+    // we peek the stream to see if it is empty or not, then re-wrap it back into a stream
+    Iterator<Object[]> rows = values.iterator(); // marks values stream as "consumed"
+    boolean hasRows = rows.hasNext();
+    Stream<Object[]> valuesRewrapped =
+        stream(spliteratorUnknownSize(rows, ORDERED), false).onClose(values::close);
+    return new GistObjectList(pager(query, hasRows), properties(planned), valuesRewrapped);
   }
 
   @Nonnull
@@ -179,7 +190,7 @@ public class DefaultGistService implements GistService {
     return queryBuilder.transform(rows);
   }
 
-  private GistPager pager(GistQuery query) {
+  private GistPager pager(GistQuery query, boolean hasRows) {
     if (!query.isPaging()) return null;
     int page = 1 + (query.getPageOffset() / query.getPageSize());
     Schema schema = schemaService.getSchema(query.getElementType());
@@ -204,7 +215,7 @@ public class DefaultGistService implements GistService {
                 .toString();
       }
       Integer pageCount = GistPager.getPageCount(total, query.getPageSize());
-      if (pageCount == null || pageCount > page) {
+      if (hasRows && (pageCount == null || pageCount > page)) {
         next =
             UriComponentsBuilder.fromUri(queryURI)
                 .replaceQueryParam("page", page + 1)

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistPagerControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistPagerControllerTest.java
@@ -30,6 +30,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.http.HttpStatus;
@@ -118,5 +119,17 @@ class GistPagerControllerTest extends AbstractGistControllerTest {
         JsonNodeType.ARRAY, GET(baseUrl + "?headless=true", getAdminUid()).content().type());
     assertEquals(
         JsonNodeType.OBJECT, GET(baseUrl + "?headless=false", getAdminUid()).content().type());
+  }
+
+  @Test
+  void testPager_NoTotal_EmptyPageHasNoNextPage() {
+    // orgUnitId has exactly one dataSet (dataSetId) at this point, from setUp()
+    String url = "/organisationUnits/{id}/dataSets/gist?pageSize=1&order=name&page=5";
+    JsonObject gist = GET(url, orgUnitId).content();
+    assertHasPager(gist, 5, 1);
+    assertNull(
+        gist.getObject("pager").getString("nextPage").string(),
+        "'nextPage' should not be present when the requested page has no results, "
+            + "even though no total/totalPages was requested");
   }
 }


### PR DESCRIPTION
### Summary
Avoid adding `nextPage` to all gist results with unknown totals. 

What made this difficult is that we want the DB results to stream process between DB and JSON rendering so we can avoid materializing the entire result list in memory. To maintain this quality we cannot count the items on the page but we can peek at the stream to see if it empty so we at least skip `nextPage` when we are dealing with an empty page. 

### Performance Impact
While the rending of the next link itself has no direct impact on the request itself the change has some importance since some clients seem to keep following the next page link even if the current page is already empty so this improvement stops such clients from endlessly moving forward to the next page. Preventing this pattern can significantly impact the load on the server when the base filtering is taxing. This is the case more often than we like since the users sharing filters alone can be responsible so even requesting an empty page can have significant costs that we can avoid indirectly by improving the next link.

### Automatic Testing
A test case was added

### Manual Testing
* browse to some Gist API list URL, `/api/dataElements/gist`
* use pager `nextPage` link until the page is empty
* there should not be a `nextPage` in the pager header