### PR TITLE
feat: enable the tracker export timeout by default DHIS2-21390

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -455,11 +455,11 @@ public enum ConfigurationKey {
   PROGRAM_TEMPORARY_OWNERSHIP_TIMEOUT("tracker.temporary.ownership.timeout", "3", false),
 
   /**
-   * Maximum number of seconds a tracker export request may spend running queries before they are
-   * canceled and the request fails with 504. The budget is shared by all queries of one request but
-   * covers only the time they run, not the wait for a connection, which the pool bounds separately
-   * via {@code connection.pool.timeout} and answers with a 503. {@code 0} disables the timeout.
-   * (default: 0)
+   * Maximum number of seconds a tracker export request may spend fetching data before it is
+   * canceled and fails with 504. The budget is shared by every database query and object store read
+   * of one request but covers only the time they run, not the wait for a connection, which the pool
+   * bounds separately via {@code connection.pool.timeout} and answers with a 503. {@code 0}
+   * disables the timeout. (default: 600)
    *
    * <p>Because the underlying JDBC timeout has whole second granularity and the remaining budget is
    * rounded up, a request can take up to one second longer than this value.
@@ -467,7 +467,7 @@ public enum ConfigurationKey {
    * <p>Set this below any timeout in front of DHIS2, such as a reverse proxy or load balancer. If
    * the proxy times out first it returns its own 504 while the query is never cancelled.
    */
-  TRACKER_EXPORT_TIMEOUT("tracker.export.timeout", "0", false),
+  TRACKER_EXPORT_TIMEOUT("tracker.export.timeout", "600", false),
 
   /** Use unlogged tables during analytics export. (default: ON) */
   ANALYTICS_TABLE_UNLOGGED("analytics.table.unlogged", Constants.ON),


### PR DESCRIPTION
Enable the tracker export timeout added in #24970 by default, with a budget of 10 minutes.

## Why 10 minutes

We picked it after discussing it in the team tracker Slack. It is a lax bound, meant as a backstop rather than a tuned limit: generous enough that typical tracker workloads are unaffected, while making sure no export runs unbounded.

10 minutes is also what the Android Capture App sets on its own OkHttp client: [`ServerModule.kt#L188-L191`](https://github.com/dhis2/dhis2-android-capture-app/blob/d87193d003a0acccc53914f88026719df6fe8fc3/app/src/main/java/org/dhis2/data/server/ServerModule.kt#L188-L191).

Deployments that want a tighter interactive bound lower it.

## Reverse proxy interaction

The new default is above nginx's stock 60s `proxy_read_timeout`, and the DHIS2-recommended nginx config sets no `proxy_read_timeout` at all, so it inherits that 60s.

A tracker timeout above the proxy timeout has the same effect as a user making a request and then closing their browser tab or console: tracker keeps processing for as long as there is budget left, even though nobody cares about the result anymore.

So the optimum is `tracker.export.timeout` < proxy timeout, which we [document](https://github.com/dhis2/dhis2-docs/pull/1795), and which each implementation picks for itself. The default is a backstop: enabling the feature with a value like 10 minutes means no tracker export request is unbounded anymore.
