### PR TITLE
fix: Allow removing report relative periods [DHIS2-22083]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/report/Report.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/report/Report.java
@@ -188,13 +188,10 @@ public class Report extends BaseIdentifiableObject implements Cacheable, Metadat
   public void setRelatives(RelativePeriods relatives) {
     if (relatives != null) {
       List<RelativePeriodEnum> enums = relatives.getRelativePeriodEnums();
+      this.rawPeriods = new ArrayList<>(enums.size());
 
       for (RelativePeriodEnum periodEnum : enums) {
-        String relativePeriod = periodEnum.name();
-
-        if (RelativePeriodEnum.contains(relativePeriod)) {
-          this.rawPeriods.add(relativePeriod);
-        }
+        this.rawPeriods.add(periodEnum.name());
       }
 
       this.relatives = relatives;

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/report/ReportTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/report/ReportTest.java
@@ -34,11 +34,16 @@ import static org.hisp.dhis.period.RelativePeriodEnum.LAST_14_DAYS;
 import static org.hisp.dhis.period.RelativePeriodEnum.LAST_3_MONTHS;
 import static org.hisp.dhis.period.RelativePeriodEnum.LAST_7_DAYS;
 import static org.hisp.dhis.period.RelativePeriodEnum.THIS_BIWEEK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.hisp.dhis.period.RelativePeriods;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /** Unit tests for {@link Report}. */
 class ReportTest {
@@ -103,5 +108,24 @@ class ReportTest {
     assertTrue(report.getRawPeriods().contains(BIMONTHS_THIS_YEAR.name()));
     assertTrue(report.getRawPeriods().contains(LAST_14_DAYS.name()));
     assertTrue(report.getRawPeriods().contains(LAST_3_MONTHS.name()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testUpdateRelativesRemovesDeselectedPeriods(boolean weeksThisYear) {
+    Report report = new Report();
+    report.setRawPeriods(new ArrayList<>(List.of("THIS_MONTH")));
+
+    RelativePeriods updated = new RelativePeriods();
+    updated.setThisMonth(false);
+    updated.setWeeksThisYear(weeksThisYear);
+    report.setRelatives(updated);
+
+    // Only rawPeriods is persisted; read the updated selection as a newly loaded report would.
+    Report reloaded = new Report();
+    reloaded.setRawPeriods(report.getRawPeriods());
+    assertFalse(reloaded.getRelatives().isThisMonth());
+    assertEquals(weeksThisYear, reloaded.getRelatives().isWeeksThisYear());
+    assertEquals(!weeksThisYear, reloaded.getRelatives().isEmpty());
   }
 }


### PR DESCRIPTION
## Summary
[DHIS2-22083](https://dhis2.atlassian.net/browse/DHIS2-22083)

Replace stored relative periods when updating a report instead of appending, so deselected periods do not reappear after reload. Add regression coverage for replacing a selection and clearing all selections.

## Verification
- Both regression cases fail before the fix and pass afterward.
- Java 17: ReportTest and RelativePeriodsTest — 55 tests passed.
- Spotless applied. No live-server verification.

AI Assisted

[DHIS2-22083]: https://dhis2.atlassian.net/browse/DHIS2-22083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ