### PR TITLE
feat: Job Scheduler - New setting for analytic job staleness detection timeout [DHIS2-22093]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationService.java
@@ -88,11 +88,9 @@ public interface JobConfigurationService {
    * least once. This is to protect against aborting a job that does not support alive signals as it
    * does not yet use the {@link JobProgress} tracking.
    *
-   * @param timeoutMinutes duration in minutes for which the job has not been updated for it to be
-   *     considered stale and changed back to {@link JobStatus#SCHEDULED}.
    * @return number of job configurations that were affected
    */
-  int rescheduleStaleJobs(int timeoutMinutes);
+  int rescheduleStaleJobs();
 
   /**
    * Add a job configuration

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationStore.java
@@ -258,7 +258,8 @@ public interface JobConfigurationStore extends GenericDimensionalObjectStore<Job
    *
    * @param timeoutMinutes duration in minutes for which the job has not been updated for it to be
    *     considered stale and changed back to {@link JobStatus#SCHEDULED}.
+   * @param types set of types to include in the operation
    * @return number of job configurations that were affected
    */
-  int rescheduleStaleJobs(int timeoutMinutes);
+  int rescheduleStaleJobs(int timeoutMinutes, Set<JobType> types);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/setting/SystemSettings.java
@@ -717,10 +717,20 @@ public non-sealed interface SystemSettings extends Settings {
   /**
    * @return A job that has not been updating its "alive" timestamp for this number of minutes is
    *     reset to initial state of being scheduled by the heartbeat job. The run that was in
-   *     progress is considered a failed run.
+   *     progress is considered a failed run. This excludes analytic jobs which use {@link
+   *     #getJobsRescheduleAnalyticsAfterMinutes()}.
    */
   default int getJobsRescheduleAfterMinutes() {
     return asInt("jobsRescheduleAfterMinutes", 10);
+  }
+
+  /**
+   * @return An analytics job that has not been updating its "alive" timestamp for this number of
+   *     minutes is reset to initial state of being scheduled by the heartbeat job. The run that was
+   *     in progress is considered a failed run.
+   */
+  default int getJobsRescheduleAnalyticsAfterMinutes() {
+    return asInt("jobsRescheduleAnalyticsAfterMinutes", 60 * 4);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
@@ -48,6 +48,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -174,11 +175,17 @@ public class DefaultJobConfigurationService implements JobConfigurationService {
 
   @Override
   @Transactional
-  public int rescheduleStaleJobs(int timeoutMinutes) {
-    if (timeoutMinutes <= 0) {
-      timeoutMinutes = settingsProvider.getCurrentSettings().getJobsRescheduleAfterMinutes();
-    }
-    return jobConfigurationStore.rescheduleStaleJobs(timeoutMinutes);
+  public int rescheduleStaleJobs() {
+    EnumSet<JobType> analyticsJobs =
+        EnumSet.of(JobType.ANALYTICS_TABLE, JobType.CONTINUOUS_ANALYTICS_TABLE);
+    EnumSet<JobType> otherJobs = EnumSet.allOf(JobType.class);
+    otherJobs.removeAll(analyticsJobs);
+    int ttlOthers = settingsProvider.getCurrentSettings().getJobsRescheduleAfterMinutes();
+    int reset = jobConfigurationStore.rescheduleStaleJobs(ttlOthers, otherJobs);
+    int ttlAnalytics =
+        settingsProvider.getCurrentSettings().getJobsRescheduleAnalyticsAfterMinutes();
+    reset += jobConfigurationStore.rescheduleStaleJobs(ttlAnalytics, analyticsJobs);
+    return reset;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
@@ -592,7 +592,7 @@ public class HibernateJobConfigurationStore
   }
 
   @Override
-  public int rescheduleStaleJobs(int timeoutMinutes) {
+  public int rescheduleStaleJobs(int timeoutMinutes, Set<JobType> types) {
     String sql =
         """
         update jobconfiguration
@@ -613,12 +613,15 @@ public class HibernateJobConfigurationStore
             when queueposition is not null then 'CRON'
             else schedulingtype end
         where jobstatus = 'RUNNING'
+        and jobtype = ANY(:types)
         and now() > lastalive + :timeout * interval '1 minute'
         """;
+    String[] jobTypes = types.stream().map(JobType::name).toArray(String[]::new);
     return runWriteInStatelessSession(
         q ->
             nativeSynchronizedQuery(q, sql)
                 .setParameter("timeout", max(1, timeoutMinutes))
+                .setParameter("types", jobTypes, StringArrayType.INSTANCE)
                 .executeUpdate());
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HousekeepingJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HousekeepingJob.java
@@ -90,9 +90,7 @@ public class HousekeepingJob implements Job {
 
     progress.startingStage("Reschedule stale jobs", SKIP_STAGE);
     progress.runStage(
-        0,
-        "%d jobs were rescheduled"::formatted,
-        () -> jobConfigurationService.rescheduleStaleJobs(-1));
+        0, "%d jobs were rescheduled"::formatted, jobConfigurationService::rescheduleStaleJobs);
 
     progress.startingStage("Deleting orphan default icons", SKIP_STAGE);
     progress.runStage(0, "%d icons were deleted"::formatted, iconService::deleteOrphanDefaultIcons);

--- a/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/test/java/org/hisp/dhis/setting/SystemSettingsTest.java
@@ -103,7 +103,7 @@ class SystemSettingsTest {
   @Test
   void testKeysWithDefaults() {
     Set<String> keys = SystemSettings.keysWithDefaults();
-    assertEquals(156, keys.size());
+    assertEquals(157, keys.size());
     // just check some at random
     assertTrue(keys.contains("syncSkipSyncForDataChangedBefore"));
     assertTrue(keys.contains("keyTrackerDashboardLayout"));


### PR DESCRIPTION
### Summary
Adds a new system setting `jobsRescheduleAnalyticsAfterMinutes` which is the maximum time for an analytics job to not update the `lastAlive` before it is considered stale (dead) and becomes target of automatic reset/rescheduling. 

The implementation simply adjusts the reset SQL to take a set of job types to target, the service then does a reset for all non analytics jobs with `jobsRescheduleAfterMinutes` as timeout and then a reset for analytics jobs with `jobsRescheduleAnalyticsAfterMinutes` as timeout.

### API Changes

With different times based on `JobType` the `/api/jobConfigurations/stale` no longer allows non-positive numbers as parameter since it would be confusing to get a result that is either inconsistent with the multi-setting behaviour of the automatic reset or includes jobs based on different assumptions. The least confusing was to only allow an explicit user specified duration and apply it similar to all types.

### Additional Bugfix
In the SQL for finding stale jobs for some reason the interval was multiplied with 2 seconds instead of 1 for fixed delay jobs. This must have been a type which got corrected. 