### PR TITLE
test: Reproducible organisation unit search benchmarks [DHIS2-22091]

### DIFF
--- a/dhis-2/dhis-test-performance/README.md
+++ b/dhis-2/dhis-test-performance/README.md
@@ -76,6 +76,196 @@ automatically converts `simulation.log` to `simulation.csv` if
 
 The `platform` package (`org.hisp.dhis.test.platform`) contains focused CRUD performance tests.
 
+### OrganisationUnitSearchPerformanceTest
+
+Shared reproducible benchmark for translated filtering (Core #25128), hierarchy scoping
+(Core #25127), and Data Entry #593. Use the same benchmark branch, fixture manifest and database
+snapshot for every variant. The backend baseline is **`7b38c692f5c`** (January-merged master);
+compare it with translated-only, hierarchy-only, and both fixes. Do not substitute current master.
+The existing Data Entry baseline already has a 200 ms debounce.
+
+#### Explicit setup (never part of Gatling)
+
+Run these commands **from `dhis-2/dhis-test-performance`**, with Java 17+ and Maven.
+Use a fresh, disposable database (DHIS2 initialized, admin account and default categories present,
+**no organisation units**). Setup is create-only and refuses a nonempty OU tree. It does not
+reset a database or update existing metadata, and never runs automatically from a simulation.
+
+Keep an untracked, permission-restricted `/absolute/path/ou-search.properties`:
+
+```properties
+baseUrl=http://localhost:8087
+username=admin
+ouSearch.manifest=/absolute/path/ou-search-manifest.json
+ouSearch.leafCount=272000
+ouSearch.translationDensity=mixed
+ouSearch.batchSize=1000
+iterations=3
+concurrency=1
+mode=sequential
+```
+
+For browser runs, optionally add `ouSearch.corsOrigins=http://localhost:3003,http://localhost:3004`.
+During explicitly authorized setup these exact origins are added to the disposable instance's
+CORS allowlist, preserving existing entries. Without this option configuration is unchanged.
+Use origins only, matching the app URLs; do not allow every origin or target a production instance.
+
+Supply administrator `password` and synthetic-user `ouSearch.password` in that private file,
+or export `DHIS2_PASSWORD` and `OU_SEARCH_PASSWORD` through your secret manager. The latter
+must satisfy the instance's password policy and is shared by the seven **synthetic** accounts;
+never use a real person's password. There are no built-in credentials. `-D` values override
+the config file; password environment variables are fallbacks. Do not put secrets in command
+arguments, published manifests, reports, or committed files.
+
+```sh
+# Generate only: deterministic JSON manifest, no network or database mutation.
+mvn test-compile org.codehaus.mojo:exec-maven-plugin:3.5.0:java \
+  -Dexec.classpathScope=test \
+  -Dexec.mainClass=org.hisp.dhis.test.platform.OrganisationUnitSearchFixture \
+  -DconfigFile=/absolute/path/ou-search.properties
+
+# Seed once: synchronous, checked metadata API batches, then write the same manifest.
+mvn test-compile org.codehaus.mojo:exec-maven-plugin:3.5.0:java \
+  -Dexec.classpathScope=test \
+  -Dexec.mainClass=org.hisp.dhis.test.platform.OrganisationUnitSearchFixture \
+  -DconfigFile=/absolute/path/ou-search.properties \
+  -DouSearch.operation=seed -DouSearch.setup=CREATE_DISPOSABLE_FIXTURE
+```
+
+`ouSearch.leafCount` must be at least 200. `translationDensity=none|mixed|dense` means
+zero, even-indexed, or all leaves have French NAME translations. Fixture version 1 contains
+one country, two districts, 200 wards, and the configured leaves (default 272,203 OUs total).
+UIDs, names, translations and contiguous leaf-to-ward assignment are deterministic. All leaves
+match `Bench`; at most 20 match `Needle`/`okp`. French translated leaves match `Traduit`;
+`Fallback` matches untranslated names. `ZZZ_NO_SUCH_OU_918273` never matches. Country,
+districts, and ward zero also contain `okp`, making hierarchy-root inclusion observable.
+
+Users `oubench_single`, `oubench_multi`, `oubench_overlap`, `oubench_small`,
+`oubench_large`, `oubench_french`, and `oubench_client` have, respectively: district zero,
+both disjoint districts, district zero plus its ward zero, ward zero, country, country,
+and country capture/view/search roots. Their DB locales are explicitly English except
+`oubench_french` (`keyDbLocale=fr`). A real monthly data set and aggregate data element
+are created, with data-write sharing and role access. The first 200 leaves and all rare
+replacement matches are assigned to the data set, so both browser pages and replacements
+are usable for Data Entry. No generated giant metadata dump is committed.
+
+**Manifest schema (`fixtureVersion: 1`):**
+
+* Top-level `leafCount`, `wardCount`, `organisationUnitCount`, `translationDensity`, `rootId`.
+* `users`: keyed by the seven account labels, each `{id, username, dbLocale, roots: [uid]}`.
+* `cases`: `{name, user, endpoint, params, url, expected}`. `params` contains exact string
+  query values (or string arrays for repeated parameters); `url` is a relative, encoded URL.
+  `expected` contains ordered `ids`, `paths`, `displayNames`, independent `total`, and
+  `checkTotal`. All expectations are calculated from generated data, never search responses.
+* `client`: `{username, dataSetId, dataSetName, searchTerm, replacementTerm, pageSize,
+  firstPagePaths, secondPagePaths, replacementPaths, total, replacementTotal, orgUnits}`.
+  `orgUnits` is `{id,path,displayName}[]` for these results and their ancestors.
+  Client pages are sorted by `id:asc`, 50 rows per page. Feed the manifest file path to
+  `Cypress.env('ouSearchManifest')`; supply browser API URL/login separately using its
+  normal Cypress configuration.
+
+No credentials or target base URL are written into the manifest. Generate-only does not
+certify that a database was seeded. After partial setup failure, restore a fresh database
+and repeat setup; do not retry against the half-imported tree. To reset/change scale or
+density, replace the disposable database, regenerate and reseed. Preserve the manifest
+beside the snapshot; changes to fixture semantics require a fixture-version bump.
+
+#### One run and comparisons
+
+```sh
+mvn gatling:test \
+  -Dgatling.simulationClass=org.hisp.dhis.test.platform.OrganisationUnitSearchPerformanceTest \
+  -DconfigFile=/absolute/path/ou-search.properties
+
+# Focus on an identical pair of cases for each application variant.
+mvn gatling:test \
+  -Dgatling.simulationClass=org.hisp.dhis.test.platform.OrganisationUnitSearchPerformanceTest \
+  -DconfigFile=/absolute/path/ou-search.properties \
+  -DouSearch.cases=display-french-selective,hierarchy-single-count \
+  -Diterations=10 -Dconcurrency=4
+```
+
+Defaults: all 66 distinct cases, `iterations=3`, `concurrency=1`, `mode=sequential`.
+`ouSearch.cases` is `all` or comma-separated exact manifest case names; unknown names fail.
+`concurrency` is virtual users **per case**, each doing exactly `iterations` searches.
+`mode=parallel` starts all selected cases concurrently; sequential runs one case population
+at a time. Every virtual user authenticates once under a separately named request; the
+timed searches reuse its session cookie and do not send Basic authentication.
+
+The suite covers scoped and unscoped broad/selective/no-match/translated/fallback
+`displayName:ilike`, second pages, path-only Data Entry requests, hierarchy
+`query=okp&withinUserSearchHierarchy=true` list/count requests, explicit roots, and
+`rootJunction=OR` intersections with mandatory scopes (including an outside-scope district).
+Responses must have the exact ordered IDs, paths and display names requested by each case;
+path-only client cases check paths. All paged cases also require the exact `pager.total`.
+Empty/incorrect responses are KOs, not performance wins.
+Current Core always counts paged collections; `totalPages` is not a supported switch here.
+The fixture sends only supported parameters and does not duplicate a request merely to
+toggle a count assertion. Case names ending in `-count` emphasize count/scope correctness,
+not a separate count-only API.
+Known baseline semantic failures remain visible and make the correctness assertion fail;
+record their status separately from latency, and retain the failed Gatling report.
+There is no default latency threshold. Optionally set `ouSearch.p95Ms` to a deliberately
+chosen positive p95 upper bound; authentication is excluded from that per-case bound.
+
+For each image/WAR, restore the **same seeded snapshot**, start the application, and run
+`iterations=1,concurrency=1` for an application-cold observation. Restart before each
+individual cold case if measuring more than one: a sequential matrix shares warmed state.
+Restarting the application does not clear PostgreSQL/OS caches; label that distinction.
+For warm results, perform an explicitly labelled warmup then run the same command without
+restarting. Repeat with `concurrency=4` (or your chosen level), preserving case order, scale,
+translation density, database/JVM/cache settings and hardware. Never include seed timings.
+Use normal `target/gatling` reports and `gstat compare` above; do not discard semantic KOs
+or describe one request as a meaningful p95 sample.
+
+#### Existing runner / CI
+
+`DB_TYPE=empty` builds a fresh PostGIS database locally without downloading a dump or
+requiring an S3 artifact. Leave `DB_DIR` unset; `DB_VERSION` remains an image-cache label.
+The normal Sierra Leone, HMIS, and platform-perf modes are unchanged.
+
+The optional `FIXTURE_SETUP_CLASS` / `FIXTURE_SETUP_ARGS` runner hook invokes a Java main
+class with the test classpath exactly once after application readiness, before analytics,
+profiling, warmup or measured requests. It forwards `MVN_ARGS` (the same config, scale,
+translation-density and manifest properties as the simulation), then setup-only arguments.
+It restarts only `web`/`web-healthcheck` and waits for readiness, keeping the database intact.
+Warmup and measurement reuse that fixture and manifest without resetting or re-seeding.
+A subsequent runner invocation starts a fresh container database and seeds deterministically
+again. With no setup class, the hook does nothing; normal Gatling execution remains read-only.
+
+Provide the private config and synthetic password as above; for example:
+
+```sh
+DHIS2_IMAGE=your-candidate-image \
+SIMULATION_CLASS=org.hisp.dhis.test.platform.OrganisationUnitSearchPerformanceTest \
+DB_DIR= DB_TYPE=empty DB_VERSION=ou-search-v1 \
+FIXTURE_SETUP_CLASS=org.hisp.dhis.test.platform.OrganisationUnitSearchFixture \
+FIXTURE_SETUP_ARGS="-DouSearch.operation=seed -DouSearch.setup=CREATE_DISPOSABLE_FIXTURE" \
+WARMUP=0 REPORT_SUFFIX=application-cold HEALTHCHECK_TIMEOUT=900 \
+MVN_ARGS="-DconfigFile=/absolute/path/ou-search.properties -DbaseUrl=http://localhost:8080 -DouSearch.manifest=target/gatling/ou-search-manifest.json -Diterations=1" \
+./run-simulation.sh
+```
+
+Use `WARMUP=1`, an appropriate iteration count, and a warm report suffix for warm comparison.
+With `WARMUP=0`, this is application-cold after seeding, not PostgreSQL/OS-cache cold.
+The runner marks warmup `gatling.failOnError=false`; still retain/review those KOs.
+Without `FIXTURE_SETUP_CLASS`, `DB_TYPE=empty` only provisions an empty database; it does
+not manufacture a manifest or make unrelated simulations fixture-aware. The explicit
+`ouSearch.setup` confirmation belongs in `FIXTURE_SETUP_ARGS` as shown; merely selecting
+the fixture's class without that confirmation cannot seed a target.
+
+Existing comparison CI's `perf_tests_git_ref` selects the **same shared benchmark branch**
+for both Core PR images. Supply the command's environment settings to both `baseline_env`
+and `candidate_env`, varying only the image/report identity; both get identical generated
+trees and expected results without a privately published database. The existing comparison
+workflow permits baseline assertion failure so it can finish both runs: preserve baseline
+semantic KOs rather than treating that workflow continuation as a correctness pass.
+Keep the generated manifest with the report artifacts and compare its fixture parameters.
+The example places it under `target/gatling` so the existing CI artifact upload includes it.
+No workflow change is needed. Keep synthetic secrets in environment or private config,
+not `MVN_ARGS` or `FIXTURE_SETUP_ARGS`. The runner records its own `DHIS2_PASSWORD` in `run-simulation.env`;
+redact that existing metadata before publishing any report archive.
+
 ### UsersPerformanceTest
 
 Tests single-user CRUD operations on `/api/users` (POST, GET, PUT, PATCH, DELETE).

--- a/dhis-2/dhis-test-performance/docker/Dockerfile.postgres
+++ b/dhis-2/dhis-test-performance/docker/Dockerfile.postgres
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
-# Dockerfile to build and restore the DB dump at build time (not runtime)
-# This significantly speeds up container startup for performance tests.
+# Build either a restored benchmark database or an empty PostGIS database at build time.
+# Author of the empty-fixture mode: Morten Svanæs
 ARG DB_DIR
 ARG DB_TYPE
 ARG DB_VERSION
@@ -11,13 +11,18 @@ ARG DB_TYPE
 ARG DB_VERSION
 WORKDIR /tmp
 
-RUN if [ -n "$DB_DIR" ]; then \
-      S3_PATH="s3://databases.dhis2.org/${DB_DIR}/${DB_TYPE}/${DB_VERSION}/dhis2-db-${DB_TYPE}.sql.gz"; \
+RUN mkdir -p /tmp/database && \
+    if [ "$DB_TYPE" = "empty" ]; then \
+      echo "Creating an empty database; no dump download"; \
     else \
-      S3_PATH="s3://databases.dhis2.org/${DB_TYPE}/${DB_VERSION}/dhis2-db-${DB_TYPE}.sql.gz"; \
-    fi && \
-    echo "Downloading from: $S3_PATH" && \
-    aws s3 cp --no-sign-request "$S3_PATH" dump.sql.gz
+      if [ -n "$DB_DIR" ]; then \
+        S3_PATH="s3://databases.dhis2.org/${DB_DIR}/${DB_TYPE}/${DB_VERSION}/dhis2-db-${DB_TYPE}.sql.gz"; \
+      else \
+        S3_PATH="s3://databases.dhis2.org/${DB_TYPE}/${DB_VERSION}/dhis2-db-${DB_TYPE}.sql.gz"; \
+      fi && \
+      echo "Downloading from: $S3_PATH" && \
+      aws s3 cp --no-sign-request "$S3_PATH" /tmp/database/dump.sql.gz; \
+    fi
 
 FROM ghcr.io/baosystems/postgis:14-3.5 AS builder
 
@@ -33,7 +38,7 @@ ENV POSTGRES_USER=dhis \
     PGDATABASE=dhis \
     PGPASSWORD=dhis
 
-COPY --from=downloader /tmp/dump.sql.gz /tmp/dump.sql.gz
+COPY --from=downloader /tmp/database/ /tmp/database/
 
 COPY docker-entrypoint-build.sh /usr/local/bin/
 # Initialize the database and restore the dump at build time

--- a/dhis-2/dhis-test-performance/docker/docker-entrypoint-build.sh
+++ b/dhis-2/dhis-test-performance/docker/docker-entrypoint-build.sh
@@ -6,6 +6,7 @@
 # https://github.com/docker-library/postgres/blob/master/14/bookworm/docker-entrypoint.sh
 #
 # Modified for build-time database initialization only (does not start postgres permanently)
+# Empty benchmark database support: Morten Svanæs
 
 set -Eeo pipefail
 
@@ -141,10 +142,17 @@ build_init() {
 	docker_setup_db
 
 	# Restore dump if provided
-	if [ -f /tmp/dump.sql.gz ]; then
+	if [ -f /tmp/database/dump.sql.gz ]; then
 		echo "Restoring database dump..."
-		gunzip -c /tmp/dump.sql.gz | docker_process_sql -d "$POSTGRES_DB"
+		gunzip -c /tmp/database/dump.sql.gz | docker_process_sql -d "$POSTGRES_DB"
 		echo "Database dump restored successfully"
+	elif [ "${DB_TYPE:-}" = "empty" ]; then
+		echo "Creating extensions for a fresh DHIS2 database..."
+		docker_process_sql -d "$POSTGRES_DB" -c 'CREATE EXTENSION IF NOT EXISTS postgis;'
+		docker_process_sql -d "$POSTGRES_DB" -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
+	else
+		echo "Expected database dump is missing" >&2
+		exit 1
 	fi
 
 	docker_temp_server_stop

--- a/dhis-2/dhis-test-performance/run-simulation.sh
+++ b/dhis-2/dhis-test-performance/run-simulation.sh
@@ -21,7 +21,7 @@ show_usage() {
   echo "                        Valid values: dev"
   echo "                        Pattern: s3://databases.dhis2.org/<dir>/<type>/<version>/dhis2-db-<type>.sql.gz"
   echo "  DB_TYPE               Database type (default: sierra-leone)"
-  echo "                        Valid values without DB_DIR: sierra-leone, hmis"
+  echo "                        Valid values without DB_DIR: sierra-leone, hmis, empty"
   echo "                        Valid values with DB_DIR: platform-perf"
   echo "  DB_VERSION            Database version (default: dev)"
   echo "                        Must be alphanumeric, dots, hyphens, underscores only"
@@ -47,6 +47,9 @@ show_usage() {
   echo "  PROF_ARGS             Async-profiler arguments (enables profiling)"
   echo "                        Options: https://github.com/async-profiler/async-profiler/blob/master/docs/ProfilerOptions.md"
   echo "  MVN_ARGS              Additional Maven arguments passed to mvn gatling:test"
+  echo "  FIXTURE_SETUP_CLASS  Optional Java main class run once before warmup using test classpath"
+  echo "                        Shares MVN_ARGS; after setup restarts only web, preserving the DB"
+  echo "  FIXTURE_SETUP_ARGS   Additional Maven arguments for fixture setup only (default: empty)"
   echo ""
   echo "EXAMPLES:"
   echo "  # Basic test run"
@@ -112,6 +115,8 @@ CAPTURE_DHIS2_LOGS=${CAPTURE_DHIS2_LOGS:-""}
 CAPTURE_SQL_LOGS=${CAPTURE_SQL_LOGS:-""}
 PROF_ARGS=${PROF_ARGS:=""}
 MVN_ARGS=${MVN_ARGS:-""}
+FIXTURE_SETUP_CLASS=${FIXTURE_SETUP_CLASS:-""}
+FIXTURE_SETUP_ARGS=${FIXTURE_SETUP_ARGS:-""}
 DHIS_CONF_FILE=${DHIS_CONF_FILE:-"dhis.conf"}
 COMPOSE_EXTRA_FILE=${COMPOSE_EXTRA_FILE:-""}
 # docker compose interpolates ${DHIS_CONF_FILE} in the volume mount
@@ -134,13 +139,13 @@ fi
 
 # Validate DB_TYPE
 if [ -z "$DB_DIR" ]; then
-  # No DB_DIR: only standard public databases are allowed
+  # No DB_DIR: public databases or an empty local database are allowed
   case "$DB_TYPE" in
-    sierra-leone|hmis)
+    sierra-leone|hmis|empty)
       # Valid
       ;;
     *)
-      echo "Error: DB_TYPE must be 'sierra-leone' or 'hmis' when DB_DIR is not set, got: $DB_TYPE" >&2
+      echo "Error: DB_TYPE must be 'sierra-leone', 'hmis', or 'empty' when DB_DIR is not set, got: $DB_TYPE" >&2
       echo "Set DB_DIR to use a custom database type" >&2
       echo "Run '$0' without arguments to see usage" >&2
       exit 1
@@ -317,6 +322,41 @@ start_containers() {
   fi
 
   echo "All containers ready! (took $(($(date +%s) - start_time))s)"
+}
+
+# One-time fixture setup support: Morten Svanæs
+prepare_fixture() {
+  if [ -z "$FIXTURE_SETUP_CLASS" ]; then
+    return 0
+  fi
+
+  echo ""
+  echo "========================================"
+  echo "PHASE: Fixture Setup (excluded from timings)"
+  echo "========================================"
+  # Share the simulation's config/manifest/scale properties; setup-only arguments override them.
+  # Password is supplied through the existing private environment, not command arguments.
+  # shellcheck disable=SC2086
+  DHIS2_PASSWORD="$DHIS2_PASSWORD" mvn test-compile org.codehaus.mojo:exec-maven-plugin:3.5.0:java \
+    -Dusername="$DHIS2_USERNAME" \
+    -DbaseUrl=http://localhost:8080 \
+    $MVN_ARGS \
+    $FIXTURE_SETUP_ARGS \
+    -Dexec.classpathScope=test \
+    -Dexec.mainClass="$FIXTURE_SETUP_CLASS"
+
+  # Setup warms application caches. Restart only the application, preserving the seeded DB.
+  # Subsequent warmup and measured runs reuse this fixture and manifest without re-seeding.
+  local compose_args
+  compose_args=$(get_compose_args)
+  # shellcheck disable=SC2086
+  docker compose $compose_args restart web web-healthcheck
+  # shellcheck disable=SC2086
+  if ! docker compose $compose_args up --detach --wait --wait-timeout "$HEALTHCHECK_TIMEOUT"; then
+    echo "Error: Application failed to become ready after fixture setup"
+    dump_container_logs
+    exit 1
+  fi
 }
 
 save_profiler_data() {
@@ -647,19 +687,18 @@ generate_metadata() {
 
   printf "Generating run metadata... "
 
-  # Get DHIS2 image digest for reproducibility
-  # DHIS2 images are only pushed to Docker Hub, so RepoDigests[0] is the Docker Hub digest
+  # Prefer a pullable registry digest; locally built images have only a local image ID.
   local dhis2_image_digest=""
   local dhis2_labels=""
 
-  # Get DHIS2 image RepoDigest (registry digest that can be pulled for exact reproduction)
-  dhis2_image_digest=$(docker inspect --format '{{index .RepoDigests 0}}' "$DHIS2_IMAGE" 2>/dev/null || echo "unknown")
+  # Avoid indexing an empty RepoDigests list, which can produce a malformed multiline .env value.
+  dhis2_image_digest=$(docker image inspect --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}' "$DHIS2_IMAGE" 2>/dev/null || echo "unknown")
 
   # Extract DHIS2 labels from image (DHIS2_BUILD_BRANCH, DHIS2_BUILD_REVISION, DHIS2_VERSION, etc.)
   dhis2_labels=$(docker inspect --format '{{json .Config.Labels}}' "$DHIS2_IMAGE" 2>/dev/null | \
     jq --raw-output 'to_entries | map(select(.key | startswith("DHIS2_"))) | sort_by(.key) | .[] | "\(.key)=\(.value)"' 2>/dev/null || echo "")
 
-  # Build reproducible command using RepoDigest
+  # A registry digest is portable; an image ID requires the image to exist locally.
   # DB image is reproducible via DB_TYPE and DB_VERSION args
   local dhis2_image_immutable="$DHIS2_IMAGE"
   if [ "$dhis2_image_digest" != "unknown" ] && [ -n "$dhis2_image_digest" ]; then
@@ -675,7 +714,7 @@ generate_metadata() {
     echo "#   git checkout $git_commit"
     echo "#   set -o allexport && source run-simulation.env && set +o allexport && ./run-simulation.sh"
     echo "#"
-    echo "# For exact reproduction with pinned image digest:"
+    echo "# For exact reproduction with pinned registry digest or locally available image ID:"
     echo "#   git checkout $git_commit"
     echo "#   set -o allexport && source run-simulation.env && DHIS2_IMAGE=$dhis2_image_immutable && set +o allexport && ./run-simulation.sh"
     echo ""
@@ -698,6 +737,8 @@ generate_metadata() {
     echo "CAPTURE_SQL_LOGS=$CAPTURE_SQL_LOGS"
     echo "PROF_ARGS=\"$PROF_ARGS\""
     echo "MVN_ARGS=\"$MVN_ARGS\""
+    echo "FIXTURE_SETUP_CLASS=\"$FIXTURE_SETUP_CLASS\""
+    echo "FIXTURE_SETUP_ARGS=\"$FIXTURE_SETUP_ARGS\""
     echo ""
     echo "# Additional metadata"
     echo "GIT_BRANCH_PERFORMANCE_TESTS=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'unknown')"
@@ -850,6 +891,7 @@ echo "========================================"
 echo "PHASE: Container Startup"
 echo "========================================"
 start_containers
+prepare_fixture
 prepare_database
 
 if [ "$WARMUP" -gt 0 ]; then

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/OrganisationUnitSearchFixture.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/OrganisationUnitSearchFixture.java
@@ -1,0 +1,572 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.test.platform;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Explicit, create-only setup for disposable organisation-unit search benchmark databases.
+ * Expectations are calculated from the generated tree, never from search responses.
+ *
+ * @author Morten Svanæs
+ */
+public final class OrganisationUnitSearchFixture {
+  static final ObjectMapper JSON = new ObjectMapper();
+  private static final int VERSION = 1;
+  private static final int WARDS = 200;
+  private static final String COUNTRY = "B0000000001";
+  private static final String DATA_SET = "D0000000001";
+  private static final String DATA_ELEMENT = "E0000000001";
+  private static final String ROLE = "R0000000001";
+  private static final String DATA_SET_NAME = "Synthetic OU Search Monthly";
+  private static final Properties CONFIG = loadConfig();
+
+  private record Unit(String id, String name, String french, String parent, String path) {
+    String displayName(boolean fr) {
+      return fr && french != null ? french : name;
+    }
+  }
+
+  private final int leaves = positiveInt("ouSearch.leafCount", 272000);
+  private final int batchSize = positiveInt("ouSearch.batchSize", 1000);
+  private final String density = prop("ouSearch.translationDensity", "mixed");
+  private final List<Unit> units = new ArrayList<>();
+  private final Map<String, List<String>> scopes = new LinkedHashMap<>();
+  private final ObjectNode manifest = JSON.createObjectNode();
+  private HttpClient http;
+  private String baseUrl;
+
+  static String prop(String key, String fallback) {
+    return System.getProperty(key, CONFIG.getProperty(key, fallback));
+  }
+
+  static String required(String key, String environment) {
+    String value = prop(key, System.getenv(environment));
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("Supply " + key + " in configFile or " + environment);
+    }
+    return value;
+  }
+
+  static int positiveInt(String key, int fallback) {
+    int value = Integer.parseInt(prop(key, Integer.toString(fallback)));
+    if (value < 1) throw new IllegalArgumentException(key + " must be positive");
+    return value;
+  }
+
+  private static Properties loadConfig() {
+    Properties properties = new Properties();
+    String path = System.getProperty("configFile");
+    if (path != null) {
+      try (var input = Files.newInputStream(Path.of(path))) {
+        properties.load(input);
+      } catch (IOException ex) {
+        throw new IllegalStateException("Cannot read configFile", ex);
+      }
+    }
+    return properties;
+  }
+
+  static String basicAuth(String username, String password) {
+    return "Basic "
+        + Base64.getEncoder()
+            .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String uid(char prefix, int index) {
+    return String.format(Locale.ROOT, "%c%010d", prefix, index);
+  }
+
+  private void add(String id, String name, String french, Unit parent) {
+    units.add(
+        new Unit(
+            id,
+            name,
+            french,
+            parent == null ? null : parent.id(),
+            (parent == null ? "" : parent.path()) + "/" + id));
+  }
+
+  private void generate() {
+    if (leaves < 200) throw new IllegalArgumentException("ouSearch.leafCount must be >= 200");
+    if (!Set.of("none", "mixed", "dense").contains(density)) {
+      throw new IllegalArgumentException("translationDensity must be none, mixed, or dense");
+    }
+    add(COUNTRY, "Synthetic Country okp", null, null);
+    Unit country = units.get(0);
+    add(uid('B', 2), "Synthetic District 0 okp", null, country);
+    add(uid('B', 3), "Synthetic District 1 okp", null, country);
+    for (int ward = 0; ward < WARDS; ward++) {
+      add(
+          uid('W', ward),
+          "Synthetic Ward " + String.format(Locale.ROOT, "%03d", ward) + (ward == 0 ? " okp" : ""),
+          null,
+          units.get(1 + ward / 100));
+    }
+    int rareStride = (leaves + 19) / 20;
+    for (int index = 0; index < leaves; index++) {
+      String number = String.format(Locale.ROOT, "%010d", index);
+      boolean rare = index % rareStride == 0;
+      boolean translated = density.equals("dense") || density.equals("mixed") && index % 2 == 0;
+      // Contiguous leaf ranges in each ward keep the first browser pages near one tree branch.
+      Unit parent = units.get(3 + (int) ((long) index * WARDS / leaves));
+      add(
+          uid('L', index),
+          "Bench Leaf " + number + " Fallback" + (rare ? " Needle okp" : ""),
+          translated ? "Bench Traduit " + number + (rare ? " Aiguille okp" : "") : null,
+          parent);
+    }
+    scopes.put("single", List.of(uid('B', 2)));
+    scopes.put("multi", List.of(uid('B', 2), uid('B', 3)));
+    scopes.put("overlap", List.of(uid('B', 2), uid('W', 0)));
+    scopes.put("small", List.of(uid('W', 0)));
+    scopes.put("large", List.of(COUNTRY));
+    scopes.put("french", List.of(COUNTRY));
+    scopes.put("client", List.of(COUNTRY));
+    createManifest();
+  }
+
+  private boolean inScope(Unit unit, String account) {
+    return scopes.get(account).stream()
+        .anyMatch(root -> unit.id().equals(root) || unit.path().contains("/" + root + "/"));
+  }
+
+  private List<Unit> matches(String account, Predicate<Unit> predicate) {
+    return units.stream()
+        .filter(unit -> inScope(unit, account))
+        .filter(predicate)
+        .sorted(Comparator.comparing(Unit::id))
+        .toList();
+  }
+
+  private static ArrayNode strings(List<String> values) {
+    ArrayNode result = JSON.createArrayNode();
+    values.forEach(result::add);
+    return result;
+  }
+
+  private static ObjectNode params(int page) {
+    ObjectNode params = JSON.createObjectNode();
+    params.put("fields", "id,path,displayName");
+    params.put("withinUserSearchHierarchy", "true");
+    params.put("paging", "true");
+    params.put("pageSize", "50");
+    params.put("page", Integer.toString(page));
+    params.put("order", "id:asc");
+    return params;
+  }
+
+  private void addCase(String name, String account, ObjectNode params, Predicate<Unit> predicate) {
+    List<Unit> all = matches(account, predicate);
+    int page = Integer.parseInt(params.path("page").asText());
+    int pageSize = Integer.parseInt(params.path("pageSize").asText());
+    int start = Math.min((page - 1) * pageSize, all.size());
+    List<Unit> result = all.subList(start, Math.min(start + pageSize, all.size()));
+    ObjectNode test = manifest.withArray("cases").addObject();
+    test.put("name", name);
+    test.put("user", account);
+    test.put("endpoint", "/api/organisationUnits");
+    test.set("params", params);
+    ObjectNode expected = test.putObject("expected");
+    expected.set("ids", strings(result.stream().map(Unit::id).toList()));
+    expected.set("paths", strings(result.stream().map(Unit::path).toList()));
+    expected.set(
+        "displayNames",
+        strings(result.stream().map(u -> u.displayName(account.equals("french"))).toList()));
+    expected.put("total", all.size());
+    expected.put("checkTotal", true);
+    test.put("url", url("/api/organisationUnits", params));
+  }
+
+  private void createManifest() {
+    manifest.put("fixtureVersion", VERSION);
+    manifest.put("leafCount", leaves);
+    manifest.put("wardCount", WARDS);
+    manifest.put("translationDensity", density);
+    manifest.put("organisationUnitCount", units.size());
+    manifest.put("rootId", COUNTRY);
+    ObjectNode users = manifest.putObject("users");
+    int userIndex = 0;
+    for (var entry : scopes.entrySet()) {
+      ObjectNode user = users.putObject(entry.getKey());
+      user.put("id", uid('U', userIndex++));
+      user.put("username", "oubench_" + entry.getKey());
+      user.put("dbLocale", entry.getKey().equals("french") ? "fr" : "en");
+      user.set("roots", strings(entry.getValue()));
+    }
+    for (String account : scopes.keySet()) {
+      if (account.equals("client")) continue;
+      boolean french = account.equals("french");
+      Map<String, String> terms = new LinkedHashMap<>();
+      terms.put("broad", "Bench");
+      terms.put("selective", french && !density.equals("none") ? "Aiguille" : "Needle");
+      terms.put("none", "ZZZ_NO_SUCH_OU_918273");
+      terms.put("translated", "Traduit");
+      terms.put("fallback", "Fallback");
+      for (var term : terms.entrySet()) {
+        ObjectNode params = params(1);
+        params.put("filter", "displayName:ilike:" + term.getValue());
+        addCase(
+            "display-" + account + "-" + term.getKey(),
+            account,
+            params,
+            u ->
+                u.displayName(french)
+                    .toLowerCase(Locale.ROOT)
+                    .contains(term.getValue().toLowerCase(Locale.ROOT)));
+        if (account.equals("large") || french) {
+          ObjectNode global = params.deepCopy();
+          global.remove("withinUserSearchHierarchy");
+          addCase(
+              "display-global-" + (french ? "fr-" : "en-") + term.getKey(),
+              account,
+              global,
+              u ->
+                  u.displayName(french)
+                      .toLowerCase(Locale.ROOT)
+                      .contains(term.getValue().toLowerCase(Locale.ROOT)));
+        }
+      }
+      ObjectNode query = params(1);
+      query.put("fields", "id,path");
+      query.put("pageSize", "15");
+      query.put("query", "okp");
+      addCase(
+          "hierarchy-" + account + (account.equals("small") ? "-list" : "-count"),
+          account,
+          query,
+          u -> u.name().contains("okp"));
+      ObjectNode or = params(1);
+      or.put("rootJunction", "OR");
+      or.set("filter", strings(List.of("displayName:ilike:Needle", "id:eq:" + uid('B', 3))));
+      addCase(
+          "hierarchy-or-" + account + "-count",
+          account,
+          or,
+          u -> u.displayName(french).contains("Needle") || u.id().equals(uid('B', 3)));
+      ObjectNode pageTwo = params(2);
+      pageTwo.put("filter", "displayName:ilike:Bench");
+      addCase(
+          "display-" + account + "-broad-page2",
+          account,
+          pageTwo,
+          u -> u.displayName(french).contains("Bench"));
+      ObjectNode roots = params(1);
+      roots.put("filter", "id:in:[" + String.join(",", scopes.get(account)) + "]");
+      addCase(
+          "hierarchy-" + account + "-roots",
+          account,
+          roots,
+          u -> scopes.get(account).contains(u.id()));
+    }
+    for (int page : List.of(1, 2)) {
+      ObjectNode clientQuery = params(page);
+      clientQuery.remove("withinUserSearchHierarchy");
+      clientQuery.put("fields", "path");
+      clientQuery.put("filter", "displayName:ilike:Bench");
+      addCase("client-paths-page" + page, "client", clientQuery, u -> u.name().contains("Bench"));
+    }
+    List<Unit> broad = matches("client", u -> u.name().contains("Bench"));
+    List<Unit> replacement = matches("client", u -> u.name().contains("Needle"));
+    ObjectNode client = manifest.putObject("client");
+    client.put("username", "oubench_client");
+    client.put("dataSetId", DATA_SET);
+    client.put("dataSetName", DATA_SET_NAME);
+    client.put("searchTerm", "Bench");
+    client.put("replacementTerm", "Needle");
+    client.put("pageSize", 50);
+    client.put("total", broad.size());
+    client.put("replacementTotal", replacement.size());
+    client.set("firstPagePaths", strings(broad.subList(0, 50).stream().map(Unit::path).toList()));
+    client.set(
+        "secondPagePaths", strings(broad.subList(50, 100).stream().map(Unit::path).toList()));
+    client.set("replacementPaths", strings(replacement.stream().map(Unit::path).toList()));
+    Set<String> visible = new LinkedHashSet<>();
+    broad.subList(0, 100).forEach(u -> visible.addAll(List.of(u.path().substring(1).split("/"))));
+    replacement.forEach(u -> visible.addAll(List.of(u.path().substring(1).split("/"))));
+    ArrayNode orgUnits = client.putArray("orgUnits");
+    units.stream()
+        .filter(u -> visible.contains(u.id()))
+        .forEach(
+            u -> {
+              ObjectNode node = orgUnits.addObject();
+              node.put("id", u.id());
+              node.put("path", u.path());
+              node.put("displayName", u.name());
+            });
+  }
+
+  static String url(String endpoint, JsonNode params) {
+    List<String> pairs = new ArrayList<>();
+    params
+        .fields()
+        .forEachRemaining(
+            entry -> {
+              JsonNode value = entry.getValue();
+              if (value.isArray())
+                value.forEach(item -> pairs.add(entry.getKey() + "=" + encode(item.asText())));
+              else pairs.add(entry.getKey() + "=" + encode(value.asText()));
+            });
+    return endpoint + "?" + String.join("&", pairs);
+  }
+
+  private static String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+
+  private JsonNode request(String method, String path, JsonNode body, String authorization)
+      throws IOException, InterruptedException {
+    HttpRequest.Builder builder =
+        HttpRequest.newBuilder(URI.create(baseUrl + path))
+            .timeout(Duration.ofMinutes(10))
+            .header("Accept", "application/json");
+    if (authorization != null) builder.header("Authorization", authorization);
+    if (body != null) builder.header("Content-Type", "application/json");
+    builder.method(
+        method,
+        body == null
+            ? HttpRequest.BodyPublishers.noBody()
+            : HttpRequest.BodyPublishers.ofString(JSON.writeValueAsString(body)));
+    HttpResponse<String> response =
+        http.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    // Never include response bodies: rejected user imports may echo password fields.
+    if (response.statusCode() < 200 || response.statusCode() >= 300) {
+      throw new IOException(
+          method
+              + " "
+              + path
+              + " returned HTTP "
+              + response.statusCode()
+              + "; inspect the disposable server log (request bodies are not logged here)");
+    }
+    JsonNode result =
+        response.body().isBlank() ? JSON.createObjectNode() : JSON.readTree(response.body());
+    if (result.has("status") && !Set.of("OK", "SUCCESS").contains(result.path("status").asText())) {
+      throw new IOException(method + " " + path + " returned non-success status");
+    }
+    return result;
+  }
+
+  private void metadata(ObjectNode objects) throws IOException, InterruptedException {
+    JsonNode report =
+        request(
+            "POST",
+            "/api/metadata?importStrategy=CREATE&atomicMode=ALL"
+                + "&async=false&importReportMode=ERRORS",
+            objects,
+            null);
+    if (!report.path("response").path("status").asText().equals("OK")) {
+      throw new IOException("Metadata import did not report OK; inspect disposable server log");
+    }
+  }
+
+  private void seed() throws IOException, InterruptedException {
+    if (!prop("ouSearch.setup", "").equals("CREATE_DISPOSABLE_FIXTURE")) {
+      throw new IllegalArgumentException(
+          "Seeding requires -DouSearch.setup=CREATE_DISPOSABLE_FIXTURE");
+    }
+    baseUrl = required("baseUrl", "DHIS2_BASE_URL").replaceAll("/+$", "");
+    String syntheticPassword = required("ouSearch.password", "OU_SEARCH_PASSWORD");
+    http =
+        HttpClient.newBuilder()
+            .cookieHandler(new CookieManager(null, CookiePolicy.ACCEPT_ALL))
+            .connectTimeout(Duration.ofSeconds(30))
+            .build();
+    request(
+        "GET",
+        "/api/me",
+        null,
+        basicAuth(prop("username", "admin"), required("password", "DHIS2_PASSWORD")));
+    JsonNode existing = request("GET", "/api/organisationUnits?fields=id&pageSize=1", null, null);
+    if (!existing.path("organisationUnits").isArray()
+        || !existing.path("organisationUnits").isEmpty()) {
+      throw new IllegalStateException(
+          "Setup requires a fresh database with no organisation units; restore an empty DB");
+    }
+    String browserOrigins = prop("ouSearch.corsOrigins", "");
+    if (!browserOrigins.isBlank()) {
+      Set<String> origins = new LinkedHashSet<>();
+      request("GET", "/api/configuration/corsWhitelist", null, null)
+          .forEach(origin -> origins.add(origin.asText()));
+      for (String origin : browserOrigins.split(",")) {
+        if (!origin.isBlank()) origins.add(origin.trim());
+      }
+      request("POST", "/api/configuration/corsWhitelist", strings(new ArrayList<>(origins)), null);
+    }
+    // Separate levels ensure every parent exists before its children are imported.
+    importUnits(units.subList(0, 1));
+    importUnits(units.subList(1, 3));
+    importUnits(units.subList(3, 3 + WARDS));
+    importUnits(units.subList(3 + WARDS, units.size()));
+
+    ObjectNode aggregate = JSON.createObjectNode();
+    ObjectNode element = aggregate.putArray("dataElements").addObject();
+    element.put("id", DATA_ELEMENT);
+    element.put("name", "Synthetic OU Search Count");
+    element.put("shortName", "Synthetic OU Search Count");
+    element.put("domainType", "AGGREGATE");
+    element.put("valueType", "INTEGER_ZERO_OR_POSITIVE");
+    element.put("aggregationType", "SUM");
+    element.putObject("sharing").put("public", "r-------");
+    ObjectNode dataSet = aggregate.putArray("dataSets").addObject();
+    dataSet.put("id", DATA_SET);
+    dataSet.put("name", DATA_SET_NAME);
+    dataSet.put("shortName", DATA_SET_NAME);
+    dataSet.put("periodType", "Monthly");
+    dataSet.put("openFuturePeriods", 12);
+    dataSet.put("expiryDays", 0);
+    dataSet.putObject("sharing").put("public", "r-rw----");
+    ObjectNode assignment = dataSet.putArray("dataSetElements").addObject();
+    assignment.putObject("dataElement").put("id", DATA_ELEMENT);
+    assignment.putObject("dataSet").put("id", DATA_SET);
+    ArrayNode assigned = dataSet.putArray("organisationUnits");
+    units.stream()
+        .filter(u -> u.id().startsWith("L"))
+        .filter(u -> u.id().compareTo(uid('L', 200)) < 0 || u.name().contains("Needle"))
+        .forEach(u -> assigned.addObject().put("id", u.id()));
+    metadata(aggregate);
+
+    ObjectNode access = JSON.createObjectNode();
+    ObjectNode role = access.putArray("userRoles").addObject();
+    role.put("id", ROLE);
+    role.put("name", "Synthetic OU Search Capture");
+    role.set("authorities", strings(List.of("F_DATAVALUE_ADD")));
+    role.putArray("dataSets").addObject().put("id", DATA_SET);
+    metadata(access);
+    ObjectNode accounts = JSON.createObjectNode();
+    ArrayNode userArray = accounts.putArray("users");
+    manifest
+        .path("users")
+        .fields()
+        .forEachRemaining(
+            entry -> {
+              JsonNode account = entry.getValue();
+              ObjectNode user = userArray.addObject();
+              user.put("id", account.path("id").asText());
+              user.put("username", account.path("username").asText());
+              user.put("firstName", "Synthetic");
+              user.put("surname", "OU Search " + entry.getKey());
+              user.put("password", syntheticPassword);
+              user.putArray("userRoles").addObject().put("id", ROLE);
+              for (String field :
+                  List.of(
+                      "organisationUnits",
+                      "dataViewOrganisationUnits",
+                      "teiSearchOrganisationUnits")) {
+                ArrayNode roots = user.putArray(field);
+                account.path("roots").forEach(root -> roots.addObject().put("id", root.asText()));
+              }
+            });
+    metadata(accounts);
+    for (JsonNode user : manifest.path("users")) {
+      request(
+          "POST",
+          "/api/userSettings/keyDbLocale?user="
+              + encode(user.path("username").asText())
+              + "&value="
+              + user.path("dbLocale").asText(),
+          null,
+          null);
+    }
+  }
+
+  private void importUnits(List<Unit> group) throws IOException, InterruptedException {
+    for (int start = 0; start < group.size(); start += batchSize) {
+      ObjectNode batch = JSON.createObjectNode();
+      ArrayNode objects = batch.putArray("organisationUnits");
+      for (Unit unit : group.subList(start, Math.min(start + batchSize, group.size()))) {
+        ObjectNode object = objects.addObject();
+        object.put("id", unit.id());
+        object.put("name", unit.name());
+        object.put("shortName", unit.name());
+        object.put("openingDate", "2020-01-01");
+        if (unit.parent() != null) object.putObject("parent").put("id", unit.parent());
+        if (unit.french() != null) {
+          ObjectNode translation = object.putArray("translations").addObject();
+          translation.put("locale", "fr");
+          translation.put("property", "NAME");
+          translation.put("value", unit.french());
+        }
+      }
+      metadata(batch);
+      System.out.println("Imported OU batch: " + objects.size() + " objects");
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    String operation = prop("ouSearch.operation", "generate");
+    if (!Set.of("generate", "seed").contains(operation)) {
+      throw new IllegalArgumentException("ouSearch.operation must be generate or seed");
+    }
+    OrganisationUnitSearchFixture fixture = new OrganisationUnitSearchFixture();
+    fixture.generate();
+    if (operation.equals("seed")) fixture.seed();
+    Path output = Path.of(prop("ouSearch.manifest", "target/ou-search-manifest.json"));
+    Path parent = output.toAbsolutePath().getParent();
+    Files.createDirectories(parent);
+    JSON.writerWithDefaultPrettyPrinter().writeValue(output.toFile(), fixture.manifest);
+    System.out.println(
+        "Fixture v"
+            + VERSION
+            + " manifest written to "
+            + output
+            + " ("
+            + operation
+            + "; "
+            + fixture.units.size()
+            + " OUs)");
+  }
+}

--- a/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/OrganisationUnitSearchPerformanceTest.java
+++ b/dhis-2/dhis-test-performance/src/test/java/org/hisp/dhis/test/platform/OrganisationUnitSearchPerformanceTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2004-2026, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.test.platform;
+
+import static io.gatling.javaapi.core.CoreDsl.*;
+import static io.gatling.javaapi.http.HttpDsl.*;
+import static org.hisp.dhis.test.platform.OrganisationUnitSearchFixture.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gatling.javaapi.core.Assertion;
+import io.gatling.javaapi.core.PopulationBuilder;
+import io.gatling.javaapi.core.Simulation;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Read-only, exact-result benchmark for translated filtering and hierarchy scope queries. Setup is
+ * exclusively the separate {@link OrganisationUnitSearchFixture} CLI.
+ *
+ * @author Morten Svanæs
+ */
+public class OrganisationUnitSearchPerformanceTest extends Simulation {
+  public OrganisationUnitSearchPerformanceTest() throws IOException {
+    JsonNode manifest =
+        JSON.readTree(
+            Path.of(prop("ouSearch.manifest", "target/ou-search-manifest.json")).toFile());
+    if (manifest.path("fixtureVersion").asInt() != 1
+        || !manifest.path("cases").isArray()
+        || manifest.path("cases").isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected organisation-unit search fixtureVersion=1 manifest with cases");
+    }
+    int concurrency = positiveInt("concurrency", 1);
+    int iterations = positiveInt("iterations", 3);
+    String mode = prop("mode", "sequential");
+    if (!Set.of("sequential", "parallel").contains(mode)) {
+      throw new IllegalArgumentException("mode must be sequential or parallel");
+    }
+    String selected = prop("ouSearch.cases", "all");
+    Set<String> requested = new LinkedHashSet<>(Arrays.asList(selected.split(",")));
+    Set<String> found = new LinkedHashSet<>();
+    List<PopulationBuilder> populations = new ArrayList<>();
+    List<Assertion> assertions = new ArrayList<>();
+    String password = required("ouSearch.password", "OU_SEARCH_PASSWORD");
+    String p95 = prop("ouSearch.p95Ms", "");
+    if (!p95.isBlank() && Integer.parseInt(p95) <= 0) {
+      throw new IllegalArgumentException("ouSearch.p95Ms must be positive when supplied");
+    }
+    for (JsonNode test : manifest.path("cases")) {
+      String name = test.path("name").asText();
+      if (!selected.equals("all") && !requested.contains(name)) continue;
+      if (!found.add(name)) throw new IllegalArgumentException("Duplicate case name: " + name);
+      JsonNode expected = test.path("expected");
+      if (!expected.path("ids").isArray()
+          || !expected.path("paths").isArray()
+          || !expected.path("displayNames").isArray()
+          || !expected.path("total").isIntegralNumber()
+          || !expected.path("checkTotal").isBoolean()) {
+        throw new IllegalArgumentException("Invalid expectation for " + name);
+      }
+      String username =
+          manifest.path("users").path(test.path("user").asText()).path("username").asText();
+      if (username.isBlank())
+        throw new IllegalArgumentException("Missing manifest username for " + name);
+      boolean checkTotal = expected.path("checkTotal").asBoolean();
+      Set<String> fields = Set.of(test.path("params").path("fields").asText().split(","));
+      ObjectNode signature = JSON.createObjectNode();
+      if (fields.contains("id")) signature.set("ids", expected.path("ids"));
+      if (fields.contains("path")) signature.set("paths", expected.path("paths"));
+      if (fields.contains("displayName"))
+        signature.set("displayNames", expected.path("displayNames"));
+      if (checkTotal) signature.set("total", expected.path("total"));
+      var authenticate =
+          exec(flushCookieJar())
+              .exec(
+                  http("Authenticate - " + name)
+                      .get("/api/me?fields=id,username")
+                      .header("Authorization", basicAuth(username, password))
+                      .check(status().is(200), jsonPath("$.username").is(username)));
+      var query =
+          http(name)
+              .get(url(test.path("endpoint").asText(), test.path("params")))
+              .check(
+                  status().is(200),
+                  bodyString()
+                      .transform(body -> responseSignature(body, fields, checkTotal))
+                      .is(signature.toString()));
+      // One cookie-authenticated session per virtual user; no Basic header on timed searches.
+      // Check failures remain normal Gatling KOs, including known baseline semantic defects.
+      populations.add(
+          scenario(name)
+              .exec(authenticate)
+              .exitHereIfFailed()
+              .repeat(iterations)
+              .on(exec(query))
+              .injectOpen(atOnceUsers(concurrency)));
+      assertions.add(details(name).successfulRequests().percent().is(100D));
+      if (!p95.isBlank())
+        assertions.add(details(name).responseTime().percentile(95).lt(Integer.parseInt(p95)));
+    }
+    if (!selected.equals("all") && !found.equals(requested)) {
+      requested.removeAll(found);
+      throw new IllegalArgumentException("Unknown ouSearch.cases: " + requested);
+    }
+    if (populations.isEmpty()) throw new IllegalArgumentException("No selected cases");
+    // Also fail failed authentication rather than silently publishing an empty measurement.
+    assertions.add(global().successfulRequests().percent().is(100D));
+    var protocol =
+        http.baseUrl(required("baseUrl", "DHIS2_BASE_URL"))
+            .acceptHeader("application/json")
+            .disableCaching();
+    var simulation =
+        mode.equals("parallel")
+            ? setUp(populations.toArray(PopulationBuilder[]::new))
+            : setUp(sequential(populations, 0));
+    simulation.protocols(protocol).assertions(assertions.toArray(Assertion[]::new));
+  }
+
+  private static PopulationBuilder sequential(List<PopulationBuilder> populations, int index) {
+    PopulationBuilder current = populations.get(index);
+    return index + 1 == populations.size()
+        ? current
+        : current.andThen(sequential(populations, index + 1));
+  }
+
+  private static String responseSignature(String body, Set<String> fields, boolean checkTotal) {
+    try {
+      JsonNode response = JSON.readTree(body);
+      JsonNode units = response.path("organisationUnits");
+      if (!units.isArray()) return "Missing organisationUnits array";
+      ObjectNode result = JSON.createObjectNode();
+      for (String field : List.of("id", "path", "displayName")) {
+        if (!fields.contains(field)) continue;
+        String key =
+            switch (field) {
+              case "id" -> "ids";
+              case "path" -> "paths";
+              default -> "displayNames";
+            };
+        var values = result.putArray(key);
+        for (JsonNode unit : units) {
+          if (!unit.path(field).isTextual()) return "Missing organisation-unit " + field;
+          values.add(unit.path(field).asText());
+        }
+      }
+      if (checkTotal) {
+        JsonNode total = response.path("pager").path("total");
+        if (!total.isIntegralNumber()) return "Missing pager.total";
+        result.set("total", total);
+      }
+      return result.toString();
+    } catch (IOException ex) {
+      return "Invalid JSON response";
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add an explicit, deterministic API fixture seeder and 66 exact-result Gatling cases for translated-name and hierarchy searches.
- Support fresh databases and one-time fixture setup in the existing performance runner; preserve baseline failures in comparisons.
- Companion evidence for #25128, #25127 and https://github.com/dhis2/aggregate-data-entry-app/pull/593. No production code changes.

## Verification
- Full fixture: 272,203 OUs, four pinned backend variants, cold/warm/concurrent measurements.
- Combined build passed all 66 distinct cases; absent/dense translation fixture modes passed on 403 OUs each.
- Existing runner exercised end to end, including setup, restart, warmup, reports and cleanup. Java formatting and shell syntax checks passed.

Local warmed medians: translated-name lookup 14,399 → 128.5 ms; small-subtree lookup 44 → 7 ms. Backend comparisons use the same 3 GB heap and include Jan's merged #25125 in every baseline. These are local synthetic measurements, not production SLAs.

AI Assisted
